### PR TITLE
Fix a clippy warning

### DIFF
--- a/api/crates/postgres/src/migrations.rs
+++ b/api/crates/postgres/src/migrations.rs
@@ -22,4 +22,10 @@ impl Migrator {
     }
 }
 
+impl Default for Migrator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub struct State;


### PR DESCRIPTION
This PR fixes the clippy warning [`new_without_default`](https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default).