### PR TITLE
Validate ID in /media/[id]

### DIFF
--- a/ui/src/components/MediumItemViewBody/index.tsx
+++ b/ui/src/components/MediumItemViewBody/index.tsx
@@ -2,6 +2,7 @@
 
 import type { FunctionComponent } from 'react'
 import { useCallback, useState } from 'react'
+import * as uuid from 'uuid'
 import { useRouter } from 'next/navigation'
 import Divider from '@mui/material/Divider'
 import Grid from '@mui/material/Unstable_Grid2'
@@ -29,6 +30,10 @@ import styles from './styles.module.scss'
 const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
   id,
 }) => {
+  if (!uuid.validate(id)) {
+    throw new Error(`medium id invalid: ${id}`)
+  }
+
   const router = useRouter()
 
   const medium = useMedium({ id })


### PR DESCRIPTION
This PR fixes `/media/[id]` to validate the ID so it does not get passed to GraphQL.
```
t [ApolloError]: Failed to parse "UUID": invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `r` at 1 (occurred while parsing "[UUID!]")
    at new t (/app/.next/server/chunks/146.js:107:15669)
    at /app/.next/server/chunks/146.js:107:137040
    at i (/app/.next/server/chunks/146.js:107:100312)
    at /app/.next/server/chunks/146.js:107:100227
    at new Promise (<anonymous>)
    at Object.then (/app/.next/server/chunks/146.js:107:100194)
    at Object.next (/app/.next/server/chunks/146.js:107:100322)
    at g (/app/.next/server/chunks/146.js:109:60138)
    at b (/app/.next/server/chunks/146.js:109:60679)
    at t.next (/app/.next/server/chunks/146.js:109:61180) {
  graphQLErrors: [
    {
      message: 'Failed to parse "UUID": invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `r` at 1 (occurred while parsing "[UUID!]")',
      locations: [Array],
      path: [Array]
    }
  ],
  protocolErrors: [],
  clientErrors: [],
  networkError: null,
  extraInfo: undefined,
  digest: '653553139'
}
```