### PR TITLE
Allow to delete objects when deleting a medium or replica

### DIFF
--- a/api/crates/domain/tests/media.rs
+++ b/api/crates/domain/tests/media.rs
@@ -2264,7 +2264,106 @@ async fn delete_medium_by_id_succeeds() {
     let mock_medium_image_processor = MockMediumImageProcessor::new();
 
     let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
-    let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777"))).await.unwrap();
+    let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), false).await.unwrap();
+
+    assert_eq!(actual, DeleteResult::Deleted(1));
+}
+
+#[tokio::test]
+async fn delete_medium_by_id_with_delete_objects_succeeds() {
+    let mut mock_media_repository = MockMediaRepository::new();
+    mock_media_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids, tag_depth, replicas, sources| {
+            (ids, tag_depth, replicas, sources) == (
+                &[MediumId::from(uuid!("77777777-7777-7777-7777-777777777777"))],
+                &None,
+                &true,
+                &false,
+            )
+        })
+        .returning(|_, _, _, _| {
+            Box::pin(ok(vec![
+                Medium {
+                    id: MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
+                    sources: Vec::new(),
+                    tags: BTreeMap::new(),
+                    replicas: vec![
+                        Replica {
+                            id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+                            display_order: 1,
+                            thumbnail: Some(Thumbnail {
+                                id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+                                size: Size::new(240, 240),
+                                created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+                                updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+                            }),
+                            original_url: "file:///77777777-7777-7777-7777-777777777777.png".to_string(),
+                            mime_type: "image/png".to_string(),
+                            size: Size::new(720, 720),
+                            created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+                            updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+                        },
+                        Replica {
+                            id: ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")),
+                            display_order: 2,
+                            thumbnail: Some(Thumbnail {
+                                id: ThumbnailId::from(uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")),
+                                size: Size::new(240, 240),
+                                created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 4, 0).unwrap(),
+                                updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 5, 0).unwrap(),
+                            }),
+                            original_url: "file:///99999999-9999-9999-9999-999999999999.png".to_string(),
+                            mime_type: "image/png".to_string(),
+                            size: Size::new(720, 720),
+                            created_at: Utc.with_ymd_and_hms(2022, 6, 3, 0, 2, 0).unwrap(),
+                            updated_at: Utc.with_ymd_and_hms(2022, 6, 3, 0, 3, 0).unwrap(),
+                        },
+                    ],
+                    created_at: Utc.with_ymd_and_hms(2022, 6, 1, 12, 34, 56).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 6, 1, 0, 5, 0).unwrap(),
+                },
+            ]))
+        });
+
+    mock_media_repository
+        .expect_delete_by_id()
+        .times(1)
+        .withf(|id| id == &MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    let mut mock_objects_repository = MockObjectsRepository::new();
+    mock_objects_repository
+        .expect_delete()
+        .times(1)
+        .withf(|url| url == &EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string()))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    mock_objects_repository
+        .expect_delete()
+        .times(1)
+        .withf(|url| url == &EntryUrl::from("file:///99999999-9999-9999-9999-999999999999.png".to_string()))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    let mut mock_replicas_repository = MockReplicasRepository::new();
+    mock_replicas_repository
+        .expect_delete_by_id()
+        .times(1)
+        .withf(|id| id == &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    mock_replicas_repository
+        .expect_delete_by_id()
+        .times(1)
+        .withf(|id| id == &ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    let mock_sources_repository = MockSourcesRepository::new();
+    let mock_medium_image_processor = MockMediumImageProcessor::new();
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), true).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 }
@@ -2284,7 +2383,7 @@ async fn delete_medium_by_id_fails() {
     let mock_medium_image_processor = MockMediumImageProcessor::new();
 
     let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
-    let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777"))).await.unwrap_err();
+    let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), false).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
 }
@@ -2304,7 +2403,57 @@ async fn delete_replica_by_id_succeeds() {
         .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
 
     let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
-    let actual = service.delete_replica_by_id(ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666"))).await.unwrap();
+    let actual = service.delete_replica_by_id(ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")), false).await.unwrap();
+
+    assert_eq!(actual, DeleteResult::Deleted(1));
+}
+
+#[tokio::test]
+async fn delete_replica_by_id_with_delete_object_succeeds() {
+    let mock_media_repository = MockMediaRepository::new();
+    let mock_sources_repository = MockSourcesRepository::new();
+    let mock_medium_image_processor = MockMediumImageProcessor::new();
+
+    let mut mock_objects_repository = MockObjectsRepository::new();
+    mock_objects_repository
+        .expect_delete()
+        .times(1)
+        .withf(|url| url == &EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string()))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    let mut mock_replicas_repository = MockReplicasRepository::new();
+    mock_replicas_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids: &[_; 1]| ids == &[ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666"))])
+        .returning(|_| {
+            Box::pin(ok(vec![
+                Replica {
+                    id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+                    display_order: 1,
+                    thumbnail: Some(Thumbnail {
+                        id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+                        size: Size::new(240, 240),
+                        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+                        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+                    }),
+                    original_url: "file:///77777777-7777-7777-7777-777777777777.png".to_string(),
+                    mime_type: "image/png".to_string(),
+                    size: Size::new(720, 720),
+                    created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+                },
+            ]))
+        });
+
+    mock_replicas_repository
+        .expect_delete_by_id()
+        .times(1)
+        .withf(|id| id == &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let actual = service.delete_replica_by_id(ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")), true).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 }
@@ -2324,7 +2473,7 @@ async fn delete_replica_by_id_fails() {
         .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
     let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
-    let actual = service.delete_replica_by_id(ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666"))).await.unwrap_err();
+    let actual = service.delete_replica_by_id(ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")), false).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
 }

--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -209,17 +209,21 @@ where
         Ok(source)
     }
 
-    async fn delete_medium(&self, ctx: &Context<'_>, id: Uuid) -> Result<DeleteResult> {
+    async fn delete_medium(&self, ctx: &Context<'_>, id: Uuid, delete_objects: Option<bool>) -> Result<DeleteResult> {
         let media_service = ctx.data_unchecked::<MediaService>();
 
-        let result = media_service.delete_medium_by_id(id.into()).await?;
+        let delete_objects = delete_objects.unwrap_or_default();
+
+        let result = media_service.delete_medium_by_id(id.into(), delete_objects).await?;
         Ok(result.into())
     }
 
-    async fn delete_replica(&self, ctx: &Context<'_>, id: Uuid) -> Result<DeleteResult> {
+    async fn delete_replica(&self, ctx: &Context<'_>, id: Uuid, delete_object: Option<bool>) -> Result<DeleteResult> {
         let media_service = ctx.data_unchecked::<MediaService>();
 
-        let result = media_service.delete_replica_by_id(id.into()).await?;
+        let delete_object = delete_object.unwrap_or_default();
+
+        let result = media_service.delete_replica_by_id(id.into(), delete_object).await?;
         Ok(result.into())
     }
 

--- a/schema/hoarder.gql
+++ b/schema/hoarder.gql
@@ -112,8 +112,8 @@ type Mutation {
 	updateMedium(id: UUID!, addSourceIds: [UUID!], removeSourceIds: [UUID!], addTagIds: [TagTagTypeInput!], removeTagIds: [TagTagTypeInput!], replicaOrders: [UUID!], createdAt: DateTime): Medium!
 	updateReplica(id: UUID!, originalUrl: String, upload: ReplicaInput): Replica!
 	updateSource(id: UUID!, externalServiceId: UUID, externalMetadata: ExternalMetadataInput): Source!
-	deleteMedium(id: UUID!): DeleteResult!
-	deleteReplica(id: UUID!): DeleteResult!
+	deleteMedium(id: UUID!, deleteObjects: Boolean): DeleteResult!
+	deleteReplica(id: UUID!, deleteObject: Boolean): DeleteResult!
 	deleteSource(id: UUID!): DeleteResult!
 	createTag(name: String!, kana: String!, aliases: [String!], parentId: UUID): Tag!
 	createTagType(slug: String!, name: String!): TagType!


### PR DESCRIPTION
This PR allows to delete associated objects from storage when deleting a medium or replica via API.