### PR TITLE
Move `hoarder --print-schema` to `hoarder schema print`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,9 @@ $ docker buildx bake -f docker-bake.hcl
 
 ### API
 
-The following command line options (or environment variables) can be used to configure API:
+#### Global Options
 
-- `--port` (`PORT`): Port number (**required**)
-- `--media-root-dir` (`MEDIA_ROOT_DIR`): Path to the media directory (**required**)
-- `--media-root-url` (`MEDIA_ROOT_URL`): Public URL for media
 - `--locale` (`LOCALE`): [Unicode locale identifier](https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier) for collation order
-- `--tls-cert`/`--tls-key` (`TLS_CERT`/`TLS_KEY`): Path to TLS certificate and private key for HTTPS
 - `--log-level` (`LOG_LEVEL`): Log level as in [RUST\_LOG](https://docs.rs/env_logger/latest/env_logger/)
 
 The following environment variables can be used to configure PostgreSQL connection:
@@ -43,6 +39,27 @@ The following environment variables can be used to configure PostgreSQL connecti
 - `PGSSLCERT`/`PGSSLKEY`: Path to the client certificate and private key in PKCS#8 format
 - `PGSSLMODE`: SSL mode
 - `PGAPPNAME`: Application name
+
+#### Serve API
+
+```
+$ hoarder [serve] [OPTIONS]
+```
+
+The following command line options (or environment variables) can be used to configure API:
+
+- `--port` (`PORT`): Port number (**required**)
+- `--media-root-dir` (`MEDIA_ROOT_DIR`): Path to the media directory (**required**)
+- `--media-root-url` (`MEDIA_ROOT_URL`): Public URL for media
+- `--tls-cert`/`--tls-key` (`TLS_CERT`/`TLS_KEY`): Path to TLS certificate and private key for HTTPS
+
+#### Manage GraphQL schema
+
+To show GraphQL schema in SDL (Schema Definition Language):
+
+```
+$ hoarder schema print
+```
 
 ## Testing
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -92,7 +92,7 @@ version = "1.0.81"
 
 [dependencies.clap]
 version = "4.5.4"
-features = ["cargo", "derive", "env", "string"]
+features = ["cargo", "derive", "env", "error-context", "string"]
 
 [dependencies.env_logger]
 version = "0.11.3"

--- a/api/crates/core/di/container.rs
+++ b/api/crates/core/di/container.rs
@@ -12,9 +12,9 @@ use anyhow::Context;
 use domain::{
     entity::replicas::Size,
     service::{
-        external_services::{ExternalServicesService, ExternalServicesServiceInterface},
-        media::{MediaService, MediaServiceInterface},
-        tags::{TagsService, TagsServiceInterface},
+        external_services::ExternalServicesService,
+        media::MediaService,
+        tags::TagsService,
     },
 };
 use graphql::{mutation::Mutation, query::Query, subscription::Subscription, APISchema, GraphQLService};
@@ -38,83 +38,120 @@ use thumbnails::{
     ThumbnailURLFactory, ThumbnailsService,
 };
 
-use crate::env;
+use crate::env::{self, commands::{Commands, SchemaCommand, SchemaCommands}};
 
-fn external_services_repository(pg_pool: PgPool) -> PostgresExternalServicesRepository {
+type ExternalServicesRepositoryImpl = PostgresExternalServicesRepository;
+type MediaRepositoryImpl = PostgresMediaRepository;
+type ReplicasRepositoryImpl = PostgresReplicasRepository;
+type SourcesRepositoryImpl = PostgresSourcesRepository;
+type TagsRepositoryImpl = PostgresTagsRepository;
+type TagTypesRepositoryImpl = PostgresTagTypesRepository;
+type ObjectsRepositoryImpl = FilesystemObjectsRepository;
+type ExternalServicesServiceImpl = ExternalServicesService<ExternalServicesRepositoryImpl>;
+type MediaServiceImpl = MediaService<MediaRepositoryImpl, ObjectsRepositoryImpl, ReplicasRepositoryImpl, SourcesRepositoryImpl, MediumImageProcessorImpl>;
+type TagsServiceImpl = TagsService<TagsRepositoryImpl, TagTypesRepositoryImpl>;
+type ObjectsServiceImpl = ObjectsService<MediaServiceImpl>;
+type ThumbnailsServiceImpl = ThumbnailsService<MediaServiceImpl>;
+type APISchemaImpl = APISchema<ExternalServicesServiceImpl, MediaServiceImpl, TagsServiceImpl>;
+type MediumImageProcessorImpl = InMemoryImageProcessor;
+type GraphQLServiceImpl = GraphQLService<ExternalServicesServiceImpl, MediaServiceImpl, TagsServiceImpl>;
+
+async fn pg_pool() -> anyhow::Result<PgPool> {
+    let pg_options = PgConnectOptions::new()
+        .log_statements(LevelFilter::Debug)
+        .log_slow_statements(LevelFilter::Warn, Duration::from_millis(500));
+
+    let pg_pool = PgPoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect_with(pg_options)
+        .await
+        .context("error connecting to database")?;
+
+    Ok(pg_pool)
+}
+
+fn external_services_repository(pg_pool: PgPool) -> ExternalServicesRepositoryImpl {
     PostgresExternalServicesRepository::new(pg_pool)
 }
 
-fn media_repository(pg_pool: PgPool) -> PostgresMediaRepository {
+fn media_repository(pg_pool: PgPool) -> MediaRepositoryImpl {
     PostgresMediaRepository::new(pg_pool)
 }
 
-fn replicas_repository(pg_pool: PgPool) -> PostgresReplicasRepository {
+fn replicas_repository(pg_pool: PgPool) -> ReplicasRepositoryImpl {
     PostgresReplicasRepository::new(pg_pool)
 }
 
-fn sources_repository(pg_pool: PgPool) -> PostgresSourcesRepository {
+fn sources_repository(pg_pool: PgPool) -> SourcesRepositoryImpl {
     PostgresSourcesRepository::new(pg_pool)
 }
 
-fn tags_repository(pg_pool: PgPool) -> PostgresTagsRepository {
+fn tags_repository(pg_pool: PgPool) -> TagsRepositoryImpl {
     PostgresTagsRepository::new(pg_pool)
 }
 
-fn tag_types_repository(pg_pool: PgPool) -> PostgresTagTypesRepository {
+fn tag_types_repository(pg_pool: PgPool) -> TagTypesRepositoryImpl {
     PostgresTagTypesRepository::new(pg_pool)
 }
 
-fn objects_repository(collator: Collator, root_dir: String) -> FilesystemObjectsRepository {
+fn objects_repository(collator: Collator, root_dir: String) -> ObjectsRepositoryImpl {
     FilesystemObjectsRepository::new(Arc::new(collator), root_dir)
 }
 
-fn external_services_service<T>(external_services_repository: T) -> ExternalServicesService<T> {
+fn external_services_service(external_services_repository: ExternalServicesRepositoryImpl) -> ExternalServicesServiceImpl {
     ExternalServicesService::new(external_services_repository)
 }
 
-fn media_service<T, U, V, W, X>(media_repository: T, objects_repository: U, replicas_repository: V, sources_repository: W, medium_image_processor: X) -> MediaService<T, U, V, W, X> {
+fn media_service(media_repository: MediaRepositoryImpl, objects_repository: ObjectsRepositoryImpl, replicas_repository: ReplicasRepositoryImpl, sources_repository: SourcesRepositoryImpl, medium_image_processor: MediumImageProcessorImpl) -> MediaServiceImpl {
     MediaService::new(media_repository, objects_repository, replicas_repository, sources_repository, medium_image_processor)
 }
 
-fn tags_service<T, U>(tags_repository: T, tag_types_repository: U) -> TagsService<T, U> {
+fn tags_service(tags_repository: TagsRepositoryImpl, tag_types_repository: TagTypesRepositoryImpl) -> TagsServiceImpl {
     TagsService::new(tags_repository, tag_types_repository)
 }
 
-fn query<T, U, V>(external_services_service: T, media_service: U, tags_service: V) -> Query<T, U, V> {
-    Query::new(external_services_service, media_service, tags_service)
+fn objects_service(media_service: MediaServiceImpl, media_url_factory: Arc<dyn MediaURLFactoryInterface>) -> ObjectsServiceImpl {
+    ObjectsService::new(media_service, media_url_factory)
 }
 
-fn mutation<T, U, V>(external_services_service: T, media_service: U, tags_service: V) -> Mutation<T, U, V> {
-    Mutation::new(external_services_service, media_service, tags_service)
+fn thumbnails_service(media_service: MediaServiceImpl) -> ThumbnailsServiceImpl {
+    ThumbnailsService::new(media_service)
 }
 
-fn schema<T, U, V>(
-    query: Query<T, U, V>,
-    mutation: Mutation<T, U, V>,
+fn schema(
+    external_services_service: ExternalServicesServiceImpl,
+    media_service: MediaServiceImpl,
+    tags_service: TagsServiceImpl,
     media_url_factory: Arc<dyn MediaURLFactoryInterface>,
     thumbnail_url_factory: Arc<dyn ThumbnailURLFactoryInterface>,
-) -> APISchema<T, U, V>
-where
-    T: ExternalServicesServiceInterface,
-    U: MediaServiceInterface,
-    V: TagsServiceInterface,
-{
-    APISchema::build(query, mutation, Subscription)
+) -> APISchemaImpl {
+    let query = Query::new();
+    let mutation = Mutation::new();
+    let subscription = Subscription;
+
+    APISchema::build(query, mutation, subscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
         .data(media_url_factory)
         .data(thumbnail_url_factory)
         .finish()
 }
 
-fn medium_image_processor() -> InMemoryImageProcessor {
+fn noop_schema() -> APISchemaImpl {
+    let query = Query::new();
+    let mutation = Mutation::new();
+    let subscription = Subscription;
+
+    APISchema::new(query, mutation, subscription)
+}
+
+fn medium_image_processor() -> MediumImageProcessorImpl {
     InMemoryImageProcessor::new(Size::new(240, 240), ImageFormat::WebP, FilterType::CatmullRom)
 }
 
-fn graphql_service<T, U, V>(schema: APISchema<T, U, V>) -> GraphQLService<T, U, V>
-where
-    T: ExternalServicesServiceInterface,
-    U: MediaServiceInterface,
-    V: TagsServiceInterface,
-{
+fn graphql_service(schema: APISchemaImpl) -> GraphQLServiceImpl {
     GraphQLService::new(schema, "/graphql")
 }
 
@@ -126,19 +163,8 @@ fn noop_media_url_factory() -> NoopMediaURLFactory {
     NoopMediaURLFactory::new()
 }
 
-fn objects_service<T>(media_service: T, media_url_factory: Arc<dyn MediaURLFactoryInterface>) -> ObjectsService<T>
-where
-    T: MediaServiceInterface,
-{
-    ObjectsService::new(media_service, media_url_factory)
-}
-
 fn thumbnail_url_factory() -> ThumbnailURLFactory {
     ThumbnailURLFactory::new("/thumbnails")
-}
-
-fn thumbnails_service<T>(media_service: T) -> ThumbnailsService<T> {
-    ThumbnailsService::new(media_service)
 }
 
 pub struct Application;
@@ -146,58 +172,51 @@ pub struct Application;
 impl Application {
     pub async fn start() -> anyhow::Result<()> {
         let config = env::init();
-        let collator = Collator::try_new(&DataLocale::from(config.locale), CollatorOptions::new())
+        let collator = Collator::try_new(&DataLocale::from(config.global.locale), CollatorOptions::new())
             .context("error instantiating collator")?;
 
-        let pg_options = PgConnectOptions::new()
-            .log_statements(LevelFilter::Debug)
-            .log_slow_statements(LevelFilter::Warn, Duration::from_millis(500));
+        match config.command {
+            Commands::Serve(serve) => {
+                let pg_pool = pg_pool().await?;
 
-        let pg_pool = PgPoolOptions::new()
-            .max_connections(5)
-            .acquire_timeout(Duration::from_secs(5))
-            .connect_with(pg_options)
-            .await
-            .context("error connecting to database")?;
+                let external_services_repository = external_services_repository(pg_pool.clone());
+                let media_repository = media_repository(pg_pool.clone());
+                let replicas_repository = replicas_repository(pg_pool.clone());
+                let sources_repository = sources_repository(pg_pool.clone());
+                let tags_repository = tags_repository(pg_pool.clone());
+                let tag_types_repository = tag_types_repository(pg_pool);
 
-        let external_services_repository = external_services_repository(pg_pool.clone());
-        let media_repository = media_repository(pg_pool.clone());
-        let replicas_repository = replicas_repository(pg_pool.clone());
-        let sources_repository = sources_repository(pg_pool.clone());
-        let tags_repository = tags_repository(pg_pool.clone());
-        let tag_types_repository = tag_types_repository(pg_pool);
+                let objects_repository = objects_repository(collator, serve.media_root_dir);
+                let medium_image_processor = medium_image_processor();
 
-        let objects_repository = objects_repository(collator, config.media_root_dir);
-        let medium_image_processor = medium_image_processor();
+                let external_services_service = external_services_service(external_services_repository);
+                let media_service = media_service(media_repository, objects_repository, replicas_repository, sources_repository, medium_image_processor);
+                let tags_service = tags_service(tags_repository, tag_types_repository);
 
-        let external_services_service = external_services_service(external_services_repository);
-        let media_service = media_service(media_repository, objects_repository, replicas_repository, sources_repository, medium_image_processor);
-        let tags_service = tags_service(tags_repository, tag_types_repository);
+                let media_url_factory: Arc<dyn MediaURLFactoryInterface> = match serve.media_root_url {
+                    Some(media_root_url) => Arc::new(file_media_url_factory(media_root_url)),
+                    None => Arc::new(noop_media_url_factory()),
+                };
 
-        let media_url_factory: Arc<dyn MediaURLFactoryInterface> = match config.media_root_url {
-            Some(media_root_url) => Arc::new(file_media_url_factory(media_root_url)),
-            None => Arc::new(noop_media_url_factory()),
-        };
+                let objects_service = objects_service(media_service.clone(), media_url_factory.clone());
 
-        let objects_service = objects_service(media_service.clone(), media_url_factory.clone());
+                let thumbnail_url_factory = Arc::new(thumbnail_url_factory());
+                let thumbnails_service = thumbnails_service(media_service.clone());
 
-        let thumbnail_url_factory = Arc::new(thumbnail_url_factory());
-        let thumbnails_service = thumbnails_service(media_service.clone());
+                let schema = schema(external_services_service, media_service, tags_service, media_url_factory, thumbnail_url_factory);
+                let graphql_service = graphql_service(schema);
 
-        let query = query(external_services_service.clone(), media_service.clone(), tags_service.clone());
-        let mutation = mutation(external_services_service, media_service, tags_service);
-        let schema = schema(query, mutation, media_url_factory, thumbnail_url_factory);
-        let graphql_service = graphql_service(schema);
-
-        if config.print_schema {
-            println!("{}", graphql_service.definitions());
-            return Ok(());
+                let tls = Option::zip(serve.tls_cert, serve.tls_key);
+                Engine::new(graphql_service, objects_service, thumbnails_service)
+                    .start(serve.port, tls)
+                    .await?;
+            },
+            Commands::Schema(SchemaCommand { command: SchemaCommands::Print(..) }) => {
+                let schema = noop_schema();
+                let graphql_service = graphql_service(schema);
+                println!("{}", graphql_service.definitions());
+            },
         }
-
-        let tls = Option::zip(config.tls_cert, config.tls_key);
-        Engine::new(graphql_service, objects_service, thumbnails_service)
-            .start(config.port, tls)
-            .await?;
 
         Ok(())
     }

--- a/api/crates/core/env/commands.rs
+++ b/api/crates/core/env/commands.rs
@@ -1,0 +1,48 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Debug, Subcommand)]
+pub enum Commands {
+    /// Serve API [default]
+    Serve(ServeCommand),
+
+    /// Manage GraphQL schema
+    Schema(SchemaCommand),
+}
+
+#[derive(Debug, Subcommand)]
+pub enum SchemaCommands {
+    /// Print schema in SDL (Schema Definition Language)
+    Print(SchemaPrintCommand),
+}
+
+#[derive(Debug, Parser)]
+pub struct ServeCommand {
+    /// Port number
+    #[arg(long, env)]
+    pub port: u16,
+
+    /// Root directory for media
+    #[arg(long, env)]
+    pub media_root_dir: String,
+
+    /// Root URL for media
+    #[arg(long, env)]
+    pub media_root_url: Option<String>,
+
+    /// Path to TLS certificate (if not specified, application is served over HTTP)
+    #[arg(long, env, requires = "tls_key")]
+    pub tls_cert: Option<String>,
+
+    /// Path to TLS private key (if not specified, application is served over HTTP)
+    #[arg(long, env, requires = "tls_cert")]
+    pub tls_key: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct SchemaCommand {
+    #[command(subcommand)]
+    pub command: SchemaCommands,
+}
+
+#[derive(Debug, Parser)]
+pub struct SchemaPrintCommand;

--- a/api/crates/graphql/src/query.rs
+++ b/api/crates/graphql/src/query.rs
@@ -1,8 +1,9 @@
+use std::marker::PhantomData;
+
 use async_graphql::{
     connection::{query, Connection},
     Context, Object,
 };
-use derive_more::Constructor;
 use domain::{
     entity::objects::EntryUrlPath,
     repository,
@@ -25,14 +26,23 @@ use crate::{
     Order,
 };
 
-#[derive(Constructor)]
 pub struct Query<ExternalServicesService, MediaService, TagsService> {
-    external_services_service: ExternalServicesService,
-    media_service: MediaService,
-    tags_service: TagsService,
+    external_services_service: PhantomData<fn() -> ExternalServicesService>,
+    media_service: PhantomData<fn() -> MediaService>,
+    tags_service: PhantomData<fn() -> TagsService>,
 }
 
 type Map<T, U, V> = std::iter::Map<T, fn(U) -> V>;
+
+impl<ExternalServicesService, MediaService, TagsService> Query<ExternalServicesService, MediaService, TagsService> {
+    pub fn new() -> Self {
+        Self {
+            external_services_service: PhantomData,
+            media_service: PhantomData,
+            tags_service: PhantomData,
+        }
+    }
+}
 
 #[Object]
 impl<ExternalServicesService, MediaService, TagsService> Query<ExternalServicesService, MediaService, TagsService>
@@ -41,15 +51,19 @@ where
     MediaService: MediaServiceInterface,
     TagsService: TagsServiceInterface,
 {
-    async fn all_external_services(&self) -> Result<Vec<ExternalService>> {
-        let external_services = self.external_services_service.get_external_services().await?;
+    async fn all_external_services(&self, ctx: &Context<'_>) -> Result<Vec<ExternalService>> {
+        let external_services_service = ctx.data_unchecked::<ExternalServicesService>();
+
+        let external_services = external_services_service.get_external_services().await?;
         Ok(external_services.into_iter().map(Into::into).collect())
     }
 
-    async fn external_services(&self, ids: Vec<Uuid>) -> Result<Vec<ExternalService>> {
+    async fn external_services(&self, ctx: &Context<'_>, ids: Vec<Uuid>) -> Result<Vec<ExternalService>> {
+        let external_services_service = ctx.data_unchecked::<ExternalServicesService>();
+
         let ids: Map<_, _, _> = ids.into_iter().map(Into::into);
 
-        let external_services = self.external_services_service.get_external_services_by_ids(ids).await?;
+        let external_services = external_services_service.get_external_services_by_ids(ids).await?;
         Ok(external_services.into_iter().map(Into::into).collect())
     }
 
@@ -67,6 +81,8 @@ where
         #[graphql(validator(maximum = 100))]
         last: Option<i32>,
     ) -> Result<Connection<MediumCursor, Medium>> {
+        let media_service = ctx.data_unchecked::<MediaService>();
+
         let node = ctx.look_ahead().field("nodes");
         let node = node.exists()
             .then_some(node)
@@ -105,15 +121,15 @@ where
                     match (source_ids, tag_ids) {
                         (Some(_), Some(_)) => return Err(Error::new(ErrorKind::ArgumentsMutuallyExclusive { arguments: vec!["sourceIds", "tagIds"] })),
                         (None, None) => {
-                            self.media_service.get_media(tag_depth, replicas, sources, cursor, order, direction, limit).await?
+                            media_service.get_media(tag_depth, replicas, sources, cursor, order, direction, limit).await?
                         },
                         (Some(source_ids), None) => {
                             let source_ids: Map<_, _, _> = source_ids.into_iter().map(Into::into);
-                            self.media_service.get_media_by_source_ids(source_ids, tag_depth, replicas, sources, cursor, order, direction, limit).await?
+                            media_service.get_media_by_source_ids(source_ids, tag_depth, replicas, sources, cursor, order, direction, limit).await?
                         },
                         (None, Some(tag_ids)) => {
                             let tag_ids: Map<_, _, _> = tag_ids.into_iter().map(Into::into);
-                            self.media_service.get_media_by_tag_ids(tag_ids, tag_depth, replicas, sources, cursor, order, direction, limit).await?
+                            media_service.get_media_by_tag_ids(tag_ids, tag_depth, replicas, sources, cursor, order, direction, limit).await?
                         },
                     }
                 };
@@ -135,6 +151,8 @@ where
     }
 
     async fn media(&self, ctx: &Context<'_>, ids: Vec<Uuid>) -> Result<Vec<Medium>> {
+        let media_service = ctx.data_unchecked::<MediaService>();
+
         let node = ctx.look_ahead();
 
         let tags = node.field("tags").field("tag");
@@ -144,27 +162,33 @@ where
 
         let ids: Map<_, _, _> = ids.into_iter().map(Into::into);
 
-        let media = self.media_service.get_media_by_ids(ids, tag_depth, replicas, sources).await?;
+        let media = media_service.get_media_by_ids(ids, tag_depth, replicas, sources).await?;
         media.into_iter().map(|m| m.try_into().map_err(Error::new)).collect()
     }
 
-    async fn replica(&self, original_url: String) -> Result<Replica> {
-        let replica = self.media_service.get_replica_by_original_url(&original_url).await?;
+    async fn replica(&self, ctx: &Context<'_>, original_url: String) -> Result<Replica> {
+        let media_service = ctx.data_unchecked::<MediaService>();
+
+        let replica = media_service.get_replica_by_original_url(&original_url).await?;
         Ok(replica.into())
     }
 
-    async fn source(&self, external_service_id: Uuid, external_metadata: ExternalMetadata) -> Result<Option<Source>> {
+    async fn source(&self, ctx: &Context<'_>, external_service_id: Uuid, external_metadata: ExternalMetadata) -> Result<Option<Source>> {
+        let media_service = ctx.data_unchecked::<MediaService>();
+
         let external_service_id = external_service_id.into();
         let external_metadata = external_metadata.try_into().map_err(Error::new)?;
 
-        let source = self.media_service.get_source_by_external_metadata(external_service_id, external_metadata).await?;
+        let source = media_service.get_source_by_external_metadata(external_service_id, external_metadata).await?;
         source.map(TryInto::try_into).transpose().map_err(Error::new)
     }
 
-    async fn objects(&self, prefix: String, kind: Option<ObjectKind>) -> Result<Vec<ObjectEntry>> {
+    async fn objects(&self, ctx: &Context<'_>, prefix: String, kind: Option<ObjectKind>) -> Result<Vec<ObjectEntry>> {
+        let media_service = ctx.data_unchecked::<MediaService>();
+
         let kind = kind.map(Into::into);
 
-        let objects = self.media_service.get_objects(EntryUrlPath::from(prefix), kind).await?;
+        let objects = media_service.get_objects(EntryUrlPath::from(prefix), kind).await?;
         Ok(objects.into_iter().map(Into::into).collect())
     }
 
@@ -180,6 +204,8 @@ where
         #[graphql(validator(maximum = 100))]
         last: Option<i32>,
     ) -> Result<Connection<TagCursor, Tag>> {
+        let tags_service = ctx.data_unchecked::<TagsService>();
+
         let node = ctx.look_ahead().field("nodes");
         let node = node.exists()
             .then_some(node)
@@ -210,7 +236,7 @@ where
                     (None, None) => None,
                 };
 
-                let tags = self.tags_service.get_tags(
+                let tags = tags_service.get_tags(
                     depth,
                     root,
                     cursor,
@@ -240,22 +266,28 @@ where
         #[graphql(validator(chars_min_length = 1))]
         name_or_alias_like: String,
     ) -> Result<Vec<Tag>> {
+        let tags_service = ctx.data_unchecked::<TagsService>();
+
         let depth = get_tag_depth(&ctx.look_ahead());
 
-        let tags = self.tags_service.get_tags_by_name_or_alias_like(&name_or_alias_like, depth).await?;
+        let tags = tags_service.get_tags_by_name_or_alias_like(&name_or_alias_like, depth).await?;
         Ok(tags.into_iter().map(Into::into).collect())
     }
 
     async fn tags(&self, ctx: &Context<'_>, ids: Vec<Uuid>) -> Result<Vec<Tag>> {
+        let tags_service = ctx.data_unchecked::<TagsService>();
+
         let depth = get_tag_depth(&ctx.look_ahead());
         let ids: Map<_, _, _> = ids.into_iter().map(Into::into);
 
-        let tags = self.tags_service.get_tags_by_ids(ids, depth).await?;
+        let tags = tags_service.get_tags_by_ids(ids, depth).await?;
         Ok(tags.into_iter().map(Into::into).collect())
     }
 
-    async fn all_tag_types(&self) -> Result<Vec<TagType>> {
-        let tag_types = self.tags_service.get_tag_types().await?;
+    async fn all_tag_types(&self, ctx: &Context<'_>) -> Result<Vec<TagType>> {
+        let tags_service = ctx.data_unchecked::<TagsService>();
+
+        let tag_types = tags_service.get_tag_types().await?;
         Ok(tag_types.into_iter().map(Into::into).collect())
     }
 }

--- a/api/crates/graphql/tests/all_external_services.rs
+++ b/api/crates/graphql/tests/all_external_services.rs
@@ -42,8 +42,13 @@ async fn succeeds() {
     let media_service = MockMediaServiceInterface::new();
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allExternalServices {

--- a/api/crates/graphql/tests/all_media-first.rs
+++ b/api/crates/graphql/tests/all_media-first.rs
@@ -75,8 +75,13 @@ async fn asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3) {
@@ -187,8 +192,13 @@ async fn desc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3, order: DESC) {
@@ -283,8 +293,13 @@ async fn after_asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3, after: "MjAyMi0wNi0wMVQxMjozNDo1Ny4wMDAwMDArMDA6MDAAODg4ODg4ODgtODg4OC04ODg4LTg4ODgtODg4ODg4ODg4ODg4") {
@@ -372,8 +387,13 @@ async fn after_desc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3, order: DESC, after: "MjAyMi0wNi0wMVQxMjozNDo1OC4wMDAwMDArMDA6MDAAOTk5OTk5OTktOTk5OS05OTk5LTk5OTktOTk5OTk5OTk5OTk5") {
@@ -461,8 +481,13 @@ async fn before_asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3, before: "MjAyMi0wNi0wMVQxMjozNDo1OC4wMDAwMDArMDA6MDAAOTk5OTk5OTktOTk5OS05OTk5LTk5OTktOTk5OTk5OTk5OTk5") {
@@ -550,8 +575,13 @@ async fn before_desc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3, order: DESC, before: "MjAyMi0wNi0wMVQxMjozNDo1Ny4wMDAwMDArMDA6MDAAODg4ODg4ODgtODg4OC04ODg4LTg4ODgtODg4ODg4ODg4ODg4") {

--- a/api/crates/graphql/tests/all_media-last.rs
+++ b/api/crates/graphql/tests/all_media-last.rs
@@ -75,8 +75,13 @@ async fn asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(last: 3, order: ASC) {
@@ -187,8 +192,13 @@ async fn desc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(last: 3, order: DESC) {
@@ -283,8 +293,13 @@ async fn after_asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(last: 3, after: "MjAyMi0wNi0wMVQxMjozNDo1Ny4wMDAwMDArMDA6MDAAODg4ODg4ODgtODg4OC04ODg4LTg4ODgtODg4ODg4ODg4ODg4") {
@@ -372,8 +387,13 @@ async fn after_desc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(last: 3, order: DESC, after: "MjAyMi0wNi0wMVQxMjozNDo1OC4wMDAwMDArMDA6MDAAOTk5OTk5OTktOTk5OS05OTk5LTk5OTktOTk5OTk5OTk5OTk5") {
@@ -461,8 +481,13 @@ async fn before_asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(last: 3, before: "MjAyMi0wNi0wMVQxMjozNDo1OC4wMDAwMDArMDA6MDAAOTk5OTk5OTktOTk5OS05OTk5LTk5OTktOTk5OTk5OTk5OTk5") {
@@ -550,8 +575,13 @@ async fn before_desc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(last: 3, order: DESC, before: "MjAyMi0wNi0wMVQxMjozNDo1Ny4wMDAwMDArMDA6MDAAODg4ODg4ODgtODg4OC04ODg4LTg4ODgtODg4ODg4ODg4ODg4") {

--- a/api/crates/graphql/tests/all_media-with.rs
+++ b/api/crates/graphql/tests/all_media-with.rs
@@ -318,8 +318,13 @@ async fn tags_asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3) {
@@ -781,8 +786,11 @@ async fn replicas_asc_succeeds() {
         .withf(|thumbnail_id| thumbnail_id == &ThumbnailId::from(uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")))
         .returning(|_| "https://img.example.com/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".to_string());
 
-    let query = Query::new(external_services_service, media_service, tags_service);
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
     let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
         .data::<Arc<dyn MediaURLFactoryInterface>>(Arc::new(media_url_factory))
         .data::<Arc<dyn ThumbnailURLFactoryInterface>>(Arc::new(thumbnail_url_factory))
         .finish();
@@ -1018,8 +1026,13 @@ async fn sources_asc_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3) {

--- a/api/crates/graphql/tests/all_media.rs
+++ b/api/crates/graphql/tests/all_media.rs
@@ -71,8 +71,13 @@ async fn by_source_ids_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(first: 3, sourceIds: ["11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333"]) {
@@ -174,8 +179,13 @@ async fn by_tag_ids_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allMedia(

--- a/api/crates/graphql/tests/all_tag_types.rs
+++ b/api/crates/graphql/tests/all_tag_types.rs
@@ -37,8 +37,13 @@ async fn succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTagTypes {

--- a/api/crates/graphql/tests/all_tags.rs
+++ b/api/crates/graphql/tests/all_tags.rs
@@ -102,8 +102,13 @@ async fn root_first_succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTags(root: true, first: 3) {
@@ -291,8 +296,13 @@ async fn root_last_succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTags(root: true, last: 3) {
@@ -469,8 +479,13 @@ async fn root_after_first_succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTags(root: true, first: 3, after: "44OW44Or44O844Ki44O844Kr44Kk44OWADY2NjY2NjY2LTY2NjYtNjY2Ni02NjY2LTY2NjY2NjY2NjY2Ng==") {
@@ -602,8 +617,13 @@ async fn root_after_last_succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTags(root: true, last: 3, after: "44GS44KT44GX44KTADQ0NDQ0NDQ0LTQ0NDQtNDQ0NC00NDQ0LTQ0NDQ0NDQ0NDQ0NA==") {
@@ -726,8 +746,13 @@ async fn root_before_first_succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTags(root: true, first: 3, before: "44OW44Or44O844Ki44O844Kr44Kk44OWADY2NjY2NjY2LTY2NjYtNjY2Ni02NjY2LTY2NjY2NjY2NjY2Ng==") {
@@ -862,8 +887,13 @@ async fn root_before_last_succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTags(root: true, last: 3, before: "44OW44Or44O844Ki44O844Kr44Kk44OWADY2NjY2NjY2LTY2NjYtNjY2Ni02NjY2LTY2NjY2NjY2NjY2Ng==") {

--- a/api/crates/graphql/tests/all_tags_like.rs
+++ b/api/crates/graphql/tests/all_tags_like.rs
@@ -83,8 +83,13 @@ async fn succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             allTagsLike(nameOrAliasLike: "り") {

--- a/api/crates/graphql/tests/external_services.rs
+++ b/api/crates/graphql/tests/external_services.rs
@@ -44,8 +44,13 @@ async fn succeeds() {
     let media_service = MockMediaServiceInterface::new();
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             externalServices(ids: ["11111111-1111-1111-1111-111111111111", "33333333-3333-3333-3333-333333333333"]) {

--- a/api/crates/graphql/tests/media-with.rs
+++ b/api/crates/graphql/tests/media-with.rs
@@ -233,8 +233,13 @@ async fn tags_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             media(ids: ["77777777-7777-7777-7777-777777777777" "99999999-9999-9999-9999-999999999999"]) {
@@ -559,8 +564,11 @@ async fn replicas_succeeds() {
         .withf(|thumbnail_id| thumbnail_id == &ThumbnailId::from(uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")))
         .returning(|_| "https://img.example.com/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa".to_string());
 
-    let query = Query::new(external_services_service, media_service, tags_service);
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
     let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
         .data::<Arc<dyn MediaURLFactoryInterface>>(Arc::new(media_url_factory))
         .data::<Arc<dyn ThumbnailURLFactoryInterface>>(Arc::new(thumbnail_url_factory))
         .finish();
@@ -717,8 +725,13 @@ async fn sources_succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             media(ids: ["77777777-7777-7777-7777-777777777777" "99999999-9999-9999-9999-999999999999"]) {

--- a/api/crates/graphql/tests/media.rs
+++ b/api/crates/graphql/tests/media.rs
@@ -61,8 +61,13 @@ async fn succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
     let req = indoc! {r#"
         query {
             media(ids: ["77777777-7777-7777-7777-777777777777" "99999999-9999-9999-9999-999999999999"]) {

--- a/api/crates/graphql/tests/replica.rs
+++ b/api/crates/graphql/tests/replica.rs
@@ -63,8 +63,11 @@ async fn succeeds() {
         .withf(|thumbnail_id| thumbnail_id == &ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")))
         .returning(|_| "https://img.example.com/88888888-8888-8888-8888-888888888888".to_string());
 
-    let query = Query::new(external_services_service, media_service, tags_service);
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
     let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
         .data::<Arc<dyn MediaURLFactoryInterface>>(Arc::new(media_url_factory))
         .data::<Arc<dyn ThumbnailURLFactoryInterface>>(Arc::new(thumbnail_url_factory))
         .finish();

--- a/api/crates/graphql/tests/source.rs
+++ b/api/crates/graphql/tests/source.rs
@@ -47,8 +47,12 @@ async fn succeeds() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
 
     let req = indoc! {r#"
         query {
@@ -111,8 +115,12 @@ async fn not_found() {
 
     let tags_service = MockTagsServiceInterface::new();
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
 
     let req = indoc! {r#"
         query {

--- a/api/crates/graphql/tests/tags.rs
+++ b/api/crates/graphql/tests/tags.rs
@@ -89,8 +89,12 @@ async fn succeeds() {
             ]))
         });
 
-    let query = Query::new(external_services_service, media_service, tags_service);
-    let schema = Schema::build(query, EmptyMutation, EmptySubscription).finish();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
 
     let req = indoc! {r#"
         query {


### PR DESCRIPTION
This PR moves `--print-schema` option to a subcommand `schema print`. A newly added subcommand `serve` is optional.

```
$ hoarder --help
Usage: hoarder [OPTIONS] [COMMAND]

Commands:
  serve   Serve API [default]
  schema  Manage GraphQL schema
  help    Print this message or the help of the given subcommand(s)

Options:
      --locale <LOCALE>        Locale [env: LOCALE=] [default: und]
      --log-level <LOG_LEVEL>  Log level [env: LOG_LEVEL=] [default: info]
  -h, --help                   Print help
  -V, --version                Print version
```

```
$ hoarder serve --help
Serve API [default]

Usage: hoarder serve [OPTIONS] --port <PORT> --media-root-dir <MEDIA_ROOT_DIR>

Options:
      --locale <LOCALE>
          Locale [env: LOCALE=] [default: und]
      --port <PORT>
          Port number [env: PORT=]
      --log-level <LOG_LEVEL>
          Log level [env: LOG_LEVEL=] [default: info]
      --media-root-dir <MEDIA_ROOT_DIR>
          Root directory for media [env: MEDIA_ROOT_DIR=]
      --media-root-url <MEDIA_ROOT_URL>
          Root URL for media [env: MEDIA_ROOT_URL=]
      --tls-cert <TLS_CERT>
          Path to TLS certificate (if not specified, application is served over HTTP) [env: TLS_CERT=]
      --tls-key <TLS_KEY>
          Path to TLS private key (if not specified, application is served over HTTP) [env: TLS_KEY=]
  -h, --help
          Print help
```

```
$ hoarder schema --help
Manage GraphQL schema

Usage: hoarder schema [OPTIONS] <COMMAND>

Commands:
  print  Print schema in SDL (Schema Definition Language)
  help   Print this message or the help of the given subcommand(s)

Options:
      --locale <LOCALE>        Locale [env: LOCALE=] [default: und]
      --log-level <LOG_LEVEL>  Log level [env: LOG_LEVEL=] [default: info]
  -h, --help                   Print help
```