### PR TITLE
Allow to cancel media upload by closing dialog

### DIFF
--- a/ui/src/components/MediumItemFileUploadAbortDialog/index.tsx
+++ b/ui/src/components/MediumItemFileUploadAbortDialog/index.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import type { FunctionComponent } from 'react'
+import Dialog from '@mui/material/Dialog'
+
+import type { MediumItemFileUploadAbortDialogBodyProps } from '@/components/MediumItemFileUploadAbortDialogBody'
+import MediumItemFileUploadAbortDialogBody from '@/components/MediumItemFileUploadAbortDialogBody'
+
+const MediumItemFileUploadAbortDialog: FunctionComponent<MediumItemFileUploadAbortDialogProps> = ({
+  close,
+  ...props
+}) => (
+  <Dialog open onClose={close}>
+    <MediumItemFileUploadAbortDialogBody close={close} {...props} />
+  </Dialog>
+)
+
+export type MediumItemFileUploadAbortDialogProps = MediumItemFileUploadAbortDialogBodyProps
+
+export default MediumItemFileUploadAbortDialog

--- a/ui/src/components/MediumItemFileUploadAbortDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadAbortDialogBody/index.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import type { FunctionComponent } from 'react'
+import { useCallback } from 'react'
+import Button from '@mui/material/Button'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+
+const MediumItemFileUploadAbortDialogBody: FunctionComponent<MediumItemFileUploadAbortDialogBodyProps> = ({
+  abort,
+  close,
+}) => {
+  const handleClickAbort = useCallback(() => {
+    abort()
+  }, [ abort ])
+
+  return (
+    <>
+      <DialogContent>
+        <DialogContentText>
+          アップロードを取り消しますか？
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={close} autoFocus>キャンセル</Button>
+        <Button color="error" onClick={handleClickAbort}>取り消す</Button>
+      </DialogActions>
+    </>
+  )
+}
+
+export interface MediumItemFileUploadAbortDialogBodyProps {
+  abort: () => void
+  close: () => void
+}
+
+export default MediumItemFileUploadAbortDialogBody
+

--- a/ui/src/components/MediumItemFileUploadDialog/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialog/index.tsx
@@ -3,7 +3,7 @@
 import type { FunctionComponent } from 'react'
 import Dialog from '@mui/material/Dialog'
 
-import type { MediumItemFileUploadDialogBodyProps } from '@/components/MediumItemFileUploadDialogBody'
+import type { MediumItemFileUploadDialogBodyProps, UploadStatus } from '@/components/MediumItemFileUploadDialogBody'
 import MediumItemFileUploadDialogBody from '@/components/MediumItemFileUploadDialogBody'
 
 import styles from './styles.module.scss'
@@ -18,5 +18,6 @@ const MediumItemFileUploadDialog: FunctionComponent<MediumItemFileUploadDialogPr
 )
 
 export type MediumItemFileUploadDialogProps = MediumItemFileUploadDialogBodyProps
+export type MediumItemFileUploadStatus = UploadStatus
 
 export default MediumItemFileUploadDialog

--- a/ui/src/components/MediumItemViewBody/index.tsx
+++ b/ui/src/components/MediumItemViewBody/index.tsx
@@ -11,6 +11,8 @@ import Snackbar from '@mui/material/Snackbar'
 import Stack from '@mui/material/Stack'
 
 import type { ReplicaCreate } from '@/components/MediumItemImageEdit'
+import type { MediumItemFileUploadStatus } from '@/components/MediumItemFileUploadDialog'
+import MediumItemFileUploadAbortDialog from '@/components/MediumItemFileUploadAbortDialog'
 import MediumItemFileUploadDialog from '@/components/MediumItemFileUploadDialog'
 import MediumItemImageEdit, { isReplica } from '@/components/MediumItemImageEdit'
 import MediumItemImageList from '@/components/MediumItemImageList'
@@ -47,7 +49,12 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
   const [ replicas, setReplicas ] = useState<(Replica | ReplicaCreate)[]>(medium.replicas)
   const [ removingReplicas, setRemovingReplicas ] = useState<Replica[]>([])
   const [ deletingObjects, setDeletingObjects ] = useState<MediumDeleteObjects | null>(null)
+
   const [ uploading, setUploading ] = useState(false)
+  const [ uploadAborting, setUploadAborting ] = useState(false)
+  const [ uploadAbortController, setUploadAbortController ] = useState(new AbortController())
+  const [ uploadInProgress, setUploadInProgress ] = useState(false)
+
   const [ error, setError ] = useState<unknown>(null)
 
   const removeReplica = useCallback((replica: Replica | ReplicaCreate) => {
@@ -119,7 +126,28 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
   }, [])
 
   const closeUpload = useCallback(() => {
-    setUploading(false)
+    if (uploadInProgress && !uploadAborting) {
+      setUploadAborting(true)
+    } else {
+      setUploading(false)
+      setUploadAborting(false)
+      setUploadAbortController(uploadAbortController => {
+        uploadAbortController.abort()
+        return new AbortController()
+      })
+    }
+  }, [ uploadAborting, uploadInProgress ])
+
+  const closeUploadAbort = useCallback(() => {
+    setUploadAborting(false)
+  }, [])
+
+  const handleProgress = useCallback((status: MediumItemFileUploadStatus) => {
+    setUploadInProgress(status === 'uploading')
+
+    if (status === 'done') {
+      setUploadAbortController(new AbortController())
+    }
   }, [])
 
   const handleComplete = useCallback(async (current: Medium, replicas: (Replica | ReplicaCreate)[]) => {
@@ -138,6 +166,7 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
     }
 
     setUploading(false)
+    setUploadAborting(false)
 
     let deleteObject: boolean | null = null
     if (removingReplicas.length) {
@@ -258,11 +287,19 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
       </Grid>
       {uploading ? (
         <MediumItemFileUploadDialog
+          abortSignal={uploadAbortController.signal}
           resolveMedium={() => Promise.resolve(medium)}
           replicas={replicas}
           setReplicas={setReplicas}
           close={closeUpload}
+          onProgress={handleProgress}
           onComplete={handleComplete}
+        />
+      ) : null}
+      {uploadAborting ? (
+        <MediumItemFileUploadAbortDialog
+          close={closeUploadAbort}
+          abort={closeUpload}
         />
       ) : null}
       {deletingObjects ? (


### PR DESCRIPTION
This PR adds a confirmation dialog before closing a media upload dialog to prevent a user from unintentionally closing the upload dialog.