### PR TITLE
Fix table layout in media upload dialog

### DIFF
--- a/ui/src/components/MediumItemFileUploadDialogBodyItem/styles.module.scss
+++ b/ui/src/components/MediumItemFileUploadDialogBodyItem/styles.module.scss
@@ -1,6 +1,8 @@
 .imageCell {
   &:global(.MuiTableCell-root) {
     width: 128px;
+    padding-right: 8px;
+    padding-left: 24px;
   }
 }
 
@@ -35,6 +37,8 @@
 .progressCell {
   &:global(.MuiTableCell-root) {
     width: 384px;
+    padding-right: 24px;
+    padding-left: 16px;
   }
 }
 


### PR DESCRIPTION
This PR fixes layout in media upload dialog to have the same margin in the inner and outer of the dialog.