### PR TITLE
Downgrade axios from 1.7.2 to 1.6.8 in /ui

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,10 @@ updates:
   open-pull-requests-limit: 99
   versioning-strategy: increase
   ignore:
+  # TODO: Update axios when `onUploadProgress` is fixed to be called on finish
+  - dependency-name: axios
+    versions:
+    - ">= 1.7.0"
   # TODO: Update eslint when eslint-config-next supports ESLint v9
   - dependency-name: eslint
     versions:

--- a/ui/package.json
+++ b/ui/package.json
@@ -35,7 +35,7 @@
     "@types/strict-uri-encode": "^2.0.2",
     "@types/uuid": "^9.0.8",
     "apollo-upload-client": "^18.0.1",
-    "axios": "^1.7.2",
+    "axios": "~1.6.8",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3765,14 +3765,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.7.2":
-  version: 1.7.2
-  resolution: "axios@npm:1.7.2"
+"axios@npm:~1.6.8":
+  version: 1.6.8
+  resolution: "axios@npm:1.6.8"
   dependencies:
     follow-redirects: "npm:^1.15.6"
     form-data: "npm:^4.0.0"
     proxy-from-env: "npm:^1.1.0"
-  checksum: 10/6ae80dda9736bb4762ce717f1a26ff997d94672d3a5799ad9941c24d4fb019c1dff45be8272f08d1975d7950bac281f3ba24aff5ecd49ef5a04d872ec428782f
+  checksum: 10/3f9a79eaf1d159544fca9576261ff867cbbff64ed30017848e4210e49f3b01e97cf416390150e6fdf6633f336cd43dc1151f890bbd09c3c01ad60bb0891eee63
   languageName: node
   linkType: hard
 
@@ -5963,7 +5963,7 @@ __metadata:
     "@types/strict-uri-encode": "npm:^2.0.2"
     "@types/uuid": "npm:^9.0.8"
     apollo-upload-client: "npm:^18.0.1"
-    axios: "npm:^1.7.2"
+    axios: "npm:~1.6.8"
     clsx: "npm:^2.1.1"
     date-fns: "npm:^3.6.0"
     date-fns-tz: "npm:^3.1.3"


### PR DESCRIPTION
This PR reverts #81 to downgrade axios from 1.7.2 to 1.6.8 and fix unstable upload progress report.