### PR TITLE
Add support for Bluesky, Mastodon, Misskey, Pleroma, and Threads

### DIFF
--- a/api/crates/domain/src/entity/external_services.rs
+++ b/api/crates/domain/src/entity/external_services.rs
@@ -16,12 +16,17 @@ pub struct ExternalService {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ExternalMetadata {
+    Bluesky { id: String, creator_id: String },
     Fantia { id: u64 },
+    Mastodon { id: u64, creator_id: Option<String> },
+    Misskey { id: String },
     Nijie { id: u64 },
     Pixiv { id: u64 },
     PixivFanbox { id: u64, creator_id: String },
+    Pleroma { id: String },
     Seiga { id: u64 },
     Skeb { id: u64, creator_id: String },
+    Threads { id: String, creator_id: Option<String> },
     Twitter { id: u64, creator_id: Option<String> },
     Website { url: String },
     Custom(String),

--- a/api/crates/domain/src/entity/sources.rs
+++ b/api/crates/domain/src/entity/sources.rs
@@ -27,12 +27,17 @@ pub enum SourceError {
 impl Source {
     pub fn validate(&self) -> Result<()> {
         match (self.external_service.kind.as_str(), &self.external_metadata) {
+            ("bluesky", &ExternalMetadata::Bluesky { .. }) => Ok(()),
             ("fantia", &ExternalMetadata::Fantia { .. }) => Ok(()),
+            ("mastodon", &ExternalMetadata::Mastodon { .. }) => Ok(()),
+            ("misskey", &ExternalMetadata::Misskey { .. }) => Ok(()),
             ("nijie", &ExternalMetadata::Nijie { .. }) => Ok(()),
             ("pixiv", &ExternalMetadata::Pixiv { .. }) => Ok(()),
             ("pixiv_fanbox", &ExternalMetadata::PixivFanbox { .. }) => Ok(()),
+            ("pleroma", &ExternalMetadata::Pleroma { .. }) => Ok(()),
             ("seiga", &ExternalMetadata::Seiga { .. }) => Ok(()),
             ("skeb", &ExternalMetadata::Skeb { .. }) => Ok(()),
+            ("threads", &ExternalMetadata::Threads { .. }) => Ok(()),
             ("twitter", &ExternalMetadata::Twitter { .. }) => Ok(()),
             ("website", &ExternalMetadata::Website { .. }) => Ok(()),
             (_, &ExternalMetadata::Custom(_)) => Ok(()),
@@ -52,6 +57,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn validate_succeeds_with_bluesky() {
+        let source = Source {
+            id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+                slug: "bsky_social".to_string(),
+                kind: "bluesky".to_string(),
+                name: "bsky.social".to_string(),
+                base_url: Some("https://bsky.social".to_string()),
+            },
+            external_metadata: ExternalMetadata::Bluesky { id: "abcdefghi".to_string(), creator_id: "creator_01".to_string() },
+            created_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 6).unwrap(),
+        };
+
+        let actual = source.validate();
+        assert!(actual.is_ok());
+    }
+
+    #[test]
     fn validate_succeeds_with_fantia() {
         let source = Source {
             id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
@@ -65,6 +90,46 @@ mod tests {
             external_metadata: ExternalMetadata::Fantia { id: 1305295 },
             created_at: Utc.with_ymd_and_hms(2022, 6, 4, 19, 34, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2022, 6, 4, 19, 34, 0).unwrap(),
+        };
+
+        let actual = source.validate();
+        assert!(actual.is_ok());
+    }
+
+    #[test]
+    fn validate_succeeds_with_mastodon() {
+        let source = Source {
+            id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+                slug: "mastodon_social".to_string(),
+                kind: "mastodon".to_string(),
+                name: "mastodon.social".to_string(),
+                base_url: Some("https://mastodon.social".to_string()),
+            },
+            external_metadata: ExternalMetadata::Mastodon { id: 123456789, creator_id: Some("creator_01".to_string()) },
+            created_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 6).unwrap(),
+        };
+
+        let actual = source.validate();
+        assert!(actual.is_ok());
+    }
+
+    #[test]
+    fn validate_succeeds_with_misskey() {
+        let source = Source {
+            id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+                slug: "misskey_io".to_string(),
+                kind: "misskey".to_string(),
+                name: "Misskey.io".to_string(),
+                base_url: Some("https://misskey.io".to_string()),
+            },
+            external_metadata: ExternalMetadata::Misskey { id: "abcdefghi".to_string() },
+            created_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 6).unwrap(),
         };
 
         let actual = source.validate();
@@ -132,6 +197,26 @@ mod tests {
     }
 
     #[test]
+    fn validate_succeeds_with_pleroma() {
+        let source = Source {
+            id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+                slug: "udongein".to_string(),
+                kind: "pleroma".to_string(),
+                name: "Udongein".to_string(),
+                base_url: Some("https://udongein.xyz".to_string()),
+            },
+            external_metadata: ExternalMetadata::Pleroma { id: "abcdefghi".to_string() },
+            created_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 6).unwrap(),
+        };
+
+        let actual = source.validate();
+        assert!(actual.is_ok());
+    }
+
+    #[test]
     fn validate_succeeds_with_seiga() {
         let source = Source {
             id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
@@ -165,6 +250,26 @@ mod tests {
             external_metadata: ExternalMetadata::Skeb { id: 18, creator_id: "pieleaf_x2".to_string() },
             created_at: Utc.with_ymd_and_hms(2021, 7, 22, 20, 40, 0).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2021, 7, 22, 20, 40, 1).unwrap(),
+        };
+
+        let actual = source.validate();
+        assert!(actual.is_ok());
+    }
+
+    #[test]
+    fn validate_succeeds_with_threads() {
+        let source = Source {
+            id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+                slug: "threads".to_string(),
+                kind: "threads".to_string(),
+                name: "Threads".to_string(),
+                base_url: Some("https://www.threads.net".to_string()),
+            },
+            external_metadata: ExternalMetadata::Threads { id: "abcdefghi".to_string(), creator_id: Some("creator_01".to_string()) },
+            created_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 6).unwrap(),
         };
 
         let actual = source.validate();

--- a/api/crates/postgres/src/sources.rs
+++ b/api/crates/postgres/src/sources.rs
@@ -59,12 +59,17 @@ struct PostgresSourceRowAndExternalServiceRow(PostgresSourceRow, PostgresExterna
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub(crate) enum PostgresExternalServiceMetadata {
+    Bluesky { id: String, creator_id: String },
     Fantia { id: u64 },
+    Mastodon { id: u64, creator_id: Option<String> },
+    Misskey { id: String },
     Nijie { id: u64 },
     Pixiv { id: u64 },
     PixivFanbox { id: u64, creator_id: String },
+    Pleroma { id: String },
     Seiga { id: u64 },
     Skeb { id: u64, creator_id: String },
+    Threads { id: String, creator_id: Option<String> },
     Twitter { id: u64, creator_id: Option<String> },
     Website { url: String },
     #[serde(untagged)]
@@ -101,12 +106,17 @@ impl From<PostgresExternalServiceMetadata> for ExternalMetadata {
     fn from(metadata: PostgresExternalServiceMetadata) -> Self {
         use PostgresExternalServiceMetadata::*;
         match metadata {
+            Bluesky { id, creator_id } => Self::Bluesky { id, creator_id },
             Fantia { id } => Self::Fantia { id },
+            Mastodon { id, creator_id } => Self::Mastodon { id, creator_id },
+            Misskey { id } => Self::Misskey { id },
             Nijie { id } => Self::Nijie { id },
             Pixiv { id } => Self::Pixiv { id },
             PixivFanbox { id, creator_id } => Self::PixivFanbox { id, creator_id },
+            Pleroma { id } => Self::Pleroma { id },
             Seiga { id } => Self::Seiga { id },
             Skeb { id, creator_id } => Self::Skeb { id, creator_id },
+            Threads { id, creator_id } => Self::Threads { id, creator_id },
             Twitter { id, creator_id } => Self::Twitter { id, creator_id },
             Website { url } => Self::Website { url },
             Custom(v) => Self::Custom(v.to_string()),
@@ -120,12 +130,17 @@ impl TryFrom<ExternalMetadata> for PostgresExternalServiceMetadata {
     fn try_from(metadata: ExternalMetadata) -> serde_json::Result<Self> {
         use ExternalMetadata::*;
         match metadata {
+            Bluesky { id, creator_id } => Ok(Self::Bluesky { id, creator_id }),
             Fantia { id } => Ok(Self::Fantia { id }),
+            Mastodon { id, creator_id } => Ok(Self::Mastodon { id, creator_id }),
+            Misskey { id } => Ok(Self::Misskey { id }),
             Nijie { id } => Ok(Self::Nijie { id }),
             Pixiv { id } => Ok(Self::Pixiv { id }),
             PixivFanbox { id, creator_id } => Ok(Self::PixivFanbox { id, creator_id }),
+            Pleroma { id } => Ok(Self::Pleroma { id }),
             Seiga { id } => Ok(Self::Seiga { id }),
             Skeb { id, creator_id } => Ok(Self::Skeb { id, creator_id }),
+            Threads { id, creator_id } => Ok(Self::Threads { id, creator_id }),
             Twitter { id, creator_id } => Ok(Self::Twitter { id, creator_id }),
             Website { url } => Ok(Self::Website { url }),
             Custom(v) => Ok(Self::Custom(serde_json::from_str(&v)?)),


### PR DESCRIPTION
This PR adds support for distributed SNS (Bluesky, Mastodon, Misskey and Pleroma) and Threads as a source.