### PR TITLE
Migrate object URLs in database to percent-encoded form

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -2637,6 +2637,7 @@ dependencies = [
  "futures",
  "include_dir",
  "indexmap",
+ "log",
  "pretty_assertions",
  "sea-query",
  "sea-query-binder",

--- a/api/crates/postgres/Cargo.toml
+++ b/api/crates/postgres/Cargo.toml
@@ -35,6 +35,9 @@ default-features = false
 version = "2.2.6"
 features = ["serde"]
 
+[dependencies.log]
+version = "0.4.21"
+
 [dependencies.sea-query]
 version = "0.30.7"
 features = ["thread-safe"]

--- a/api/crates/postgres/src/migrations.rs
+++ b/api/crates/postgres/src/migrations.rs
@@ -2,6 +2,7 @@ use sqlx::Postgres;
 use sqlx_migrator::{migrator::{self, Info}, vec_box};
 
 mod v1;
+mod v2;
 
 pub struct Migrator(migrator::Migrator<Postgres, State>);
 
@@ -10,6 +11,7 @@ impl Migrator {
         let mut migrator = migrator::Migrator::new(State);
         migrator.add_migrations(vec_box![
             v1::V1Migration,
+            v2::V2Migration,
         ]);
 
         Self(migrator)

--- a/api/crates/postgres/src/migrations/v2.rs
+++ b/api/crates/postgres/src/migrations/v2.rs
@@ -1,0 +1,124 @@
+use async_trait::async_trait;
+use domain::entity::objects::{EntryUrl, EntryUrlPath};
+use sea_query::{Expr, LockType, PostgresQueryBuilder, Query};
+use sea_query_binder::SqlxBinder;
+use sqlx::{migrate::MigrateError, prelude::FromRow, Connection, PgConnection, Postgres};
+use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
+
+use crate::{migrations::State, replicas::{PostgresReplica, PostgresReplicaId}};
+
+const URL_SCHEME: &str = "file";
+const URL_PREFIX: &str = "file://";
+
+pub(super) struct V2Migration;
+
+impl Migration<Postgres, State> for V2Migration {
+    fn app(&self) -> &str {
+        "hoarder"
+    }
+
+    fn name(&self) -> &str {
+        "replicas_urlencode_original_url"
+    }
+
+    fn parents(&self) -> Vec<Box<dyn Migration<Postgres, State>>> {
+        vec_box![]
+    }
+
+    fn operations(&self) -> Vec<Box<dyn Operation<Postgres, State>>> {
+        vec_box![ReplicaUrlOperation]
+    }
+}
+
+struct ReplicaUrlOperation;
+
+#[derive(Debug, FromRow)]
+struct PostgresReplicaOriginalUrlRow {
+    id: PostgresReplicaId,
+    original_url: String,
+}
+
+#[async_trait]
+impl Operation<Postgres, State> for ReplicaUrlOperation {
+    async fn up(&self, connection: &mut PgConnection, _state: &State) -> Result<(), Error> {
+        let mut tx = connection.begin().await?;
+
+        let (sql, values) = Query::select()
+            .columns([
+                PostgresReplica::Id,
+                PostgresReplica::OriginalUrl,
+            ])
+            .from(PostgresReplica::Table)
+            .lock(LockType::Update)
+            .build_sqlx(PostgresQueryBuilder);
+
+        let replicas = sqlx::query_as_with::<_, PostgresReplicaOriginalUrlRow, _>(&sql, values)
+            .fetch_all(&mut *tx)
+            .await?;
+
+        for replica in replicas {
+            if let Some(path) = replica.original_url.strip_prefix(URL_PREFIX) {
+                let url = EntryUrl::from_path_str(URL_PREFIX, path);
+                let (sql, values) = Query::update()
+                    .table(PostgresReplica::Table)
+                    .value(PostgresReplica::OriginalUrl, url.into_inner())
+                    .and_where(Expr::col(PostgresReplica::Id).eq(replica.id))
+                    .build_sqlx(PostgresQueryBuilder);
+
+                sqlx::query_with(&sql, values)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn down(&self, connection: &mut PgConnection, _state: &State) -> Result<(), Error> {
+        let mut tx = connection.begin().await?;
+
+        let (sql, values) = Query::select()
+            .columns([
+                PostgresReplica::Id,
+                PostgresReplica::OriginalUrl,
+            ])
+            .from(PostgresReplica::Table)
+            .lock(LockType::Update)
+            .build_sqlx(PostgresQueryBuilder);
+
+        let replicas = sqlx::query_as_with::<_, PostgresReplicaOriginalUrlRow, _>(&sql, values)
+            .fetch_all(&mut *tx)
+            .await?;
+
+        let mut errors = Vec::new();
+        for replica in replicas {
+            match EntryUrl::from(replica.original_url).to_path_string(URL_PREFIX) {
+                Ok(path) => {
+                    let url = EntryUrlPath::from(path).to_url(URL_SCHEME).into_inner();
+                    let (sql, values) = Query::update()
+                        .table(PostgresReplica::Table)
+                        .value(PostgresReplica::OriginalUrl, url)
+                        .and_where(Expr::col(PostgresReplica::Id).eq(replica.id))
+                        .build_sqlx(PostgresQueryBuilder);
+
+                    sqlx::query_with(&sql, values)
+                        .execute(&mut *tx)
+                        .await?;
+                },
+                Err(e) => {
+                    log::error!("failed to decode URL\nID: {:?}\nError: {e:?}", replica.id);
+                    errors.push(e);
+                },
+            }
+        }
+
+        if let Some(e) = errors.pop() {
+            log::error!("{} error(s) found", errors.len());
+            return Err(sqlx::Error::Migrate(Box::new(MigrateError::Source(Box::new(e)))))?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR migrates object URLs to percent-encoded form as per #8.