### PR TITLE
Remove unnecessary error handling in file upload dialog

### DIFF
--- a/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
@@ -109,14 +109,9 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
   }, [ close ])
 
   const processReplicaUpload = useCallback(async (medium: Medium, replica: ReplicaCreate, overwrite?: boolean): Promise<Replica> => {
-    let file: File
-    try {
-      const path = container ? `/${container}` : ''
-      const url = `${path}/${replica.name}`.split('/').map(strictUriEncode).join('/')
-      file = new File([ replica.blob ], url)
-    } catch (e) {
-      throw new Error('error reading file', { cause: e })
-    }
+    const path = container ? `/${container}` : ''
+    const url = `${path}/${replica.name}`.split('/').map(strictUriEncode).join('/')
+    const file = new File([ replica.blob ], url)
 
     try {
       const newReplica = await createReplica(


### PR DESCRIPTION
This PR removes unnecessary error handling from file uploading as `replica.blob` no longer throws since ca49e3ee6244d48b68ebec640a8c965b13e8a753.