### PR TITLE
Handle the EXIF orientation tag of images properly

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -2019,6 +2019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2269,12 @@ dependencies = [
  "spin 0.9.8",
  "version_check",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "nanorand"
@@ -3859,6 +3874,7 @@ dependencies = [
  "derive_more",
  "domain",
  "image",
+ "kamadak-exif",
  "tokio",
 ]
 

--- a/api/crates/thumbnails/Cargo.toml
+++ b/api/crates/thumbnails/Cargo.toml
@@ -22,6 +22,9 @@ version = "0.99.17"
 [dependencies.image]
 version = "0.25.1"
 
+[dependencies.kamadak-exif]
+version = "0.5.5"
+
 [dependencies.tokio]
 version = "1.37.0"
 features = ["rt-multi-thread"]

--- a/api/crates/thumbnails/src/processor.rs
+++ b/api/crates/thumbnails/src/processor.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, Cursor, Seek};
+use std::io::{BufRead, Cursor, Seek, SeekFrom};
 
 use derive_more::Constructor;
 use domain::{
@@ -6,7 +6,8 @@ use domain::{
     error::{Error, ErrorKind, Result},
     processor::media::MediumImageProcessor,
 };
-use image::io::Reader;
+use exif::{In, Tag};
+use image::{imageops::{flip_horizontal, flip_vertical, rotate180, rotate270, rotate90}, io::Reader, DynamicImage};
 use tokio::task;
 
 pub use image::{imageops::FilterType, ImageFormat};
@@ -18,8 +19,24 @@ pub struct InMemoryImageProcessor {
     thumbnail_filter: FilterType,
 }
 
+fn rotate(image: DynamicImage, orientation: u32) -> Result<DynamicImage> {
+    let image = match orientation {
+        1 => image,
+        2 => DynamicImage::from(flip_horizontal(&image)),
+        3 => DynamicImage::from(rotate180(&image)),
+        4 => DynamicImage::from(flip_vertical(&image)),
+        5 => DynamicImage::from(flip_horizontal(&rotate90(&image))),
+        6 => DynamicImage::from(rotate90(&image)),
+        7 => DynamicImage::from(flip_horizontal(&rotate270(&image))),
+        8 => DynamicImage::from(rotate270(&image)),
+        _ => return Err(Error::from(ErrorKind::MediumReplicaDecodeFailed)),
+    };
+
+    Ok(image)
+}
+
 impl MediumImageProcessor for InMemoryImageProcessor {
-    async fn generate_thumbnail<R>(&self, read: R) -> Result<(OriginalImage, ThumbnailImage)>
+    async fn generate_thumbnail<R>(&self, mut read: R) -> Result<(OriginalImage, ThumbnailImage)>
     where
         R: BufRead + Seek + Send + 'static,
     {
@@ -28,13 +45,23 @@ impl MediumImageProcessor for InMemoryImageProcessor {
         let thumbnail_format = self.thumbnail_format;
 
         task::spawn_blocking(move || {
+            let orientation = exif::Reader::new()
+                .read_from_container(&mut read)
+                .ok()
+                .and_then(|e| e.get_field(Tag::Orientation, In::PRIMARY).and_then(|f| f.value.get_uint(0)))
+                .unwrap_or(1);
+
+            read.seek(SeekFrom::Start(0))
+                .map_err(|e| Error::new(ErrorKind::MediumReplicaReadFailed, e))?;
+
             let reader = Reader::new(read)
                 .with_guessed_format()
                 .map_err(|e| Error::new(ErrorKind::MediumReplicaReadFailed, e))?;
 
             let format = reader.format().ok_or(ErrorKind::MediumReplicaUnsupported)?;
             let image = reader.decode()
-                .map_err(|e| Error::new(ErrorKind::MediumReplicaDecodeFailed, e))?;
+                .map_err(|e| Error::new(ErrorKind::MediumReplicaDecodeFailed, e))
+                .and_then(|i| rotate(i, orientation))?;
 
             let mut body = Vec::new();
             let thumbnail = image.resize(thumbnail_size.width, thumbnail_size.height, thumbnail_filter);


### PR DESCRIPTION
This PR fixes handling of the EXIF orientation tag of images that previously ended up in incorrect thumbnail and size.

See: [JPEG Orientation – magnushoff.com](https://magnushoff.com/articles/jpeg-orientation/)