### PR TITLE
Switch to jemalloc by default

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1485,6 +1485,7 @@ dependencies = [
  "icu_collator",
  "icu_locid",
  "icu_provider",
+ "jemallocator",
  "log",
  "media",
  "objects",
@@ -1944,6 +1945,26 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -59,7 +59,7 @@ codegen-units = 1
 opt-level = 3
 
 [features]
-default = ["tls"]
+default = ["jemallocator", "tls"]
 tls = ["application/tls"]
 test-postgres = []
 
@@ -108,6 +108,10 @@ features = ["std"]
 [dependencies.icu_provider]
 version = "1.4.0"
 features = ["std", "sync"]
+
+[dependencies.jemallocator]
+version = "0.5.4"
+optional = true
 
 [dependencies.log]
 version = "0.4.21"

--- a/api/crates/core/main.rs
+++ b/api/crates/core/main.rs
@@ -5,6 +5,10 @@ use di::container::Application;
 mod di;
 mod env;
 
+#[cfg(feature = "jemallocator")]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 #[tokio::main]
 async fn main() {
     match Application::start().await {


### PR DESCRIPTION
This PR updates API to use jemalloc as the global allocator by default in order to fine-tune the behavior of allocator.