### PR TITLE
Fix clippy warnings in graphql crate

### DIFF
--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -36,6 +36,7 @@ impl From<repository::DeleteResult> for DeleteResult {
     }
 }
 
+#[derive(Default)]
 pub struct Mutation<ExternalServicesService, MediaService, TagsService> {
     external_services_service: PhantomData<fn() -> ExternalServicesService>,
     media_service: PhantomData<fn() -> MediaService>,

--- a/api/crates/graphql/src/query.rs
+++ b/api/crates/graphql/src/query.rs
@@ -26,6 +26,7 @@ use crate::{
     Order,
 };
 
+#[derive(Default)]
 pub struct Query<ExternalServicesService, MediaService, TagsService> {
     external_services_service: PhantomData<fn() -> ExternalServicesService>,
     media_service: PhantomData<fn() -> MediaService>,


### PR DESCRIPTION
This PR fixes the clippy warning [`new_without_default`](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default).