### PR TITLE
Add kind and base_url fields for external services

### DIFF
--- a/api/crates/domain/src/entity/external_services.rs
+++ b/api/crates/domain/src/entity/external_services.rs
@@ -9,7 +9,9 @@ pub struct ExternalServiceId(Uuid);
 pub struct ExternalService {
     pub id: ExternalServiceId,
     pub slug: String,
+    pub kind: String,
     pub name: String,
+    pub base_url: Option<String>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/api/crates/domain/src/entity/sources.rs
+++ b/api/crates/domain/src/entity/sources.rs
@@ -26,7 +26,7 @@ pub enum SourceError {
 
 impl Source {
     pub fn validate(&self) -> Result<()> {
-        match (self.external_service.slug.as_str(), &self.external_metadata) {
+        match (self.external_service.kind.as_str(), &self.external_metadata) {
             ("fantia", &ExternalMetadata::Fantia { .. }) => Ok(()),
             ("nijie", &ExternalMetadata::Nijie { .. }) => Ok(()),
             ("pixiv", &ExternalMetadata::Pixiv { .. }) => Ok(()),
@@ -36,7 +36,7 @@ impl Source {
             ("twitter", &ExternalMetadata::Twitter { .. }) => Ok(()),
             ("website", &ExternalMetadata::Website { .. }) => Ok(()),
             (_, &ExternalMetadata::Custom(_)) => Ok(()),
-            (slug, _) => Err(ErrorKind::SourceMetadataNotMatch { slug: slug.to_string() })?,
+            (kind, _) => Err(ErrorKind::SourceMetadataNotMatch { kind: kind.to_string() })?,
         }
     }
 }
@@ -58,7 +58,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "fantia".to_string(),
+                kind: "fantia".to_string(),
                 name: "Fantia".to_string(),
+                base_url: Some("https://fantia.jp".to_string()),
             },
             external_metadata: ExternalMetadata::Fantia { id: 1305295 },
             created_at: Utc.with_ymd_and_hms(2022, 6, 4, 19, 34, 0).unwrap(),
@@ -76,7 +78,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "nijie".to_string(),
+                kind: "nijie".to_string(),
                 name: "ニジエ".to_string(),
+                base_url: Some("https://nijie.info".to_string()),
             },
             external_metadata: ExternalMetadata::Nijie { id: 323512 },
             created_at: Utc.with_ymd_and_hms(2019, 7, 19, 18, 9, 54).unwrap(),
@@ -94,7 +98,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "pixiv".to_string(),
+                kind: "pixiv".to_string(),
                 name: "pixiv".to_string(),
+                base_url: Some("https://www.pixiv.net".to_string()),
             },
             external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
             created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -112,7 +118,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "pixiv_fanbox".to_string(),
+                kind: "pixiv_fanbox".to_string(),
                 name: "pixivFANBOX".to_string(),
+                base_url: None,
             },
             external_metadata: ExternalMetadata::PixivFanbox { id: 178080, creator_id: "fairyeye".to_string() },
             created_at: Utc.with_ymd_and_hms(2018, 10, 18, 12, 22, 0).unwrap(),
@@ -130,7 +138,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "seiga".to_string(),
+                kind: "seiga".to_string(),
                 name: "ニコニコ静画".to_string(),
+                base_url: Some("https://seiga.nicovideo.jp".to_string()),
             },
             external_metadata: ExternalMetadata::Seiga { id: 6452903 },
             created_at: Utc.with_ymd_and_hms(2017, 2, 1, 23, 34, 0).unwrap(),
@@ -148,7 +158,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "skeb".to_string(),
+                kind: "skeb".to_string(),
                 name: "Skeb".to_string(),
+                base_url: Some("https://skeb.jp".to_string()),
             },
             external_metadata: ExternalMetadata::Skeb { id: 18, creator_id: "pieleaf_x2".to_string() },
             created_at: Utc.with_ymd_and_hms(2021, 7, 22, 20, 40, 0).unwrap(),
@@ -166,7 +178,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "twitter".to_string(),
+                kind: "twitter".to_string(),
                 name: "Twitter".to_string(),
+                base_url: Some("https://twitter.com".to_string()),
             },
             external_metadata: ExternalMetadata::Twitter { id: 727620202049900544 },
             created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -184,7 +198,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "website".to_string(),
+                kind: "website".to_string(),
                 name: "Website".to_string(),
+                base_url: None,
             },
             external_metadata: ExternalMetadata::Website { url: "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885".to_string() },
             created_at: Utc.with_ymd_and_hms(2022, 4, 1, 0, 0, 0).unwrap(),
@@ -202,7 +218,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "custom".to_string(),
+                kind: "custom".to_string(),
                 name: "Custom".to_string(),
+                base_url: None,
             },
             external_metadata: ExternalMetadata::Custom(r#"{"id":42}"#.to_string()),
             created_at: Utc.with_ymd_and_hms(2022, 6, 1, 0, 0, 0).unwrap(),
@@ -220,7 +238,9 @@ mod tests {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 slug: "website".to_string(),
+                kind: "website".to_string(),
                 name: "Website".to_string(),
+                base_url: None,
             },
             external_metadata: ExternalMetadata::Fantia { id: 1305295 },
             created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -228,6 +248,6 @@ mod tests {
         };
 
         let actual = source.validate().unwrap_err();
-        assert_matches!(actual.kind(), ErrorKind::SourceMetadataNotMatch { slug } if slug == "website");
+        assert_matches!(actual.kind(), ErrorKind::SourceMetadataNotMatch { kind } if kind == "website");
     }
 }

--- a/api/crates/domain/src/error.rs
+++ b/api/crates/domain/src/error.rs
@@ -134,7 +134,7 @@ pub enum ErrorKind {
     SourceMetadataInvalid,
 
     #[error("the source metadata does not match with external service")]
-    SourceMetadataNotMatch { slug: String },
+    SourceMetadataNotMatch { kind: String },
 
     #[error("the source was not found")]
     SourceNotFound { id: SourceId },

--- a/api/crates/domain/src/repository/external_services.rs
+++ b/api/crates/domain/src/repository/external_services.rs
@@ -9,7 +9,7 @@ use crate::{
 #[cfg_attr(feature = "test-mock", mockall::automock)]
 pub trait ExternalServicesRepository: Send + Sync + 'static {
     /// Creates an external service.
-    fn create(&self, slug: &str, name: &str) -> impl Future<Output = Result<ExternalService>> + Send;
+    fn create<'a>(&self, slug: &str, kind: &str, name: &str, base_url: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
     /// Fetches the external services by their IDs.
     fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send
@@ -20,7 +20,7 @@ pub trait ExternalServicesRepository: Send + Sync + 'static {
     fn fetch_all(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;
 
     /// Updates the external service by ID.
-    fn update_by_id<'a>(&self, id: ExternalServiceId, name: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
+    fn update_by_id<'a>(&self, id: ExternalServiceId, slug: Option<&'a str>, name: Option<&'a str>, base_url: Option<Option<&'a str>>) -> impl Future<Output = Result<ExternalService>> + Send;
 
     /// Deletes the external service by ID.
     fn delete_by_id(&self, id: ExternalServiceId) -> impl Future<Output = Result<DeleteResult>> + Send;

--- a/api/crates/domain/src/service/external_services.rs
+++ b/api/crates/domain/src/service/external_services.rs
@@ -12,7 +12,7 @@ use crate::{
 #[cfg_attr(feature = "test-mock", mockall::automock)]
 pub trait ExternalServicesServiceInterface: Send + Sync + 'static {
     /// Creates an external service.
-    fn create_external_service(&self, slug: &str, name: &str) -> impl Future<Output = Result<ExternalService>> + Send;
+    fn create_external_service<'a>(&self, slug: &str, kind: &str, name: &str, base_url: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
     /// Gets external services.
     fn get_external_services(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;
@@ -23,7 +23,7 @@ pub trait ExternalServicesServiceInterface: Send + Sync + 'static {
         T: IntoIterator<Item = ExternalServiceId> + Send + Sync + 'static;
 
     /// Updates the external service by ID.
-    fn update_external_service_by_id<'a>(&self, id: ExternalServiceId, name: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
+    fn update_external_service_by_id<'a>(&self, id: ExternalServiceId, slug: Option<&'a str>, name: Option<&'a str>, base_url: Option<Option<&'a str>>) -> impl Future<Output = Result<ExternalService>> + Send;
 
     /// Deletes the external service by ID.
     fn delete_external_service_by_id(&self, id: ExternalServiceId) -> impl Future<Output = Result<DeleteResult>> + Send;
@@ -38,8 +38,8 @@ impl<ExternalServicesRepository> ExternalServicesServiceInterface for ExternalSe
 where
     ExternalServicesRepository: external_services::ExternalServicesRepository,
 {
-    async fn create_external_service(&self, slug: &str, name: &str) -> Result<ExternalService> {
-        match self.external_services_repository.create(slug, name).await {
+    async fn create_external_service<'a>(&self, slug: &str, kind: &str, name: &str, base_url: Option<&'a str>) -> Result<ExternalService> {
+        match self.external_services_repository.create(slug, kind, name, base_url).await {
             Ok(service) => Ok(service),
             Err(e) => {
                 log::error!("failed to create an external service\nError: {e:?}");
@@ -71,8 +71,8 @@ where
         }
     }
 
-    async fn update_external_service_by_id<'a>(&self, id: ExternalServiceId, name: Option<&'a str>) -> Result<ExternalService> {
-        match self.external_services_repository.update_by_id(id, name).await {
+    async fn update_external_service_by_id<'a>(&self, id: ExternalServiceId, slug: Option<&'a str>, name: Option<&'a str>, base_url: Option<Option<&'a str>>) -> Result<ExternalService> {
+        match self.external_services_repository.update_by_id(id, slug, name, base_url).await {
             Ok(service) => Ok(service),
             Err(e) => {
                 log::error!("failed to update the external service\nError: {e:?}");

--- a/api/crates/domain/tests/media.rs
+++ b/api/crates/domain/tests/media.rs
@@ -65,7 +65,9 @@ async fn create_medium_succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                             slug: "twitter".to_string(),
+                            kind: "twitter".to_string(),
                             name: "Twitter".to_string(),
+                            base_url: Some("https://twitter.com".to_string()),
                         },
                         external_metadata: ExternalMetadata::Twitter { id: 727620202049900544 },
                         created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -76,7 +78,9 @@ async fn create_medium_succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                             slug: "pixiv".to_string(),
+                            kind: "pixiv".to_string(),
                             name: "pixiv".to_string(),
+                            base_url: Some("https://www.pixiv.net".to_string()),
                         },
                         external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
                         created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
@@ -165,7 +169,9 @@ async fn create_medium_succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "twitter".to_string(),
+                    kind: "twitter".to_string(),
                     name: "Twitter".to_string(),
+                    base_url: Some("https://twitter.com".to_string()),
                 },
                 external_metadata: ExternalMetadata::Twitter { id: 727620202049900544 },
                 created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -176,7 +182,9 @@ async fn create_medium_succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
+                    kind: "pixiv".to_string(),
                     name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
                 },
                 external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
                 created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
@@ -567,7 +575,9 @@ async fn create_source_succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "twitter".to_string(),
+                    kind: "twitter".to_string(),
                     name: "Twitter".to_string(),
+                    base_url: Some("https://twitter.com".to_string()),
                 },
                 external_metadata: ExternalMetadata::Twitter { id: 727620202049900544 },
                 created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -586,7 +596,9 @@ async fn create_source_succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
             slug: "twitter".to_string(),
+            kind: "twitter".to_string(),
             name: "Twitter".to_string(),
+            base_url: Some("https://twitter.com".to_string()),
         },
         external_metadata: ExternalMetadata::Twitter { id: 727620202049900544 },
         created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -1355,7 +1367,9 @@ async fn get_source_by_external_metadata_succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
+                    kind: "pixiv".to_string(),
                     name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
                 },
                 external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
                 created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
@@ -1374,7 +1388,9 @@ async fn get_source_by_external_metadata_succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             slug: "pixiv".to_string(),
+            kind: "pixiv".to_string(),
             name: "pixiv".to_string(),
+            base_url: Some("https://www.pixiv.net".to_string()),
         },
         external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
         created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
@@ -2165,7 +2181,9 @@ async fn update_source_by_id_succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
+                    kind: "pixiv".to_string(),
                     name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
                 },
                 external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
                 created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -2185,7 +2203,9 @@ async fn update_source_by_id_succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             slug: "pixiv".to_string(),
+            kind: "pixiv".to_string(),
             name: "pixiv".to_string(),
+            base_url: Some("https://www.pixiv.net".to_string()),
         },
         external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
         created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),

--- a/api/crates/graphql/src/error.rs
+++ b/api/crates/graphql/src/error.rs
@@ -103,7 +103,7 @@ pub(crate) enum ErrorKind {
     SourceMetadataInvalid,
 
     #[error("the source metadata does not match with external service")]
-    SourceMetadataNotMatch { slug: String },
+    SourceMetadataNotMatch { kind: String },
 
     #[error("the source was not found")]
     SourceNotFound { id: SourceId },
@@ -194,7 +194,7 @@ impl From<domain::error::ErrorKind> for ErrorKind {
             ReplicaOriginalUrlDuplicate { original_url } => ErrorKind::ReplicaOriginalUrlDuplicate { original_url },
             SourceMetadataDuplicate { id } => ErrorKind::SourceMetadataDuplicate { id },
             SourceMetadataInvalid => ErrorKind::SourceMetadataInvalid,
-            SourceMetadataNotMatch { slug } => ErrorKind::SourceMetadataNotMatch { slug },
+            SourceMetadataNotMatch { kind } => ErrorKind::SourceMetadataNotMatch { kind },
             SourceNotFound { id } => ErrorKind::SourceNotFound { id },
             TagAttachingRoot | TagDeletingRoot | TagDetachingRoot | TagUpdatingRoot => ErrorKind::TagNotFound { id: TagId::default() },
             TagAttachingToDescendant { id } => ErrorKind::TagAttachingToDescendant { id },

--- a/api/crates/graphql/src/external_services.rs
+++ b/api/crates/graphql/src/external_services.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 pub(crate) struct ExternalService {
     id: Uuid,
     slug: String,
+    kind: String,
     name: String,
+    base_url: Option<String>,
 }
 
 impl From<external_services::ExternalService> for ExternalService {
@@ -14,7 +16,9 @@ impl From<external_services::ExternalService> for ExternalService {
         Self {
             id: *external_service.id,
             slug: external_service.slug,
+            kind: external_service.kind,
             name: external_service.name,
+            base_url: external_service.base_url,
         }
     }
 }

--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -77,17 +77,23 @@ where
     MediaService: MediaServiceInterface,
     TagsService: TagsServiceInterface,
 {
-    async fn create_external_service(&self, ctx: &Context<'_>, slug: String, name: String) -> Result<ExternalService> {
+    async fn create_external_service(&self, ctx: &Context<'_>, slug: String, kind: String, name: String, base_url: Option<String>) -> Result<ExternalService> {
         let external_services_service = ctx.data_unchecked::<ExternalServicesService>();
 
-        let service = external_services_service.create_external_service(&slug, &name).await?;
+        let service = external_services_service.create_external_service(&slug, &kind, &name, base_url.as_deref()).await?;
         Ok(service.into())
     }
 
-    async fn update_external_service(&self, ctx: &Context<'_>, id: Uuid, name: Option<String>) -> Result<ExternalService> {
+    async fn update_external_service(&self, ctx: &Context<'_>, id: Uuid, slug: Option<String>, name: Option<String>, base_url: Option<String>) -> Result<ExternalService> {
         let external_services_service = ctx.data_unchecked::<ExternalServicesService>();
 
-        let service = external_services_service.update_external_service_by_id(id.into(), name.as_deref()).await?;
+        let base_url = match &base_url {
+            Some(base_url) if base_url.is_empty() => Some(None),
+            Some(base_url) => Some(Some(base_url.as_str())),
+            None => None,
+        };
+
+        let service = external_services_service.update_external_service_by_id(id.into(), slug.as_deref(), name.as_deref(), base_url).await?;
         Ok(service.into())
     }
 

--- a/api/crates/graphql/tests/all_external_services.rs
+++ b/api/crates/graphql/tests/all_external_services.rs
@@ -24,17 +24,23 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
+                    kind: "pixiv".to_string(),
                     name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
                 },
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                     slug: "skeb".to_string(),
+                    kind: "skeb".to_string(),
                     name: "Skeb".to_string(),
+                    base_url: Some("https://skeb.jp".to_string()),
                 },
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "twitter".to_string(),
+                    kind: "twitter".to_string(),
                     name: "Twitter".to_string(),
+                    base_url: Some("https://twitter.com".to_string()),
                 },
             ]))
         });
@@ -54,7 +60,9 @@ async fn succeeds() {
             allExternalServices {
                 id
                 slug
+                kind
                 name
+                baseUrl
             }
         }
     "#};
@@ -65,17 +73,23 @@ async fn succeeds() {
             {
                 "id": "11111111-1111-1111-1111-111111111111",
                 "slug": "pixiv",
+                "kind": "pixiv",
                 "name": "pixiv",
+                "baseUrl": "https://www.pixiv.net",
             },
             {
                 "id": "22222222-2222-2222-2222-222222222222",
                 "slug": "skeb",
+                "kind": "skeb",
                 "name": "Skeb",
+                "baseUrl": "https://skeb.jp",
             },
             {
                 "id": "33333333-3333-3333-3333-333333333333",
                 "slug": "twitter",
+                "kind": "twitter",
                 "name": "Twitter",
+                "baseUrl": "https://twitter.com",
             },
         ],
     }));

--- a/api/crates/graphql/tests/all_media-with.rs
+++ b/api/crates/graphql/tests/all_media-with.rs
@@ -962,7 +962,9 @@ async fn sources_asc_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                                 slug: "twitter".to_string(),
+                                kind: "twitter".to_string(),
                                 name: "Twitter".to_string(),
+                                base_url: Some("https://twitter.com".to_string()),
                             },
                             external_metadata: ExternalMetadata::Twitter { id: 727620202049900544 },
                             created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -973,7 +975,9 @@ async fn sources_asc_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                                 slug: "pixiv".to_string(),
+                                kind: "pixiv".to_string(),
                                 name: "pixiv".to_string(),
+                                base_url: Some("https://www.pixiv.net".to_string()),
                             },
                             external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
                             created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
@@ -993,7 +997,9 @@ async fn sources_asc_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                                 slug: "pixiv".to_string(),
+                                kind: "pixiv".to_string(),
                                 name: "pixiv".to_string(),
+                                base_url: Some("https://www.pixiv.net".to_string()),
                             },
                             external_metadata: ExternalMetadata::Pixiv { id: 1234 },
                             created_at: Utc.with_ymd_and_hms(2016, 5, 5, 7, 6, 0).unwrap(),
@@ -1048,7 +1054,9 @@ async fn sources_asc_succeeds() {
                             externalService {
                                 id
                                 slug
+                                kind
                                 name
+                                baseUrl
                             }
                             externalMetadata
                             createdAt
@@ -1079,7 +1087,9 @@ async fn sources_asc_succeeds() {
                                 "externalService": {
                                     "id": "33333333-3333-3333-3333-333333333333",
                                     "slug": "twitter",
+                                    "kind": "twitter",
                                     "name": "Twitter",
+                                    "baseUrl": "https://twitter.com",
                                 },
                                 "externalMetadata": {
                                     "twitter": {
@@ -1094,7 +1104,9 @@ async fn sources_asc_succeeds() {
                                 "externalService": {
                                     "id": "11111111-1111-1111-1111-111111111111",
                                     "slug": "pixiv",
+                                    "kind": "pixiv",
                                     "name": "pixiv",
+                                    "baseUrl": "https://www.pixiv.net",
                                 },
                                 "externalMetadata": {
                                     "pixiv": {
@@ -1118,7 +1130,9 @@ async fn sources_asc_succeeds() {
                                 "externalService": {
                                     "id": "11111111-1111-1111-1111-111111111111",
                                     "slug": "pixiv",
+                                    "kind": "pixiv",
                                     "name": "pixiv",
+                                    "baseUrl": "https://www.pixiv.net",
                                 },
                                 "externalMetadata": {
                                     "pixiv": {

--- a/api/crates/graphql/tests/external_services.rs
+++ b/api/crates/graphql/tests/external_services.rs
@@ -31,12 +31,16 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
+                    kind: "pixiv".to_string(),
                     name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
                 },
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "twitter".to_string(),
+                    kind: "twitter".to_string(),
                     name: "Twitter".to_string(),
+                    base_url: Some("https://twitter.com".to_string()),
                 },
             ]))
         });

--- a/api/crates/graphql/tests/media-with.rs
+++ b/api/crates/graphql/tests/media-with.rs
@@ -689,7 +689,9 @@ async fn sources_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                                 slug: "twitter".to_string(),
+                                kind: "twitter".to_string(),
                                 name: "Twitter".to_string(),
+                                base_url: Some("https://twitter.com".to_string()),
                             },
                             external_metadata: ExternalMetadata::Twitter { id: 727620202049900544 },
                             created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -700,7 +702,9 @@ async fn sources_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                                 slug: "pixiv".to_string(),
+                                kind: "pixiv".to_string(),
                                 name: "pixiv".to_string(),
+                                base_url: Some("https://www.pixiv.net".to_string()),
                             },
                             external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
                             created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
@@ -741,7 +745,9 @@ async fn sources_succeeds() {
                     externalService {
                         id
                         slug
+                        kind
                         name
+                        baseUrl
                     }
                     externalMetadata
                     createdAt
@@ -764,7 +770,9 @@ async fn sources_succeeds() {
                         "externalService": {
                             "id": "33333333-3333-3333-3333-333333333333",
                             "slug": "twitter",
+                            "kind": "twitter",
                             "name": "Twitter",
+                            "baseUrl": "https://twitter.com",
                         },
                         "externalMetadata": {
                             "twitter": {
@@ -779,7 +787,9 @@ async fn sources_succeeds() {
                         "externalService": {
                             "id": "11111111-1111-1111-1111-111111111111",
                             "slug": "pixiv",
+                            "kind": "pixiv",
                             "name": "pixiv",
+                            "baseUrl": "https://www.pixiv.net",
                         },
                         "externalMetadata": {
                             "pixiv": {

--- a/api/crates/graphql/tests/source.rs
+++ b/api/crates/graphql/tests/source.rs
@@ -37,7 +37,9 @@ async fn succeeds() {
                 external_service: external_services::ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "twitter".to_string(),
+                    kind: "twitter".to_string(),
                     name: "Twitter".to_string(),
+                    base_url: Some("https://twitter.com".to_string()),
                 },
                 external_metadata: external_services::ExternalMetadata::Twitter { id: 727620202049900544 },
                 created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
@@ -68,7 +70,9 @@ async fn succeeds() {
                 externalService {
                     id
                     slug
+                    kind
                     name
+                    baseUrl
                 }
                 externalMetadata
                 createdAt
@@ -84,7 +88,9 @@ async fn succeeds() {
             "externalService": {
                 "id": "33333333-3333-3333-3333-333333333333",
                 "slug": "twitter",
+                "kind": "twitter",
                 "name": "Twitter",
+                "baseUrl": "https://twitter.com",
             },
             "externalMetadata": {
                 "twitter": {
@@ -136,7 +142,9 @@ async fn not_found() {
                 externalService {
                     id
                     slug
+                    kind
                     name
+                    baseUrl
                 }
                 externalMetadata
                 createdAt

--- a/api/crates/postgres/src/media.rs
+++ b/api/crates/postgres/src/media.rs
@@ -62,7 +62,9 @@ struct PostgresMediumSourceExternalServiceRow {
     source_updated_at: DateTime<Utc>,
     external_service_id: PostgresExternalServiceId,
     external_service_slug: String,
+    external_service_kind: String,
     external_service_name: String,
+    external_service_base_url: Option<String>,
 }
 
 #[derive(Debug, FromRow)]
@@ -138,7 +140,9 @@ impl From<PostgresMediumSourceExternalServiceRow> for (MediumId, Source) {
                 external_service: ExternalService {
                     id: row.external_service_id.into(),
                     slug: row.external_service_slug,
+                    kind: row.external_service_kind,
                     name: row.external_service_name,
+                    base_url: row.external_service_base_url,
                 },
                 external_metadata,
                 created_at: row.source_created_at,
@@ -297,7 +301,9 @@ where
         .expr_as(Expr::col((PostgresSource::Table, PostgresSource::UpdatedAt)), PostgresSourceExternalService::SourceUpdatedAt)
         .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Id)), PostgresSourceExternalService::ExternalServiceId)
         .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Slug)), PostgresSourceExternalService::ExternalServiceSlug)
+        .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Kind)), PostgresSourceExternalService::ExternalServiceKind)
         .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Name)), PostgresSourceExternalService::ExternalServiceName)
+        .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::BaseUrl)), PostgresSourceExternalService::ExternalServiceBaseUrl)
         .from(PostgresMediumSource::Table)
         .join(
             JoinType::InnerJoin,

--- a/api/crates/postgres/src/migrations.rs
+++ b/api/crates/postgres/src/migrations.rs
@@ -3,6 +3,7 @@ use sqlx_migrator::{migrator::{self, Info}, vec_box};
 
 mod v1;
 mod v2;
+mod v3;
 
 pub struct Migrator(migrator::Migrator<Postgres, State>);
 
@@ -12,6 +13,7 @@ impl Migrator {
         migrator.add_migrations(vec_box![
             v1::V1Migration,
             v2::V2Migration,
+            v3::V3Migration,
         ]);
 
         Self(migrator)

--- a/api/crates/postgres/src/migrations/v3.rs
+++ b/api/crates/postgres/src/migrations/v3.rs
@@ -1,0 +1,100 @@
+use async_trait::async_trait;
+use sea_query::{ColumnDef, Expr, Iden, PostgresQueryBuilder, Query, Table};
+use sqlx::{PgConnection, Postgres};
+use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
+
+use crate::{external_services::PostgresExternalService, migrations::State};
+
+pub(super) struct V3Migration;
+
+impl Migration<Postgres, State> for V3Migration {
+    fn app(&self) -> &str {
+        "hoarder"
+    }
+
+    fn name(&self) -> &str {
+        "external_services_add_kind_base_url"
+    }
+
+    fn parents(&self) -> Vec<Box<dyn Migration<Postgres, State>>> {
+        vec_box![]
+    }
+
+    fn operations(&self) -> Vec<Box<dyn Operation<Postgres, State>>> {
+        vec_box![ExternalServiceKindOperation]
+    }
+}
+
+struct ExternalServiceKindOperation;
+
+#[derive(Iden)]
+enum PostgresExternalServiceTemporary {
+    NameOld,
+}
+
+#[async_trait]
+impl Operation<Postgres, State> for ExternalServiceKindOperation {
+    async fn up(&self, connection: &mut PgConnection, _state: &State) -> Result<(), Error> {
+        let sql = Table::alter()
+            .table(PostgresExternalService::Table)
+            .rename_column(PostgresExternalService::Name, PostgresExternalServiceTemporary::NameOld)
+            .to_string(PostgresQueryBuilder);
+
+        sqlx::query(&sql).execute(&mut *connection).await?;
+
+        let sql = Table::alter()
+            .table(PostgresExternalService::Table)
+            .add_column(ColumnDef::new(PostgresExternalService::Kind).text())
+            .add_column(ColumnDef::new(PostgresExternalService::Name).text())
+            .add_column(ColumnDef::new(PostgresExternalService::BaseUrl).text())
+            .to_string(PostgresQueryBuilder);
+
+        sqlx::query(&sql).execute(&mut *connection).await?;
+
+        let sql = Query::update()
+            .table(PostgresExternalService::Table)
+            .value(PostgresExternalService::Kind, Expr::col(PostgresExternalService::Slug))
+            .value(PostgresExternalService::Name, Expr::col(PostgresExternalServiceTemporary::NameOld))
+            .to_string(PostgresQueryBuilder);
+
+        sqlx::query(&sql).execute(&mut *connection).await?;
+
+        let sql = Query::update()
+            .table(PostgresExternalService::Table)
+            .value(
+                PostgresExternalService::BaseUrl,
+                Expr::case(Expr::col(PostgresExternalService::Kind).eq("fantia"), "https://fantia.jp")
+                    .case(Expr::col(PostgresExternalService::Kind).eq("nijie"), "https://nijie.info")
+                    .case(Expr::col(PostgresExternalService::Kind).eq("pixiv"), "https://www.pixiv.net")
+                    .case(Expr::col(PostgresExternalService::Kind).eq("seiga"), "https://seiga.nicovideo.jp")
+                    .case(Expr::col(PostgresExternalService::Kind).eq("skeb"), "https://skeb.jp")
+                    .case(Expr::col(PostgresExternalService::Kind).eq("twitter"), "https://twitter.com"),
+            )
+            .to_string(PostgresQueryBuilder);
+
+        sqlx::query(&sql).execute(&mut *connection).await?;
+
+        let sql = Table::alter()
+            .table(PostgresExternalService::Table)
+            .drop_column(PostgresExternalServiceTemporary::NameOld)
+            .modify_column(ColumnDef::new(PostgresExternalService::Kind).not_null())
+            .modify_column(ColumnDef::new(PostgresExternalService::Name).not_null())
+            .to_string(PostgresQueryBuilder);
+
+        sqlx::query(&sql).execute(&mut *connection).await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, connection: &mut PgConnection, _state: &State) -> Result<(), Error> {
+        let sql = Table::alter()
+            .table(PostgresExternalService::Table)
+            .drop_column(PostgresExternalService::Kind)
+            .drop_column(PostgresExternalService::BaseUrl)
+            .to_string(PostgresQueryBuilder);
+
+        sqlx::query(&sql).execute(&mut *connection).await?;
+
+        Ok(())
+    }
+}

--- a/api/crates/postgres/src/sources.rs
+++ b/api/crates/postgres/src/sources.rs
@@ -46,7 +46,9 @@ struct PostgresSourceExternalServiceRow {
     source_updated_at: DateTime<Utc>,
     external_service_id: PostgresExternalServiceId,
     external_service_slug: String,
+    external_service_kind: String,
     external_service_name: String,
+    external_service_base_url: Option<String>,
 }
 
 #[derive(Debug)]
@@ -86,7 +88,9 @@ pub(crate) enum PostgresSourceExternalService {
     SourceUpdatedAt,
     ExternalServiceId,
     ExternalServiceSlug,
+    ExternalServiceKind,
     ExternalServiceName,
+    ExternalServiceBaseUrl,
 }
 
 sea_query_uuid_value!(PostgresSourceId, SourceId);
@@ -152,7 +156,9 @@ impl From<PostgresSourceExternalServiceRow> for Source {
             external_service: ExternalService {
                 id: row.external_service_id.into(),
                 slug: row.external_service_slug,
+                kind: row.external_service_kind,
                 name: row.external_service_name,
+                base_url: row.external_service_base_url,
             },
             external_metadata,
             created_at: row.source_created_at,
@@ -169,7 +175,9 @@ impl SourcesRepository for PostgresSourcesRepository {
             .columns([
                 PostgresExternalService::Id,
                 PostgresExternalService::Slug,
+                PostgresExternalService::Kind,
                 PostgresExternalService::Name,
+                PostgresExternalService::BaseUrl,
             ])
             .from(PostgresExternalService::Table)
             .and_where(Expr::col(PostgresExternalService::Id).eq(PostgresExternalServiceId::from(external_service_id)))
@@ -234,7 +242,9 @@ impl SourcesRepository for PostgresSourcesRepository {
             .expr_as(Expr::col((PostgresSource::Table, PostgresSource::UpdatedAt)), PostgresSourceExternalService::SourceUpdatedAt)
             .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Id)), PostgresSourceExternalService::ExternalServiceId)
             .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Slug)), PostgresSourceExternalService::ExternalServiceSlug)
+            .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Kind)), PostgresSourceExternalService::ExternalServiceKind)
             .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::Name)), PostgresSourceExternalService::ExternalServiceName)
+            .expr_as(Expr::col((PostgresExternalService::Table, PostgresExternalService::BaseUrl)), PostgresSourceExternalService::ExternalServiceBaseUrl)
             .from(PostgresSource::Table)
             .join(
                 JoinType::InnerJoin,
@@ -315,7 +325,9 @@ impl SourcesRepository for PostgresSourcesRepository {
             .columns([
                 PostgresExternalService::Id,
                 PostgresExternalService::Slug,
+                PostgresExternalService::Kind,
                 PostgresExternalService::Name,
+                PostgresExternalService::BaseUrl,
             ])
             .from(PostgresExternalService::Table)
             .and_where(Expr::col(PostgresExternalService::Id).eq(row.external_service_id.clone()))

--- a/api/crates/postgres/tests/external_services-fetch_all.rs
+++ b/api/crates/postgres/tests/external_services-fetch_all.rs
@@ -21,22 +21,30 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
+            kind: "pixiv".to_string(),
             name: "pixiv".to_string(),
+            base_url: Some("https://www.pixiv.net".to_string()),
         },
         ExternalService {
             id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
             slug: "skeb".to_string(),
+            kind: "skeb".to_string(),
             name: "Skeb".to_string(),
+            base_url: Some("https://skeb.jp".to_string()),
         },
         ExternalService {
             id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
             slug: "twitter".to_string(),
+            kind: "twitter".to_string(),
             name: "Twitter".to_string(),
+            base_url: Some("https://twitter.com".to_string()),
         },
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
+            kind: "custom".to_string(),
             name: "Custom".to_string(),
+            base_url: None,
         },
     ]);
 }

--- a/api/crates/postgres/tests/external_services-fetch_by_ids.rs
+++ b/api/crates/postgres/tests/external_services-fetch_by_ids.rs
@@ -24,12 +24,16 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
+            kind: "pixiv".to_string(),
             name: "pixiv".to_string(),
+            base_url: Some("https://www.pixiv.net".to_string()),
         },
         ExternalService {
             id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
             slug: "twitter".to_string(),
+            kind: "twitter".to_string(),
             name: "Twitter".to_string(),
+            base_url: Some("https://twitter.com".to_string()),
         },
     ]);
 }

--- a/api/crates/postgres/tests/fixtures/00_external_services.sql
+++ b/api/crates/postgres/tests/fixtures/00_external_services.sql
@@ -1,7 +1,7 @@
 INSERT INTO "external_services"
-    ("id", "slug", "name")
+    ("id", "slug", "kind", "name", "base_url")
 VALUES
-    ('4e0c68c7-e5ec-4d60-b9eb-733f47290cd3', 'pixiv', 'pixiv'),
-    ('2018afa2-aed9-46de-af9e-02e5fab64ed7', 'skeb', 'Skeb'),
-    ('99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab', 'twitter', 'Twitter'),
-    ('6c07eb4d-93a1-4efd-afce-e13f8f2c0e14', 'whatever', 'Custom');
+    ('4e0c68c7-e5ec-4d60-b9eb-733f47290cd3', 'pixiv', 'pixiv', 'pixiv', 'https://www.pixiv.net'),
+    ('2018afa2-aed9-46de-af9e-02e5fab64ed7', 'skeb', 'skeb', 'Skeb', 'https://skeb.jp'),
+    ('99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab', 'twitter', 'twitter', 'Twitter', 'https://twitter.com'),
+    ('6c07eb4d-93a1-4efd-afce-e13f8f2c0e14', 'whatever', 'custom', 'Custom', NULL);

--- a/api/crates/postgres/tests/media-create.rs
+++ b/api/crates/postgres/tests/media-create.rs
@@ -98,7 +98,9 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "twitter".to_string(),
+                kind: "twitter".to_string(),
                 name: "Twitter".to_string(),
+                base_url: Some("https://twitter.com".to_string()),
             },
             external_metadata: ExternalMetadata::Twitter { id: 111111111111 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
@@ -109,7 +111,9 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                 slug: "pixiv".to_string(),
+                kind: "pixiv".to_string(),
                 name: "pixiv".to_string(),
+                base_url: Some("https://www.pixiv.net".to_string()),
             },
             external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -383,7 +387,9 @@ async fn with_sources_tags_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "twitter".to_string(),
+                kind: "twitter".to_string(),
                 name: "Twitter".to_string(),
+                base_url: Some("https://twitter.com".to_string()),
             },
             external_metadata: ExternalMetadata::Twitter { id: 111111111111 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
@@ -394,7 +400,9 @@ async fn with_sources_tags_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                 slug: "pixiv".to_string(),
+                kind: "pixiv".to_string(),
                 name: "pixiv".to_string(),
+                base_url: Some("https://www.pixiv.net".to_string()),
             },
             external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),

--- a/api/crates/postgres/tests/media-fetch_all-with-sources.rs
+++ b/api/crates/postgres/tests/media-fetch_all-with-sources.rs
@@ -41,7 +41,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -52,7 +54,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -72,7 +76,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 3333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -83,7 +89,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 3333, creator_id: "creator_01".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap(),
@@ -103,7 +111,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -150,7 +160,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 4444, creator_id: "creator_01".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 10).unwrap(),
@@ -161,7 +173,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 5555555 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 9).unwrap(),
@@ -181,7 +195,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 2222, creator_id: "creator_02".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 12).unwrap(),
@@ -192,7 +208,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 6666666 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 9).unwrap(),
@@ -231,7 +249,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 111111111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
@@ -242,7 +262,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -262,7 +284,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 4444444 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -273,7 +297,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -293,7 +319,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -332,7 +360,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 9999999 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 8).unwrap(),
@@ -352,7 +382,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -372,7 +404,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 4444444 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -383,7 +417,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -422,7 +458,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -433,7 +471,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -453,7 +493,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 3333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -464,7 +506,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 3333, creator_id: "creator_01".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap(),
@@ -503,7 +547,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -523,7 +569,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 4444444 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -534,7 +582,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -554,7 +604,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 111111111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
@@ -565,7 +617,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),

--- a/api/crates/postgres/tests/media-fetch_by_ids-with-sources.rs
+++ b/api/crates/postgres/tests/media-fetch_by_ids-with-sources.rs
@@ -41,7 +41,9 @@ async fn succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -61,7 +63,9 @@ async fn succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 4444444 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -72,7 +76,9 @@ async fn succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),

--- a/api/crates/postgres/tests/media-fetch_by_source_ids-with-sources.rs
+++ b/api/crates/postgres/tests/media-fetch_by_source_ids-with-sources.rs
@@ -46,7 +46,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -57,7 +59,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -77,7 +81,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -97,7 +103,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 4444444 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -108,7 +116,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -152,7 +162,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -172,7 +184,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 4444444 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -183,7 +197,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -203,7 +219,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -247,7 +265,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 4444444 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -258,7 +278,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -278,7 +300,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -322,7 +346,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -333,7 +359,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -377,7 +405,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -388,7 +418,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -408,7 +440,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -452,7 +486,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),

--- a/api/crates/postgres/tests/media-fetch_by_tag_ids-with-sources.rs
+++ b/api/crates/postgres/tests/media-fetch_by_tag_ids-with-sources.rs
@@ -49,7 +49,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -60,7 +62,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -80,7 +84,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 3333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -91,7 +97,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 3333, creator_id: "creator_01".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap(),
@@ -111,7 +119,9 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -156,7 +166,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 111111111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
@@ -167,7 +179,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -187,7 +201,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -207,7 +223,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 3333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -218,7 +236,9 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 3333, creator_id: "creator_01".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap(),
@@ -263,7 +283,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 3333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -274,7 +296,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 3333, creator_id: "creator_01".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap(),
@@ -294,7 +318,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 1111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -314,7 +340,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 111111111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
@@ -325,7 +353,9 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
@@ -370,7 +400,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -381,7 +413,9 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -426,7 +460,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
@@ -437,7 +473,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 222222222222 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
@@ -457,7 +495,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 3333333 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
@@ -468,7 +508,9 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
                         name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
                     },
                     external_metadata: ExternalMetadata::Skeb { id: 3333, creator_id: "creator_01".to_string() },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap(),
@@ -513,7 +555,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "twitter".to_string(),
+                        kind: "twitter".to_string(),
                         name: "Twitter".to_string(),
+                        base_url: Some("https://twitter.com".to_string()),
                     },
                     external_metadata: ExternalMetadata::Twitter { id: 111111111111 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
@@ -524,7 +568,9 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
                         name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
                     },
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),

--- a/api/crates/postgres/tests/media-update_by_id.rs
+++ b/api/crates/postgres/tests/media-update_by_id.rs
@@ -465,7 +465,9 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "twitter".to_string(),
+                kind: "twitter".to_string(),
                 name: "Twitter".to_string(),
+                base_url: Some("https://twitter.com".to_string()),
             },
             external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -476,7 +478,9 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                 slug: "skeb".to_string(),
+                kind: "skeb".to_string(),
                 name: "Skeb".to_string(),
+                base_url: Some("https://skeb.jp".to_string()),
             },
             external_metadata: ExternalMetadata::Skeb { id: 1111, creator_id: "creator_02".to_string() },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 13).unwrap(),
@@ -1016,7 +1020,9 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "twitter".to_string(),
+                kind: "twitter".to_string(),
                 name: "Twitter".to_string(),
+                base_url: Some("https://twitter.com".to_string()),
             },
             external_metadata: ExternalMetadata::Twitter { id: 333333333333 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
@@ -1027,7 +1033,9 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                 slug: "skeb".to_string(),
+                kind: "skeb".to_string(),
                 name: "Skeb".to_string(),
+                base_url: Some("https://skeb.jp".to_string()),
             },
             external_metadata: ExternalMetadata::Skeb { id: 1111, creator_id: "creator_02".to_string() },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 13).unwrap(),

--- a/api/crates/postgres/tests/sources-create.rs
+++ b/api/crates/postgres/tests/sources-create.rs
@@ -27,7 +27,9 @@ async fn succeeds_with_default(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
+            kind: "pixiv".to_string(),
             name: "pixiv".to_string(),
+            base_url: Some("https://www.pixiv.net".to_string()),
         },
     );
     assert_eq!(actual.external_metadata, ExternalMetadata::Pixiv { id: 123456789 });
@@ -63,7 +65,9 @@ async fn succeeds_with_custom_object(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
+            kind: "custom".to_string(),
             name: "Custom".to_string(),
+            base_url: None,
         },
     );
     assert_eq!(actual.external_metadata, ExternalMetadata::Custom(r#"{"id":123456789}"#.to_string()));
@@ -98,7 +102,9 @@ async fn succeeds_with_custom_string(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
+            kind: "custom".to_string(),
             name: "Custom".to_string(),
+            base_url: None,
         },
     );
     assert_eq!(actual.external_metadata, ExternalMetadata::Custom(r#""123456789abcdefg""#.to_string()));
@@ -131,7 +137,9 @@ async fn succeeds_with_custom_number(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
+            kind: "custom".to_string(),
             name: "Custom".to_string(),
+            base_url: None,
         },
     );
     assert_eq!(actual.external_metadata, ExternalMetadata::Custom("123456789".to_string()));

--- a/api/crates/postgres/tests/sources-fetch_by_external_metadata.rs
+++ b/api/crates/postgres/tests/sources-fetch_by_external_metadata.rs
@@ -29,7 +29,9 @@ async fn succeeds(ctx: &DatabaseContext) {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
+            kind: "pixiv".to_string(),
             name: "pixiv".to_string(),
+            base_url: Some("https://www.pixiv.net".to_string()),
         },
         external_metadata: ExternalMetadata::Pixiv { id: 8888888 },
         created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 8).unwrap(),

--- a/api/crates/postgres/tests/sources-update_by_id.rs
+++ b/api/crates/postgres/tests/sources-update_by_id.rs
@@ -34,7 +34,9 @@ async fn with_external_metadata_succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
+            kind: "pixiv".to_string(),
             name: "pixiv".to_string(),
+            base_url: Some("https://www.pixiv.net".to_string()),
         },
     );
     assert_eq!(actual.external_metadata, ExternalMetadata::Pixiv { id: 123456789 });
@@ -74,7 +76,9 @@ async fn with_external_service_and_external_metadata_succeeds(ctx: &DatabaseCont
         ExternalService {
             id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
             slug: "skeb".to_string(),
+            kind: "skeb".to_string(),
             name: "Skeb".to_string(),
+            base_url: Some("https://skeb.jp".to_string()),
         },
     );
     assert_eq!(


### PR DESCRIPTION
This PR adds `kind` and `base_url` as new fields for external services to allow external services with different `base_url`s such as Mastodon and Misskey can be handled using the same `kind` (in the upcoming future).