### PR TITLE
Allow www.fanbox.cc as a post URL of pixivFANBOX

### DIFF
--- a/ui/src/components/AutocompleteSourceBody/index.tsx
+++ b/ui/src/components/AutocompleteSourceBody/index.tsx
@@ -70,6 +70,7 @@ const builders: Builder[] = [
   {
     kind: 'pixiv_fanbox',
     patterns: [
+      /^https?:\/\/www\.fanbox\.cc\/@(?<creatorId>[^.]+)\/posts\/(?<id>\d+)(?:[?#].*)?$/,
       /^https?:\/\/(?<creatorId>[^.]+)\.fanbox\.cc\/posts\/(?<id>\d+)(?:[?#].*)?$/,
     ],
     build: ({ id, creatorId }) => ({ id, creatorId }),


### PR DESCRIPTION
The post URL of pixivFANBOX used to be `https://www.fanbox.cc/@{creatorId}/posts/{id}`. With this PR, Hoarder UI now allows to accept this format as well.