### PR TITLE
Require creator_id for Mastodon sources

### DIFF
--- a/api/crates/domain/src/entity/external_services.rs
+++ b/api/crates/domain/src/entity/external_services.rs
@@ -18,7 +18,7 @@ pub struct ExternalService {
 pub enum ExternalMetadata {
     Bluesky { id: String, creator_id: String },
     Fantia { id: u64 },
-    Mastodon { id: u64, creator_id: Option<String> },
+    Mastodon { id: u64, creator_id: String },
     Misskey { id: String },
     Nijie { id: u64 },
     Pixiv { id: u64 },

--- a/api/crates/domain/src/entity/sources.rs
+++ b/api/crates/domain/src/entity/sources.rs
@@ -107,7 +107,7 @@ mod tests {
                 name: "mastodon.social".to_string(),
                 base_url: Some("https://mastodon.social".to_string()),
             },
-            external_metadata: ExternalMetadata::Mastodon { id: 123456789, creator_id: Some("creator_01".to_string()) },
+            external_metadata: ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() },
             created_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 6).unwrap(),
         };

--- a/api/crates/graphql/src/sources.rs
+++ b/api/crates/graphql/src/sources.rs
@@ -24,7 +24,7 @@ pub(crate) struct Source {
 pub(crate) enum ExternalMetadata {
     Bluesky(ExternalMetadataIdCreatorId),
     Fantia(ExternalMetadataId),
-    Mastodon(ExternalMetadataIdOptionalCreatorId),
+    Mastodon(ExternalMetadataIdCreatorId),
     Misskey(ExternalMetadataId),
     Nijie(ExternalMetadataId),
     Pixiv(ExternalMetadataId),
@@ -75,7 +75,7 @@ impl TryFrom<external_services::ExternalMetadata> for ExternalMetadata {
         match value {
             Bluesky { id, creator_id } => Ok(Self::Bluesky(ExternalMetadataIdCreatorId { id, creator_id })),
             Fantia { id } => Ok(Self::Fantia(ExternalMetadataId { id: id.to_string() })),
-            Mastodon { id, creator_id } => Ok(Self::Mastodon(ExternalMetadataIdOptionalCreatorId { id: id.to_string(), creator_id })),
+            Mastodon { id, creator_id } => Ok(Self::Mastodon(ExternalMetadataIdCreatorId { id: id.to_string(), creator_id })),
             Misskey { id } => Ok(Self::Misskey(ExternalMetadataId { id })),
             Nijie { id } => Ok(Self::Nijie(ExternalMetadataId { id: id.to_string() })),
             Pixiv { id } => Ok(Self::Pixiv(ExternalMetadataId { id: id.to_string() })),
@@ -99,7 +99,7 @@ impl TryFrom<ExternalMetadata> for external_services::ExternalMetadata {
         match value {
             Bluesky(ExternalMetadataIdCreatorId { id, creator_id }) => Ok(Self::Bluesky { id, creator_id }),
             Fantia(ExternalMetadataId { id }) => Ok(Self::Fantia { id: id.parse().map_err(|_| ErrorKind::SourceMetadataInvalid)? }),
-            Mastodon(ExternalMetadataIdOptionalCreatorId { id, creator_id }) => Ok(Self::Mastodon { id: id.parse().map_err(|_| ErrorKind::SourceMetadataInvalid)?, creator_id }),
+            Mastodon(ExternalMetadataIdCreatorId { id, creator_id }) => Ok(Self::Mastodon { id: id.parse().map_err(|_| ErrorKind::SourceMetadataInvalid)?, creator_id }),
             Misskey(ExternalMetadataId { id }) => Ok(Self::Misskey { id }),
             Nijie(ExternalMetadataId { id }) => Ok(Self::Nijie { id: id.parse().map_err(|_| ErrorKind::SourceMetadataInvalid)? }),
             Pixiv(ExternalMetadataId { id }) => Ok(Self::Pixiv { id: id.parse().map_err(|_| ErrorKind::SourceMetadataInvalid)? }),
@@ -166,15 +166,15 @@ mod tests {
 
     #[test]
     fn convert_mastodon() {
-        let metadata = ExternalMetadata::Mastodon(ExternalMetadataIdOptionalCreatorId { id: "123456789".to_string(), creator_id: Some("creator_01".to_string()) });
+        let metadata = ExternalMetadata::Mastodon(ExternalMetadataIdCreatorId { id: "123456789".to_string(), creator_id: "creator_01".to_string() });
         let actual = external_services::ExternalMetadata::try_from(metadata).unwrap();
 
-        assert_eq!(actual, external_services::ExternalMetadata::Mastodon { id: 123456789, creator_id: Some("creator_01".to_string()) });
+        assert_eq!(actual, external_services::ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() });
 
-        let metadata = external_services::ExternalMetadata::Mastodon { id: 123456789, creator_id: Some("creator_01".to_string()) };
+        let metadata = external_services::ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() };
         let actual = ExternalMetadata::try_from(metadata).unwrap();
 
-        assert_eq!(actual, ExternalMetadata::Mastodon(ExternalMetadataIdOptionalCreatorId { id: "123456789".to_string(), creator_id: Some("creator_01".to_string()) }));
+        assert_eq!(actual, ExternalMetadata::Mastodon(ExternalMetadataIdCreatorId { id: "123456789".to_string(), creator_id: "creator_01".to_string() }));
     }
 
     #[test]

--- a/api/crates/postgres/src/sources.rs
+++ b/api/crates/postgres/src/sources.rs
@@ -61,7 +61,7 @@ struct PostgresSourceRowAndExternalServiceRow(PostgresSourceRow, PostgresExterna
 pub(crate) enum PostgresExternalServiceMetadata {
     Bluesky { id: String, creator_id: String },
     Fantia { id: u64 },
-    Mastodon { id: u64, creator_id: Option<String> },
+    Mastodon { id: u64, creator_id: String },
     Misskey { id: String },
     Nijie { id: u64 },
     Pixiv { id: u64 },


### PR DESCRIPTION
With this PR, a Mastodon source now requires `creator_id` as its input.