### PR TITLE
Fix filename handling in media upload dialog

### DIFF
--- a/ui/src/components/MediumItemFileUploadDialogBodyItem/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBodyItem/index.tsx
@@ -25,6 +25,7 @@ const MediumItemFileUploadDialogBodyItem: FunctionComponent<MediumItemFileUpload
   status,
   progress,
   error,
+  nameValidationError,
   onChangeName,
 }) => {
   const { graphQLError } = useError()
@@ -48,8 +49,11 @@ const MediumItemFileUploadDialogBodyItem: FunctionComponent<MediumItemFileUpload
       </TableCell>
       <TableCell>
         <TextField
+          className={styles.filename}
           fullWidth
           value={replica.name}
+          error={Boolean(nameValidationError)}
+          helperText={nameValidationError}
           onChange={handleChangeName}
           disabled={Boolean(status) && status !== 'error' && status !== 'aborted'}
         />
@@ -125,6 +129,7 @@ export interface MediumItemFileUploadDialogBodyItemProps {
   status: ReplicaUploadStatus
   progress: ReplicaUploadProgress | null
   error: unknown | null
+  nameValidationError?: string | null
   onChangeName?: (name: string) => void
 }
 

--- a/ui/src/components/MediumItemFileUploadDialogBodyItem/styles.module.scss
+++ b/ui/src/components/MediumItemFileUploadDialogBodyItem/styles.module.scss
@@ -19,6 +19,13 @@
   max-height: 100%;
 }
 
+.filename {
+  &:global(.MuiTextField-root .MuiFormHelperText-root) {
+    position: absolute;
+    bottom: -2em;
+  }
+}
+
 .filesizeCell {
   &:global(.MuiTableCell-root) {
     width: 128px;

--- a/ui/src/components/MediumItemImageItemBar/index.tsx
+++ b/ui/src/components/MediumItemImageItemBar/index.tsx
@@ -70,7 +70,7 @@ const MediumItemImageItemBar: FunctionComponent<MediumItemImageItemBarProps> = (
               <span className={styles.all}>/−</span>
             </Typography>
           )}
-          {name ? (
+          {typeof name === 'string' ? (
             <TextField className={styles.name} variant="standard" value={name} onChange={handleChangeName} />
           ) : null}
         </Stack>


### PR DESCRIPTION
This PR fixes a bug in media upload dialog where it used to accept empty or duplicate filename.