### PR TITLE
Validate filename when saving a media to storage

### DIFF
--- a/api/crates/storage/src/filesystem.rs
+++ b/api/crates/storage/src/filesystem.rs
@@ -48,6 +48,10 @@ impl ObjectsRepository for FilesystemObjectsRepository {
         let url = FilesystemEntryUrl::try_from(url)?;
         let fullpath = self.fullpath(url.as_path());
 
+        if Path::new(&self.root_dir) == fullpath {
+            return Err(Error::from(ErrorKind::ObjectUrlInvalid { url: url.into_url().into_inner() }))?;
+        }
+
         if let Some(parent) = fullpath.parent() {
             DirBuilder::new()
                 .mode(0o0755)


### PR DESCRIPTION
This PR fixes an issue where a medium upload with an empty filename meant it tried to overwrite the root directory (though it finally failed with an OBJECT\_ALREADY\_EXISTS error).