### PR TITLE
Fix set functions of `useState()` to be idempotent

### DIFF
--- a/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
@@ -100,7 +100,7 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
         return uploads
       }
 
-      return new Map(uploads.set(replica.tempid, upload))
+      return new Map(uploads).set(replica.tempid, upload)
     })
   }, [])
 

--- a/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
@@ -109,7 +109,7 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
 
       newSources.push(source)
 
-      const newAddingSources = new Map(addingSources.set(externalService.id, newSources))
+      const newAddingSources = new Map(addingSources).set(externalService.id, newSources)
       setResolveSourceIDs(() => resolveSourceIDs(newAddingSources))
       return newAddingSources
     })
@@ -125,7 +125,7 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
         return addingSources
       }
 
-      const newAddingSources = new Map(addingSources.set(externalService.id, newSources.toSpliced(idx, 1)))
+      const newAddingSources = new Map(addingSources).set(externalService.id, newSources.toSpliced(idx, 1))
       setResolveSourceIDs(() => resolveSourceIDs(newAddingSources))
       return newAddingSources
     })

--- a/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
@@ -111,7 +111,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
       }
 
       newSources.push(source)
-      return new Map(addingSources.set(externalService.id, newSources))
+      return new Map(addingSources).set(externalService.id, newSources)
     })
 
     setRemovingSources(removingSources => {
@@ -125,7 +125,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
         return removingSources
       }
 
-      return new Map(removingSources.set(externalService.id, newSources.toSpliced(idx, 1)))
+      return new Map(removingSources).set(externalService.id, newSources.toSpliced(idx, 1))
     })
   }, [ groups ])
 
@@ -139,7 +139,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
         return addingSources
       }
 
-      return new Map(addingSources.set(externalService.id, newSources.toSpliced(idx, 1)))
+      return new Map(addingSources).set(externalService.id, newSources.toSpliced(idx, 1))
     })
 
     if (!isSource(source) || !groups.some(group => group.externalService.id === externalService.id && group.sources.some(({ id }) => id === source.id))) {
@@ -153,7 +153,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
       }
 
       newSources.push(source)
-      return new Map(removingSources.set(externalService.id, newSources))
+      return new Map(removingSources).set(externalService.id, newSources)
     })
   }, [ groups ])
 
@@ -167,7 +167,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
         return removingSources
       }
 
-      return new Map(removingSources.set(externalService.id, newSources.toSpliced(idx, 1)))
+      return new Map(removingSources).set(externalService.id, newSources.toSpliced(idx, 1))
     })
   }, [])
 

--- a/ui/src/components/MediumItemMetadataTagCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagCreate/index.tsx
@@ -67,7 +67,7 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
 
       newTags.push(tag)
 
-      const newAddingTags = new Map(addingTags.set(type.id, newTags))
+      const newAddingTags = new Map(addingTags).set(type.id, newTags)
       setTagTagTypeIDs(() => resolveTagTagTypeIDs(newAddingTags))
       return newAddingTags
     })
@@ -83,7 +83,7 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
         return addingTags
       }
 
-      const newAddingTags = new Map(addingTags.set(type.id, newTags.toSpliced(idx, 1)))
+      const newAddingTags = new Map(addingTags).set(type.id, newTags.toSpliced(idx, 1))
       setTagTagTypeIDs(() => resolveTagTagTypeIDs(newAddingTags))
       return newAddingTags
     })

--- a/ui/src/components/MediumItemMetadataTagEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagEdit/index.tsx
@@ -102,7 +102,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
       }
 
       newTags.push(tag)
-      return new Map(addingTags.set(type.id, newTags))
+      return new Map(addingTags).set(type.id, newTags)
     })
 
     setRemovingTags(removingTags => {
@@ -112,7 +112,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
         return removingTags
       }
 
-      return new Map(removingTags.set(type.id, newTags.toSpliced(idx, 1)))
+      return new Map(removingTags).set(type.id, newTags.toSpliced(idx, 1))
     })
   }, [ groups ])
 
@@ -126,7 +126,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
         return addingTags
       }
 
-      return new Map(addingTags.set(type.id, newTags.toSpliced(idx, 1)))
+      return new Map(addingTags).set(type.id, newTags.toSpliced(idx, 1))
     })
 
     if (!groups.some(group => group.type.id === type.id && group.tags.some(({ id }) => id === tag.id))) {
@@ -140,7 +140,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
       }
 
       newTags.push(tag)
-      return new Map(removingTags.set(type.id, newTags))
+      return new Map(removingTags).set(type.id, newTags)
     })
   }, [ groups ])
 
@@ -154,7 +154,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
         return removingTags
       }
 
-      return new Map(removingTags.set(type.id, newTags.toSpliced(idx, 1)))
+      return new Map(removingTags).set(type.id, newTags.toSpliced(idx, 1))
     })
   }, [])
 


### PR DESCRIPTION
This PR fixes callbacks passed to a set function returned by `useState()` hooks to be idempotent. Previously, some callbacks mutated the given state inside of it, causing an unexpected behavior when they were called twice.