### PR TITLE
Leave input value in combo boxes as is on blur

### DIFF
--- a/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { FunctionComponent } from 'react'
+import type { FunctionComponent, SyntheticEvent } from 'react'
 import { useCallback, useState } from 'react'
 import deepEqual from 'deep-equal'
 import Stack from '@mui/material/Stack'
@@ -24,6 +24,7 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
 
   const [ focusedExternalService, setFocusedExternalService ] = useState<ExternalService | null>(null)
   const [ newExternalService, setNewExternalService ] = useState<ExternalService | null>(null)
+  const [ newExternalServiceInput, setNewExternalServiceInput ] = useState('')
 
   const [ addingExternalServices, setAddingExternalServices ] = useState<ExternalService[]>([])
   const [ addingSources, setAddingSources ] = useState(new Map<ExternalServiceID, (Source | SourceCreate)[]>())
@@ -34,11 +35,17 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
     }
 
     setNewExternalService(null)
+    setNewExternalServiceInput('')
+
     setFocusedExternalService(type)
     setAddingExternalServices(addingExternalServices => [
       ...addingExternalServices,
       type,
     ])
+  }, [])
+
+  const handleChangeNewExternalServiceInput = useCallback((_e: SyntheticEvent, value: string) => {
+    setNewExternalServiceInput(value)
   }, [])
 
   const removeExternalService = useCallback((type: ExternalService) => {
@@ -151,13 +158,17 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
             openOnFocus
             autoHighlight
             blurOnSelect
+            clearOnBlur={false}
+            clearOnEscape
             includeInputInList
             placeholder="サービスの追加..."
             disabled={loading}
             value={newExternalService}
+            inputValue={newExternalServiceInput}
             getOptionDisabled={({ id }) => addingExternalServices.some(externalService => externalService.id === id)}
             icon={({ ...props }) => <FolderSpecialIcon {...props} />}
             onChange={handleChangeNewExternalService}
+            onInputChange={handleChangeNewExternalServiceInput}
           />
         </Stack>
       </Stack>

--- a/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { FunctionComponent } from 'react'
+import type { FunctionComponent, SyntheticEvent } from 'react'
 import { useCallback, useState } from 'react'
 import deepEqual from 'deep-equal'
 import Button from '@mui/material/Button'
@@ -31,6 +31,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
 
   const [ focusedExternalService, setFocusedExternalService ] = useState<ExternalService | null>(null)
   const [ newExternalService, setNewExternalService ] = useState<ExternalService | null>(null)
+  const [ newExternalServiceInput, setNewExternalServiceInput ] = useState('')
 
   const [ addingExternalServices, setAddingExternalServices ] = useState<ExternalService[]>([])
   const [ removingExternalServices, setRemovingExternalServices ] = useState<ExternalService[]>([])
@@ -58,11 +59,17 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
     }
 
     setNewExternalService(null)
+    setNewExternalServiceInput('')
+
     setFocusedExternalService(type)
     setAddingExternalServices(addingExternalServices => [
       ...addingExternalServices,
       type,
     ])
+  }, [])
+
+  const handleChangeNewExternalServiceInput = useCallback((_e: SyntheticEvent, value: string) => {
+    setNewExternalServiceInput(value)
   }, [])
 
   const removeExternalService = useCallback((type: ExternalService) => {
@@ -273,14 +280,18 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
             openOnFocus
             autoHighlight
             blurOnSelect
+            clearOnBlur={false}
+            clearOnEscape
             includeInputInList
             focus={focus && groups.length === 0}
             placeholder="サービスの追加..."
             disabled={loading}
             value={newExternalService}
+            inputValue={newExternalServiceInput}
             getOptionDisabled={({ id }) => groups.some(group => group.externalService.id === id) || addingExternalServices.some(externalService => externalService.id === id)}
             icon={({ ...props }) => <FolderSpecialIcon {...props} />}
             onChange={handleChangeNewExternalService}
+            onInputChange={handleChangeNewExternalServiceInput}
           />
         </Stack>
       </Stack>

--- a/ui/src/components/MediumItemMetadataSourceGroupEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceGroupEdit/index.tsx
@@ -148,6 +148,8 @@ const MetadataSourceGroupEdit: FunctionComponent<MetadataSourceGroupEditProps> =
             variant="standard"
             fullWidth
             blurOnSelect
+            clearOnBlur={false}
+            clearOnEscape
             includeInputInList
             focus={focus}
             forcePopupIcon={false}

--- a/ui/src/components/MediumItemMetadataTagCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagCreate/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { FunctionComponent } from 'react'
+import type { FunctionComponent, SyntheticEvent } from 'react'
 import { useCallback, useState } from 'react'
 import Stack from '@mui/material/Stack'
 import LabelIcon from '@mui/icons-material/Label'
@@ -17,6 +17,7 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
 }) => {
   const [ focusedTagType, setFocusedTagType ] = useState<TagType | null>(null)
   const [ newTagType, setNewTagType ] = useState<TagType | null>(null)
+  const [ newTagTypeInput, setNewTagTypeInput ] = useState('')
 
   const [ addingTagTypes, setAddingTagTypes ] = useState<TagType[]>([])
   const [ addingTags, setAddingTags ] = useState(new Map<TagTypeID, Tag[]>())
@@ -27,11 +28,17 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
     }
 
     setNewTagType(null)
+    setNewTagTypeInput('')
+
     setFocusedTagType(type)
     setAddingTagTypes(addingTagTypes => [
       ...addingTagTypes,
       type,
     ])
+  }, [])
+
+  const handleChangeNewTagTypeInput = useCallback((_e: SyntheticEvent, value: string) => {
+    setNewTagTypeInput(value)
   }, [])
 
   const removeTagType = useCallback((type: TagType) => {
@@ -119,13 +126,17 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
             openOnFocus
             autoHighlight
             blurOnSelect
+            clearOnBlur={false}
+            clearOnEscape
             includeInputInList
             placeholder="タイプの追加..."
             disabled={loading}
             value={newTagType}
+            inputValue={newTagTypeInput}
             getOptionDisabled={({ id }) => addingTagTypes.some(type => type.id === id)}
             icon={({ ...props }) => <LabelIcon {...props} />}
             onChange={handleChangeNewTagType}
+            onInputChange={handleChangeNewTagTypeInput}
           />
         </Stack>
       </Stack>

--- a/ui/src/components/MediumItemMetadataTagEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagEdit/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { FunctionComponent } from 'react'
+import type { FunctionComponent, SyntheticEvent } from 'react'
 import { useCallback, useState } from 'react'
 import Button from '@mui/material/Button'
 import LoadingButton from '@mui/lab/LoadingButton'
@@ -22,6 +22,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
 }) => {
   const [ focusedTagType, setFocusedTagType ] = useState<TagType | null>(null)
   const [ newTagType, setNewTagType ] = useState<TagType | null>(null)
+  const [ newTagTypeInput, setNewTagTypeInput ] = useState('')
 
   const [ addingTagTypes, setAddingTagTypes ] = useState<TagType[]>([])
   const [ removingTagTypes, setRemovingTagTypes ] = useState<TagType[]>([])
@@ -49,11 +50,17 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
     }
 
     setNewTagType(null)
+    setNewTagTypeInput('')
+
     setFocusedTagType(type)
     setAddingTagTypes(addingTagTypes => [
       ...addingTagTypes,
       type,
     ])
+  }, [])
+
+  const handleChangeNewTagTypeInput = useCallback((_e: SyntheticEvent, value: string) => {
+    setNewTagTypeInput(value)
   }, [])
 
   const removeTagType = useCallback((type: TagType) => {
@@ -227,14 +234,18 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
             openOnFocus
             autoHighlight
             blurOnSelect
+            clearOnBlur={false}
+            clearOnEscape
             includeInputInList
             focus={focus && groups.length === 0}
             placeholder="タイプの追加..."
             disabled={loading}
             value={newTagType}
+            inputValue={newTagTypeInput}
             getOptionDisabled={({ id }) => groups.some(group => group.type.id === id) || addingTagTypes.some(type => type.id === id)}
             icon={({ ...props }) => <LabelIcon {...props} />}
             onChange={handleChangeNewTagType}
+            onInputChange={handleChangeNewTagTypeInput}
           />
         </Stack>
       </Stack>

--- a/ui/src/components/MediumItemMetadataTagGroupEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagGroupEdit/index.tsx
@@ -136,6 +136,8 @@ const MediumItemMetadataTagEditGroup: FunctionComponent<MediumItemMetadataTagEdi
             fullWidth
             autoHighlight
             blurOnSelect
+            clearOnBlur={false}
+            clearOnEscape
             includeInputInList
             focus={focus}
             forcePopupIcon={false}


### PR DESCRIPTION
This PR fixes combo boxes used in media metadata edit view to leave their input values as they are on blur. Previously they were removed instead. Also, `Esc` key now clears input value.