### PR TITLE
Encode/decode object URLs in domain service

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "futures",
  "log",
  "mockall",
+ "percent-encoding",
  "pretty_assertions",
  "serde",
  "thiserror",
@@ -3521,7 +3522,6 @@ dependencies = [
  "icu_collator",
  "libc",
  "normalize-path",
- "percent-encoding",
  "tokio",
  "tokio-stream",
 ]

--- a/api/crates/domain/Cargo.toml
+++ b/api/crates/domain/Cargo.toml
@@ -25,6 +25,9 @@ version = "0.4.21"
 version = "0.12.1"
 optional = true
 
+[dependencies.percent-encoding]
+version = "2.3.1"
+
 [dependencies.serde]
 version = "1.0.197"
 features = ["derive"]

--- a/api/crates/domain/src/entity/objects.rs
+++ b/api/crates/domain/src/entity/objects.rs
@@ -1,6 +1,9 @@
 use chrono::{DateTime, Utc};
 use derive_more::{Constructor, Deref, Display, From};
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, ErrorKind, Result};
 
 #[derive(Clone, Debug, Default, Deref, Deserialize, Display, Eq, From, Hash, PartialEq, Serialize)]
 pub struct EntryUrl(String);
@@ -32,28 +35,94 @@ pub enum EntryKind {
 }
 
 impl EntryUrl {
+    const RFC3986_PATH: &'static AsciiSet = &CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'%')
+        .add(b'<')
+        .add(b'>')
+        .add(b'?')
+        .add(b'^')
+        .add(b'`')
+        .add(b'{')
+        .add(b'}');
+
+    pub fn from_path_str(prefix: &str, path: &str) -> Self {
+        let url = format!(
+            "{}{}",
+            prefix,
+            utf8_percent_encode(path, Self::RFC3986_PATH),
+        );
+
+        Self::from(url)
+    }
+
+    pub fn to_path_string(&self, prefix: &str) -> Result<String> {
+        let path = self
+            .strip_prefix(prefix)
+            .ok_or_else(|| ErrorKind::ObjectUrlUnsupported { url: self.to_string() })?;
+
+        let path = percent_decode_str(path)
+            .decode_utf8()
+            .map_err(|e| Error::new(ErrorKind::ObjectPathInvalid, e))?
+            .to_string();
+
+        Ok(path)
+    }
+
     pub fn into_inner(self) -> String {
         self.0
     }
 }
 
 impl EntryUrlPath {
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-
     pub fn to_url(&self, scheme: &str) -> EntryUrl {
         let path = &self.0;
         let url = format!("{scheme}://{path}");
         EntryUrl::from(url)
     }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use pretty_assertions::assert_eq;
+    use pretty_assertions::{assert_eq, assert_matches};
 
-    use crate::entity::objects::{EntryUrl, EntryUrlPath};
+    use crate::{entity::objects::{EntryUrl, EntryUrlPath}, error::ErrorKind};
+
+    #[test]
+    fn entry_url_from_path_str() {
+        let actual = EntryUrl::from_path_str("file://", "/ゆるゆり/77777777-7777-7777-7777-777777777777.png");
+        assert_eq!(actual, EntryUrl::from("file:///%E3%82%86%E3%82%8B%E3%82%86%E3%82%8A/77777777-7777-7777-7777-777777777777.png".to_string()));
+    }
+
+    #[test]
+    fn entry_url_to_path_string_prefix_mismatch() {
+        let url = EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string());
+
+        let actual = url.to_path_string("s3://").unwrap_err();
+        assert_matches!(actual.kind(), ErrorKind::ObjectUrlUnsupported { url } if url == "file:///77777777-7777-7777-7777-777777777777.png");
+    }
+
+    #[test]
+    fn entry_url_to_path_string_utf8_valid() {
+        let url = EntryUrl::from("file:///%E3%82%86%E3%82%8B%E3%82%86%E3%82%8A/77777777-7777-7777-7777-777777777777.png".to_string());
+
+        let actual = url.to_path_string("file://").unwrap();
+        assert_eq!(actual, "/ゆるゆり/77777777-7777-7777-7777-777777777777.png".to_string());
+    }
+
+    #[test]
+    fn entry_url_to_path_string_utf8_invalid() {
+        let url = EntryUrl::from("file:///%80.png".to_string());
+
+        let actual = url.to_path_string("file://").unwrap_err();
+        assert_matches!(actual.kind(), ErrorKind::ObjectPathInvalid);
+    }
 
     #[test]
     fn entry_url_into_inner() {
@@ -64,18 +133,18 @@ mod tests {
     }
 
     #[test]
-    fn entry_url_path_into_inner() {
-        let url = EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
-
-        let actual = url.into_inner();
-        assert_eq!(actual, "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
-    }
-
-    #[test]
     fn entry_url_path_to_url() {
         let path = EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
 
         let actual = path.to_url("file");
         assert_eq!(actual, EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()));
+    }
+
+    #[test]
+    fn entry_url_path_into_inner() {
+        let url = EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
+
+        let actual = url.into_inner();
+        assert_eq!(actual, "/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string());
     }
 }

--- a/api/crates/storage/Cargo.toml
+++ b/api/crates/storage/Cargo.toml
@@ -26,9 +26,6 @@ version = "1.4.0"
 [dependencies.normalize-path]
 version = "0.2.1"
 
-[dependencies.percent-encoding]
-version = "2.3.1"
-
 [dependencies.tokio]
 version = "1.37.0"
 features = ["fs", "io-util", "rt-multi-thread"]

--- a/api/crates/storage/src/filesystem/url.rs
+++ b/api/crates/storage/src/filesystem/url.rs
@@ -2,10 +2,7 @@ use std::path::{Path, PathBuf, MAIN_SEPARATOR_STR};
 
 use cow_utils::CowUtils;
 use derive_more::Display;
-use domain::{
-    entity::objects::EntryUrl,
-    error::{Error, ErrorKind, Result},
-};
+use domain::{entity::objects::EntryUrl, error::{Error, ErrorKind, Result}};
 use normalize_path::NormalizePath;
 
 use crate::StorageEntryUrl;
@@ -25,7 +22,7 @@ impl FilesystemEntryUrl {
             .ok_or_else(|| ErrorKind::ObjectPathInvalid)?
             .cow_replace(MAIN_SEPARATOR_STR, "/");
 
-        Self::from_path_str(&path)
+        Self::try_from(EntryUrl::from_path_str(Self::URL_PREFIX, &path))
     }
 
     pub(crate) fn as_path(&self) -> &Path {
@@ -37,7 +34,7 @@ impl TryFrom<EntryUrl> for FilesystemEntryUrl {
     type Error = Error;
 
     fn try_from(url: EntryUrl) -> Result<Self> {
-        let path = Self::to_path_string(&url)?;
+        let path = url.to_path_string(Self::URL_PREFIX)?;
         let path = match path.strip_prefix('/') {
             Some(path) => path,
             None => return Err(ErrorKind::ObjectUrlInvalid { url: url.into_inner() })?,

--- a/api/crates/storage/src/lib.rs
+++ b/api/crates/storage/src/lib.rs
@@ -1,8 +1,4 @@
-use domain::{
-    entity::objects::{Entry, EntryUrl},
-    error::{Error, ErrorKind, Result},
-};
-use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
+use domain::{entity::objects::{Entry, EntryUrl}, error::Error};
 
 pub mod filesystem;
 
@@ -12,42 +8,6 @@ pub(crate) trait StorageEntry {
 
 pub(crate) trait StorageEntryUrl: TryFrom<EntryUrl, Error = Error> {
     const URL_PREFIX: &'static str;
-
-    const RFC3986_PATH: &'static AsciiSet = &CONTROLS
-        .add(b' ')
-        .add(b'"')
-        .add(b'#')
-        .add(b'%')
-        .add(b'<')
-        .add(b'>')
-        .add(b'?')
-        .add(b'^')
-        .add(b'`')
-        .add(b'{')
-        .add(b'}');
-
-    fn from_path_str(path: &str) -> Result<Self> {
-        let url = format!(
-            "{}{}",
-            Self::URL_PREFIX,
-            utf8_percent_encode(path, Self::RFC3986_PATH),
-        );
-
-        Self::try_from(EntryUrl::from(url))
-    }
-
-    fn to_path_string(url: &str) -> Result<String> {
-        let path = url
-            .strip_prefix(Self::URL_PREFIX)
-            .ok_or_else(|| ErrorKind::ObjectUrlUnsupported { url: url.to_string() })?;
-
-        let path = percent_decode_str(path)
-            .decode_utf8()
-            .map_err(|e| Error::new(ErrorKind::ObjectPathInvalid, e))?
-            .to_string();
-
-        Ok(path)
-    }
 
     fn into_url(self) -> EntryUrl;
 }


### PR DESCRIPTION
This PR refactors API to encode/decode object URLs in domain crate rather than storage crate.