### PR TITLE
Deploy API after a new release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,3 +41,27 @@ jobs:
       - name: Push to Container Registry
         run: |
           docker push container.chitoku.jp/chitoku-k/hoarder/api
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+      - name: Set up ID token
+        uses: actions/github-script@v7
+        id: id-token
+        with:
+          result-encoding: string
+          script: |
+            return await core.getIDToken('k8s.chitoku.jp');
+      - name: Set context
+        run: |
+          kubectl config set-cluster k8s.chitoku.jp --server=https://k8s.chitoku.jp
+          kubectl config set-credentials github-actions --token=${{ steps.id-token.outputs.result }}
+          kubectl config set-context k8s.chitoku.jp --cluster=k8s.chitoku.jp --user=github-actions
+          kubectl config use-context k8s.chitoku.jp
+      - name: Rollout restart
+        run: |
+          kubectl rollout restart deployment/hoarder-api


### PR DESCRIPTION
This PR updates CD workflow to restart hoarder API after a new release.