### PR TITLE
Fix a bug in /media/new where metadata did not get updated when canceled

### DIFF
--- a/ui/src/components/MediumCreateView/index.tsx
+++ b/ui/src/components/MediumCreateView/index.tsx
@@ -221,17 +221,25 @@ const MediumCreateView: FunctionComponent = () => {
     }
   }, [ medium, resolveSourceIDs, tagTagTypeIDs, replicas, createMedium, handleComplete ])
 
-  const saveTags = useCallback((id: string, addTagTagTypeIDs: TagTagTypeInput[], removeTagTagTypeIDs: TagTagTypeInput[]) => updateMedium({
-    id,
-    addTagTagTypeIDs,
-    removeTagTagTypeIDs,
-  }), [ updateMedium ])
+  const saveTags = useCallback(async (id: string, addTagTagTypeIDs: TagTagTypeInput[], removeTagTagTypeIDs: TagTagTypeInput[]) => {
+    const medium = await updateMedium({
+      id,
+      addTagTagTypeIDs,
+      removeTagTagTypeIDs,
+    })
+    setMedium(medium)
+    return medium
+  }, [ updateMedium ])
 
-  const saveSources = useCallback((id: string, addSourceIDs: string[], removeSourceIDs: string[]) => updateMedium({
-    id,
-    addSourceIDs,
-    removeSourceIDs,
-  }), [ updateMedium ])
+  const saveSources = useCallback(async (id: string, addSourceIDs: string[], removeSourceIDs: string[]) => {
+    const medium = await updateMedium({
+      id,
+      addSourceIDs,
+      removeSourceIDs,
+    })
+    setMedium(medium)
+    return medium
+  }, [ updateMedium ])
 
   const handleDeleteMedium = useCallback(() => {
     router.replace('/')


### PR DESCRIPTION
When media update has been canceled in /media/new, metadata did not get updated after save. This PR fixes the issue by updating the states after saving tags and/or sources.