### PR TITLE
Refactor using `std::rc::Rc::unwrap_or_clone()`

### DIFF
--- a/api/crates/postgres/src/tags.rs
+++ b/api/crates/postgres/src/tags.rs
@@ -198,9 +198,7 @@ impl FromIterator<PostgresTagRelativeRow> for IndexMap<TagId, Rc<RefCell<TagRela
 }
 
 fn extract(rc: Rc<RefCell<TagRelation>>, depth: TagDepth) -> Tag {
-    let relation = Rc::try_unwrap(rc)
-        .unwrap_or_else(|rc| (*rc).clone())
-        .into_inner();
+    let relation = Rc::unwrap_or_clone(rc).into_inner();
 
     let parent = depth
         .has_parent()


### PR DESCRIPTION
This PR refactors API using [`std::rc::Rc::unwrap_or_clone()`](https://doc.rust-lang.org/std/rc/struct.Rc.html#method.unwrap_or_clone) available since Rust 1.76.