### PR TITLE
Sort media tags in hierarchical order

### DIFF
--- a/api/crates/postgres/src/expr/array.rs
+++ b/api/crates/postgres/src/expr/array.rs
@@ -3,6 +3,13 @@ use sea_query::{Expr, SimpleExpr};
 pub(crate) struct ArrayExpr;
 
 impl ArrayExpr {
+    pub fn agg<T>(arg: T) -> SimpleExpr
+    where
+        T: Into<SimpleExpr>,
+    {
+        Expr::cust_with_expr("array_agg($1)", arg)
+    }
+
     pub fn unnest<T>(arg: T) -> SimpleExpr
     where
         T: Into<SimpleExpr>,


### PR DESCRIPTION
This PR fixes API to sort tags attached to media in their hierarchical order.

The subquery which the implementation joins to:
```sql
SELECT "tags"."id", array_agg("ancestors"."kana" ORDER BY "tag_paths"."distance" DESC) "display_order"
FROM "tags"
INNER JOIN "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
INNER JOIN "tags" "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
WHERE "tag_paths"."ancestor_id" <> '00000000-0000-0000-0000-000000000000'
GROUP BY "tags"."id"
ORDER BY "display_order";
```