### PR TITLE
Accept drag and drop not only from FileSystemEntry but also from File

### DIFF
--- a/ui/src/components/FileDrop/index.tsx
+++ b/ui/src/components/FileDrop/index.tsx
@@ -55,6 +55,13 @@ const FileDrop = function <Flatten extends boolean | undefined>({
       const entry = item.webkitGetAsEntry()
       if (entry) {
         promises.push(readFileSystemEntry(entry))
+        continue
+      }
+
+      const file = item.getAsFile()
+      if (file) {
+        promises.push(Promise.resolve([ file ]))
+        continue
       }
     }
 


### PR DESCRIPTION
This PR fixes `FileDrop` component to accept drag and drop not only from [`FileSystemEntry`](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemEntry) but also from [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File) so that drag from an image element in another Web browser window is also handled. Currently, in this case Chrome does not support `FileSystemEntry` but support `File` instead while Firefox does not support both interfaces in this case.