### PR TITLE
Disable horizontal scroll to prevent page from overflowing

### DIFF
--- a/ui/src/app/global.scss
+++ b/ui/src/app/global.scss
@@ -3,6 +3,8 @@
 }
 
 body {
+  overflow-x: hidden;
+
   > .MuiDialog-root {
     & + .MuiDialog-root .MuiBackdrop-root {
       transition: none !important;

--- a/ui/src/components/MediumItemMetadataSourceItem/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceItem/index.tsx
@@ -2,7 +2,7 @@
 
 import type { FunctionComponent } from 'react'
 import clsx from 'clsx'
-import Link from 'next/link'
+import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
 import LaunchIcon from '@mui/icons-material/Launch'
 import LinkIcon from '@mui/icons-material/Link'
@@ -165,13 +165,13 @@ const MediumItemMetadataSourceItem: FunctionComponent<MediumItemMetadataSourceIt
         <span className={clsx(styles.item, styles.noLink)}>
           <span className={styles.text}>{displayURL(url)}</span>
           {!noLaunch ? (
-            <Link className={styles.link} href={url} target="_blank">
+            <Link href={url} target="_blank" rel="noopener noreferrer" underline="none">
               <LaunchIcon className={styles.launch} fontSize="inherit" />
             </Link>
           ) : null}
         </span>
       ) : url ? (
-        <Link className={clsx(styles.item, styles.link)} href={url} target="_blank">
+        <Link className={styles.item} href={url} target="_blank" rel="noopener noreferrer" underline="none">
           <span className={styles.text}>{displayURL(url)}</span>
           {!noLaunch ? (
             <LaunchIcon className={styles.launch} fontSize="inherit" />

--- a/ui/src/components/MediumItemMetadataSourceItem/styles.module.scss
+++ b/ui/src/components/MediumItemMetadataSourceItem/styles.module.scss
@@ -22,7 +22,3 @@
     color: #666;
   }
 }
-
-.link {
-  text-decoration: none;
-}

--- a/ui/src/components/MediumItemMetadataSourceItemNew/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceItemNew/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { FunctionComponent } from 'react'
-import Link from 'next/link'
+import Link from '@mui/material/Link'
 import Stack from '@mui/material/Stack'
 import AddLinkIcon from '@mui/icons-material/AddLink'
 import LaunchIcon from '@mui/icons-material/Launch'
@@ -26,7 +26,7 @@ const MediumItemMetadataSourceItemNew: FunctionComponent<MediumItemMetadataSourc
           <>
             <span className={styles.text}>{displayURL(url)}</span>
             {!noLaunch ? (
-              <Link className={styles.link} href={url} target="_blank">
+              <Link href={url} target="_blank" rel="noopener noreferrer" underline="none">
                 <LaunchIcon className={styles.launch} fontSize="inherit" />
               </Link>
             ) : null}

--- a/ui/src/components/MediumItemMetadataSourceItemNew/styles.module.scss
+++ b/ui/src/components/MediumItemMetadataSourceItemNew/styles.module.scss
@@ -20,6 +20,3 @@
   }
 }
 
-.link {
-  text-decoration: none;
-}


### PR DESCRIPTION
This PR fixes a bug where `<Autocomplete />` sometimes used to cause the media edit page to overflow horizontally for an instant.