### PR TITLE
Fix images not to overflow in medium view in Chrome

### DIFF
--- a/ui/src/components/MediumItemImageItem/styles.module.scss
+++ b/ui/src/components/MediumItemImageItem/styles.module.scss
@@ -9,6 +9,7 @@
 .wrapper {
   &:global(.MuiStack-root) {
     margin: auto;
+    max-width: 100%;
     height: 100%;
   }
 }


### PR DESCRIPTION
This PR fixes an issue in Chrome where images in  landscape orientation overflow in medium view page.