### PR TITLE
Use Web Worker to measure the size of media

### DIFF
--- a/ui/src/components/ImageBodyBlob/index.tsx
+++ b/ui/src/components/ImageBodyBlob/index.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ComponentPropsWithoutRef, FunctionComponent, SyntheticEvent } from 'react'
-import { use, useCallback, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useErrorBoundary } from 'react-error-boundary'
 
 const ImageBodyBlob: FunctionComponent<ImageBodyBlobProps> = ({
@@ -9,8 +9,7 @@ const ImageBodyBlob: FunctionComponent<ImageBodyBlobProps> = ({
   onError,
   ...props
 }) => {
-  const blob = use(src)
-  const url = useMemo(() => URL.createObjectURL(blob), [ blob ])
+  const url = useMemo(() => URL.createObjectURL(src), [ src ])
 
   const { showBoundary } = useErrorBoundary()
 
@@ -35,7 +34,7 @@ const ImageBodyBlob: FunctionComponent<ImageBodyBlobProps> = ({
 }
 
 export interface ImageBodyBlobProps extends Omit<ComponentPropsWithoutRef<'img'>, 'src'> {
-  src: Promise<Blob>
+  src: Blob
 }
 
 export default ImageBodyBlob

--- a/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
@@ -82,7 +82,7 @@ export interface MediumItemFileOverwriteDialogBodyProps {
     name: string
     size: number
     lastModified: Date
-    blob: Promise<Blob>
+    blob: Blob
   }
   existing: {
     name: string

--- a/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
@@ -113,7 +113,7 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
     try {
       const path = container ? `/${container}` : ''
       const url = `${path}/${replica.name}`.split('/').map(strictUriEncode).join('/')
-      file = new File([ await replica.blob ], url)
+      file = new File([ replica.blob ], url)
     } catch (e) {
       throw new Error('error reading file', { cause: e })
     }

--- a/ui/src/components/MediumItemImageEdit/index.tsx
+++ b/ui/src/components/MediumItemImageEdit/index.tsx
@@ -109,7 +109,7 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
           width,
           height,
           lastModified: new Date(file.lastModified),
-          blob: Promise.resolve(new Blob([ buffer ])),
+          blob: new Blob([ buffer ]),
         }
       } catch (e) {
         console.warn('Error reading a file\n', file, '\n', e)
@@ -343,7 +343,7 @@ export interface ReplicaCreate {
   width?: number
   height?: number
   lastModified: Date
-  blob: Promise<Blob>
+  blob: Blob
 }
 
 export interface MediumItemImageEditProps {

--- a/ui/src/components/MediumItemImageEdit/worker.ts
+++ b/ui/src/components/MediumItemImageEdit/worker.ts
@@ -1,0 +1,5 @@
+import { imageSize } from 'image-size'
+
+self.addEventListener('message', (e: MessageEvent<ArrayBuffer>) => {
+  self.postMessage(imageSize(new Uint8Array(e.data)))
+})

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -5,7 +5,8 @@
       "dom",
       "dom.iterable",
       "es2023",
-      "esnext.promise"
+      "esnext.promise",
+      "webworker"
     ],
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
This PR updates the media edit component to measure the size of newly created media using Web Workers in order to achieve optimal performance.