### PR TITLE
Percent-encode object URLs

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -2838,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -3858,12 +3858,14 @@ checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
 name = "storage"
 version = "0.0.0"
 dependencies = [
+ "cow-utils",
  "derive_more",
  "domain",
  "futures",
  "icu",
  "libc",
  "normalize-path",
+ "percent-encoding",
  "tokio",
  "tokio-stream",
 ]

--- a/api/crates/domain/src/entity/objects.rs
+++ b/api/crates/domain/src/entity/objects.rs
@@ -3,16 +3,15 @@ use derive_more::{Constructor, Deref, Display, From};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, Deref, Deserialize, Display, Eq, From, Hash, PartialEq, Serialize)]
-pub struct EntryPath(String);
+pub struct EntryUrl(String);
 
 #[derive(Clone, Debug, Default, Deref, Deserialize, Display, Eq, From, Hash, PartialEq, Serialize)]
-pub struct EntryUrl(String);
+pub struct EntryUrlPath(String);
 
 #[derive(Clone, Constructor, Debug, Eq, PartialEq)]
 pub struct Entry {
     pub name: String,
-    pub path: EntryPath,
-    pub url: EntryUrl,
+    pub url: Option<EntryUrl>,
     pub kind: EntryKind,
     pub metadata: Option<EntryMetadata>,
 }
@@ -32,14 +31,51 @@ pub enum EntryKind {
     Unknown,
 }
 
-impl EntryPath {
+impl EntryUrl {
     pub fn into_inner(self) -> String {
         self.0
     }
 }
 
-impl EntryUrl {
+impl EntryUrlPath {
     pub fn into_inner(self) -> String {
         self.0
+    }
+
+    pub fn to_url(&self, scheme: &str) -> EntryUrl {
+        let path = &self.0;
+        let url = format!("{scheme}://{path}");
+        EntryUrl::from(url)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use crate::entity::objects::{EntryUrl, EntryUrlPath};
+
+    #[test]
+    fn entry_url_into_inner() {
+        let url = EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
+
+        let actual = url.into_inner();
+        assert_eq!(actual, "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
+    }
+
+    #[test]
+    fn entry_url_path_into_inner() {
+        let url = EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
+
+        let actual = url.into_inner();
+        assert_eq!(actual, "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
+    }
+
+    #[test]
+    fn entry_url_path_to_url() {
+        let path = EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
+
+        let actual = path.to_url("file");
+        assert_eq!(actual, EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()));
     }
 }

--- a/api/crates/domain/src/error.rs
+++ b/api/crates/domain/src/error.rs
@@ -92,25 +92,28 @@ pub enum ErrorKind {
     MediumTagNotFound { id: MediumId },
 
     #[error("the object with the same path already exists")]
-    ObjectAlreadyExists { path: String, entry: Option<Box<Entry>> },
+    ObjectAlreadyExists { url: String, entry: Option<Box<Entry>> },
 
     #[error("the object was unable to be deleted")]
-    ObjectDeleteFailed { path: String },
+    ObjectDeleteFailed { url: String },
 
     #[error("the object was unable to be gotten")]
-    ObjectGetFailed { path: String },
+    ObjectGetFailed { url: String },
 
     #[error("the objects were unable to be listed")]
-    ObjectListFailed { path: String },
+    ObjectListFailed { url: String },
 
     #[error("the object was not found")]
-    ObjectNotFound { path: String },
+    ObjectNotFound { url: String },
 
     #[error("the object path is invalid")]
-    ObjectPathInvalid { path: String },
+    ObjectPathInvalid,
 
     #[error("the object was unable to be put")]
-    ObjectPutFailed { path: String },
+    ObjectPutFailed { url: String },
+
+    #[error("the object URL is invalid")]
+    ObjectUrlInvalid { url: String },
 
     #[error("the object URL is unsupported")]
     ObjectUrlUnsupported { url: String },

--- a/api/crates/domain/src/repository/objects.rs
+++ b/api/crates/domain/src/repository/objects.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use tokio::io::{AsyncRead, AsyncSeek};
 
 use crate::{
-    entity::objects::{Entry, EntryPath, EntryUrl},
+    entity::objects::{Entry, EntryUrl},
     error::Result,
     repository::DeleteResult,
 };
@@ -28,14 +28,16 @@ impl ObjectOverwriteBehavior {
 pub trait ObjectsRepository: Send + Sync + 'static {
     type Read: AsyncRead + AsyncSeek + Send + Unpin + 'static;
 
+    fn scheme() -> &'static str;
+
     #[cfg_attr(feature = "test-mock", mockall::concretize)]
-    fn put<T>(&self, path: &EntryPath, content: T, overwrite: ObjectOverwriteBehavior) -> impl Future<Output = Result<Entry>> + Send
+    fn put<T>(&self, url: EntryUrl, content: T, overwrite: ObjectOverwriteBehavior) -> impl Future<Output = Result<Entry>> + Send
     where
         T: AsyncRead + Send + Unpin;
 
-    fn get(&self, url: &EntryUrl) -> impl Future<Output = Result<(Entry, Self::Read)>> + Send;
+    fn get(&self, url: EntryUrl) -> impl Future<Output = Result<(Entry, Self::Read)>> + Send;
 
-    fn list(&self, prefix: &EntryPath) -> impl Future<Output = Result<Vec<Entry>>> + Send;
+    fn list(&self, prefix: EntryUrl) -> impl Future<Output = Result<Vec<Entry>>> + Send;
 
-    fn delete(&self, url: &EntryUrl) -> impl Future<Output = Result<DeleteResult>> + Send;
+    fn delete(&self, url: EntryUrl) -> impl Future<Output = Result<DeleteResult>> + Send;
 }

--- a/api/crates/graphql/src/error.rs
+++ b/api/crates/graphql/src/error.rs
@@ -61,25 +61,28 @@ pub(crate) enum ErrorKind {
     MediumTagNotFound { id: MediumId },
 
     #[error("the object with the same path already exists")]
-    ObjectAlreadyExists { path: String, entry: Option<Box<ObjectEntry>> },
+    ObjectAlreadyExists { url: String, entry: Option<Box<ObjectEntry>> },
 
     #[error("the object was unable to be deleted")]
-    ObjectDeleteFailed { path: String },
+    ObjectDeleteFailed { url: String },
 
     #[error("the object was unable to be gotten")]
-    ObjectGetFailed { path: String },
+    ObjectGetFailed { url: String },
 
     #[error("the objects were unable to be listed")]
-    ObjectListFailed { path: String },
+    ObjectListFailed { url: String },
 
     #[error("the object was not found")]
-    ObjectNotFound { path: String },
+    ObjectNotFound { url: String },
 
     #[error("the object path is invalid")]
-    ObjectPathInvalid { path: String },
+    ObjectPathInvalid,
 
     #[error("the object was unable to be put")]
-    ObjectPutFailed { path: String },
+    ObjectPutFailed { url: String },
+
+    #[error("the object URL is invalid")]
+    ObjectUrlInvalid { url: String },
 
     #[error("the object URL is unsupported")]
     ObjectUrlUnsupported { url: String },
@@ -174,16 +177,17 @@ impl From<domain::error::ErrorKind> for ErrorKind {
             MediumReplicasNotMatch { medium_id, expected_replicas, actual_replicas } => ErrorKind::MediumReplicasNotMatch { medium_id, expected_replicas, actual_replicas },
             MediumSourceNotFound { id } => ErrorKind::MediumSourceNotFound { id },
             MediumTagNotFound { id } => ErrorKind::MediumTagNotFound { id },
-            ObjectAlreadyExists { path, entry } => ErrorKind::ObjectAlreadyExists {
-                path,
+            ObjectAlreadyExists { url, entry } => ErrorKind::ObjectAlreadyExists {
+                url,
                 entry: entry.map(|e| Box::new(ObjectEntry::from(*e))),
             },
-            ObjectDeleteFailed { path, .. } => ErrorKind::ObjectDeleteFailed { path },
-            ObjectGetFailed { path, .. } => ErrorKind::ObjectGetFailed { path },
-            ObjectListFailed { path, .. } => ErrorKind::ObjectListFailed { path },
-            ObjectNotFound { path } => ErrorKind::ObjectNotFound { path },
-            ObjectPathInvalid { path } => ErrorKind::ObjectPathInvalid { path },
-            ObjectPutFailed { path, .. } => ErrorKind::ObjectPutFailed { path },
+            ObjectDeleteFailed { url, .. } => ErrorKind::ObjectDeleteFailed { url },
+            ObjectGetFailed { url, .. } => ErrorKind::ObjectGetFailed { url },
+            ObjectListFailed { url, .. } => ErrorKind::ObjectListFailed { url },
+            ObjectNotFound { url } => ErrorKind::ObjectNotFound { url },
+            ObjectPathInvalid => ErrorKind::ObjectPathInvalid,
+            ObjectPutFailed { url, .. } => ErrorKind::ObjectPutFailed { url },
+            ObjectUrlInvalid { url } => ErrorKind::ObjectUrlInvalid { url },
             ObjectUrlUnsupported { url } => ErrorKind::ObjectUrlUnsupported { url },
             ReplicaNotFound { id } => ErrorKind::ReplicaNotFound { id },
             ReplicaNotFoundByUrl { original_url } => ErrorKind::ReplicaNotFoundByUrl { original_url },

--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -2,7 +2,7 @@ use async_graphql::{Context, Object, SimpleObject};
 use chrono::{DateTime, FixedOffset};
 use derive_more::Constructor;
 use domain::{
-    entity::objects::{EntryPath, EntryUrl},
+    entity::objects::{EntryUrl, EntryUrlPath},
     repository,
     service::{
         external_services::ExternalServicesServiceInterface,
@@ -54,7 +54,7 @@ async fn create_medium_source(ctx: &Context<'_>, original_url: Option<String>, u
             let value = file.value(ctx).map_err(|_| Error::new(ErrorKind::InternalServerError))?;
             let filename = value.filename.clone();
             let content = process_upload(value).await?;
-            Ok(MediumSource::Content(EntryPath::from(filename), content, overwrite))
+            Ok(MediumSource::Content(EntryUrlPath::from(filename), content, overwrite))
         },
     }
 }

--- a/api/crates/graphql/src/objects.rs
+++ b/api/crates/graphql/src/objects.rs
@@ -6,8 +6,7 @@ use serde::Serialize;
 #[derive(Debug, Serialize, SimpleObject)]
 pub(crate) struct ObjectEntry {
     name: String,
-    path: String,
-    url: String,
+    url: Option<String>,
     kind: ObjectKind,
     metadata: Option<ObjectEntryMetadata>,
 }
@@ -32,8 +31,7 @@ impl From<objects::Entry> for ObjectEntry {
     fn from(entry: objects::Entry) -> Self {
         Self {
             name: entry.name,
-            path: entry.path.into_inner(),
-            url: entry.url.into_inner(),
+            url: entry.url.map(|u| u.into_inner()),
             kind: entry.kind.into(),
             metadata: entry.metadata.map(Into::into),
         }

--- a/api/crates/graphql/src/query.rs
+++ b/api/crates/graphql/src/query.rs
@@ -4,7 +4,7 @@ use async_graphql::{
 };
 use derive_more::Constructor;
 use domain::{
-    entity::objects::EntryPath,
+    entity::objects::EntryUrlPath,
     repository,
     service::{
         external_services::ExternalServicesServiceInterface,
@@ -164,7 +164,7 @@ where
     async fn objects(&self, prefix: String, kind: Option<ObjectKind>) -> Result<Vec<ObjectEntry>> {
         let kind = kind.map(Into::into);
 
-        let objects = self.media_service.get_objects(&EntryPath::from(prefix), kind).await?;
+        let objects = self.media_service.get_objects(EntryUrlPath::from(prefix), kind).await?;
         Ok(objects.into_iter().map(Into::into).collect())
     }
 

--- a/api/crates/storage/Cargo.toml
+++ b/api/crates/storage/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 [lib]
 doctest = false
 
+[dependencies.cow-utils]
+version = "0.1.3"
+
 [dependencies.domain]
 workspace = true
 
@@ -23,6 +26,9 @@ features = ["sync"]
 
 [dependencies.normalize-path]
 version = "0.2.1"
+
+[dependencies.percent-encoding]
+version = "2.3.1"
 
 [dependencies.tokio]
 version = "1.36.0"

--- a/api/crates/storage/src/filesystem/entry.rs
+++ b/api/crates/storage/src/filesystem/entry.rs
@@ -1,0 +1,76 @@
+use std::{
+    fs::{FileType, Metadata},
+    path::{Path, MAIN_SEPARATOR_STR},
+};
+
+use domain::{
+    entity::objects::{Entry, EntryMetadata, EntryKind},
+    error::{Error, Result},
+};
+use tokio::fs::{DirEntry, File};
+
+use crate::{filesystem::FilesystemEntryUrl, StorageEntry, StorageEntryUrl};
+
+pub(crate) struct FilesystemEntry(Entry);
+
+impl FilesystemEntry {
+    pub(crate) async fn from_dir_entry<P>(path: P, entry: &DirEntry) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let url = FilesystemEntryUrl::from_path(Path::new(MAIN_SEPARATOR_STR).join(path).join(entry.file_name()))
+            .map(|url| url.into_url())
+            .ok();
+        let kind = entry.file_type()
+            .await
+            .map(Self::kind)
+            .unwrap_or(EntryKind::Unknown);
+
+        Ok(Self(Entry::new(name, url, kind, None)))
+    }
+
+    pub(crate) async fn from_file<P>(path: P, file: &File) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path.as_ref();
+        let name = path.file_name().unwrap_or_default().to_string_lossy().into_owned().to_string();
+        let url = FilesystemEntryUrl::from_path(Path::new(MAIN_SEPARATOR_STR).join(path))
+            .map(|url| url.into_url())
+            .ok();
+        let (kind, metadata) = file.metadata()
+            .await
+            .map(|metadata| {
+                let kind = Self::kind(metadata.file_type());
+                let metadata = Self::metadata(&metadata).ok();
+                (kind, metadata)
+            })
+            .unwrap_or((EntryKind::Unknown, None));
+
+        Ok(Self(Entry::new(name, url, kind, metadata)))
+    }
+
+    fn kind(file_type: FileType) -> EntryKind {
+        if file_type.is_dir() {
+            EntryKind::Container
+        } else {
+            EntryKind::Object
+        }
+    }
+
+    fn metadata(metadata: &Metadata) -> Result<EntryMetadata> {
+        let len = metadata.len();
+        let created = metadata.created().map_err(Error::other)?;
+        let modified = metadata.modified().map_err(Error::other)?;
+        let accessed = metadata.accessed().map_err(Error::other)?;
+        Ok(EntryMetadata::new(len, created.into(), modified.into(), accessed.into()))
+    }
+}
+
+impl StorageEntry for FilesystemEntry {
+    fn into_entry(self) -> Entry {
+        self.0
+    }
+}

--- a/api/crates/storage/src/filesystem/url.rs
+++ b/api/crates/storage/src/filesystem/url.rs
@@ -1,0 +1,60 @@
+use std::path::{Path, PathBuf, MAIN_SEPARATOR_STR};
+
+use cow_utils::CowUtils;
+use derive_more::Display;
+use domain::{
+    entity::objects::EntryUrl,
+    error::{Error, ErrorKind, Result},
+};
+use normalize_path::NormalizePath;
+
+use crate::StorageEntryUrl;
+
+#[derive(Display)]
+#[display(fmt = "{_0}")]
+pub(crate) struct FilesystemEntryUrl(EntryUrl, PathBuf);
+
+impl FilesystemEntryUrl {
+    pub(crate) fn from_path<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let path = path
+            .as_ref()
+            .to_str()
+            .ok_or_else(|| ErrorKind::ObjectPathInvalid)?
+            .cow_replace(MAIN_SEPARATOR_STR, "/");
+
+        Self::from_path_str(&path)
+    }
+
+    pub(crate) fn as_path(&self) -> &Path {
+        self.1.as_path()
+    }
+}
+
+impl TryFrom<EntryUrl> for FilesystemEntryUrl {
+    type Error = Error;
+
+    fn try_from(url: EntryUrl) -> Result<Self> {
+        let path = Self::to_path_string(&url)?;
+        let path = match path.strip_prefix('/') {
+            Some(path) => path,
+            None => return Err(ErrorKind::ObjectUrlInvalid { url: url.into_inner() })?,
+        };
+        let path = match PathBuf::from(path).try_normalize() {
+            Some(path) => path,
+            None => return Err(ErrorKind::ObjectUrlInvalid { url: url.into_inner() })?,
+        };
+
+        Ok(Self(url, path))
+    }
+}
+
+impl StorageEntryUrl for FilesystemEntryUrl {
+    const URL_PREFIX: &'static str = "file://";
+
+    fn into_url(self) -> EntryUrl {
+        self.0
+    }
+}

--- a/api/crates/storage/src/lib.rs
+++ b/api/crates/storage/src/lib.rs
@@ -1,1 +1,53 @@
+use domain::{
+    entity::objects::{Entry, EntryUrl},
+    error::{Error, ErrorKind, Result},
+};
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
+
 pub mod filesystem;
+
+pub(crate) trait StorageEntry {
+    fn into_entry(self) -> Entry;
+}
+
+pub(crate) trait StorageEntryUrl: TryFrom<EntryUrl, Error = Error> {
+    const URL_PREFIX: &'static str;
+
+    const RFC3986_PATH: &'static AsciiSet = &CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'%')
+        .add(b'<')
+        .add(b'>')
+        .add(b'?')
+        .add(b'^')
+        .add(b'`')
+        .add(b'{')
+        .add(b'}');
+
+    fn from_path_str(path: &str) -> Result<Self> {
+        let url = format!(
+            "{}{}",
+            Self::URL_PREFIX,
+            utf8_percent_encode(path, Self::RFC3986_PATH),
+        );
+
+        Self::try_from(EntryUrl::from(url))
+    }
+
+    fn to_path_string(url: &str) -> Result<String> {
+        let path = url
+            .strip_prefix(Self::URL_PREFIX)
+            .ok_or_else(|| ErrorKind::ObjectUrlUnsupported { url: url.to_string() })?;
+
+        let path = percent_decode_str(path)
+            .decode_utf8()
+            .map_err(|e| Error::new(ErrorKind::ObjectPathInvalid, e))?
+            .to_string();
+
+        Ok(path)
+    }
+
+    fn into_url(self) -> EntryUrl;
+}


### PR DESCRIPTION
This PR makes object URLs stored in database as well as API request and response to be percent-encoded so the following problems are fixed:
* `/objects?url={url}` now redirects with URL whose path is percent-encoded as per RFC 3986
* Paths with invalid Unicode characters are now rejected with `OBJECT_PATH_INVALID` error