### PR TITLE
Fix thubmnails in /media to render in correct aspect ratio

### DIFF
--- a/ui/src/components/MediumListItem/index.tsx
+++ b/ui/src/components/MediumListItem/index.tsx
@@ -12,10 +12,11 @@ import styles from './styles.module.scss'
 
 export const MediumListItem: FunctionComponent<MediumListItemProps> = ({
   medium,
+  size,
 }) => (
   <ImageListItem className={styles.item}>
     <Link className={styles.link} href={`/media/${medium.id}`}>
-      <MediumListItemThumbnail replica={medium.replicas?.[0]} />
+      <MediumListItemThumbnail replica={medium.replicas?.[0]} size={size} />
       <MediumListItemCount className={styles.count} count={medium.replicas?.length} fontSize="small" />
     </Link>
   </ImageListItem>
@@ -23,6 +24,7 @@ export const MediumListItem: FunctionComponent<MediumListItemProps> = ({
 
 export interface MediumListItemProps {
   medium: Medium
+  size: number
 }
 
 export default MediumListItem

--- a/ui/src/components/MediumListItemThumbnail/index.tsx
+++ b/ui/src/components/MediumListItemThumbnail/index.tsx
@@ -9,16 +9,15 @@ import type { Replica } from '@/types'
 
 import styles from './styles.module.scss'
 
-const imagePixelRatio = 1.5;
-
 const MediumListItemThumbnail: FunctionComponent<MediumListItemThumbnailProps> = ({
   replica,
+  size,
 }) => replica?.thumbnail ? (
   <Image
     className={styles.image}
     src={replica.thumbnail.url}
-    width={Math.round(replica.thumbnail.width / imagePixelRatio)}
-    height={Math.round(replica.thumbnail.height / imagePixelRatio)}
+    width={replica.width >= replica.height ? size : Math.round(size / (replica.height / replica.width))}
+    height={replica.width <= replica.height ? size : Math.round(size / (replica.width / replica.height))}
     quality={100}
     loading="lazy"
     alt=""
@@ -31,6 +30,7 @@ const MediumListItemThumbnail: FunctionComponent<MediumListItemThumbnailProps> =
 
 export interface MediumListItemThumbnailProps {
   replica?: Replica
+  size: number
 }
 
 export default MediumListItemThumbnail

--- a/ui/src/components/MediumListItemThumbnail/styles.module.scss
+++ b/ui/src/components/MediumListItemThumbnail/styles.module.scss
@@ -1,6 +1,5 @@
 .image {
   border-radius: 8px;
-  max-width: 100%;
 }
 
 .noimage {

--- a/ui/src/components/MediumListViewBody/index.tsx
+++ b/ui/src/components/MediumListViewBody/index.tsx
@@ -28,7 +28,7 @@ const MediumListViewBody: FunctionComponent<MediumListViewBodyProps> = ({
     <Stack>
       <ImageList className={styles.container} gap={40}>
         {media.map(medium => (
-          <MediumListItem key={medium.id} medium={medium} />
+          <MediumListItem key={medium.id} medium={medium} size={160} />
         ))}
       </ImageList>
       <Stack className={styles.pagination} alignItems="center">


### PR DESCRIPTION
This PR fixes thumbnails in /media to render in their correct aspect ratio especially when the window width is too narrow.