### PR TITLE
Prevent users from leaving the page while editing

### DIFF
--- a/ui/src/components/MediumCreateView/index.tsx
+++ b/ui/src/components/MediumCreateView/index.tsx
@@ -25,11 +25,29 @@ import MediumItemMetadataTagCreate from '@/components/MediumItemMetadataTagCreat
 import MediumItemMetadataTagEdit from '@/components/MediumItemMetadataTagEdit'
 import MediumItemMetadataTagList from '@/components/MediumItemMetadataTagList'
 import MediumItemReplicaDeleteDialog from '@/components/MediumItemReplicaDeleteDialog'
-import { useCreateMedium, useDeleteReplica, useUpdateMedium } from '@/hooks'
+import { useBeforeUnload, useCreateMedium, useDeleteReplica, useUpdateMedium } from '@/hooks'
 import type { TagTagTypeInput } from '@/hooks/types.generated'
 import type { Medium, Replica } from '@/types'
 
 import styles from './styles.module.scss'
+
+const hasChanges = (medium: Medium | null, replicas: (Replica | ReplicaCreate)[], removingReplicas: Replica[]) => {
+  if ((medium?.replicas?.length ?? 0) !== replicas.length || removingReplicas.length > 0) {
+    return true
+  }
+
+  for (const [ idx, replica ] of replicas.entries()) {
+    if (!isReplica(replica)) {
+      return true
+    }
+
+    if (medium?.replicas?.[idx]?.id !== replica.id) {
+      return true
+    }
+  }
+
+  return false
+}
 
 const MediumCreateView: FunctionComponent = () => {
   const router = useRouter()
@@ -275,6 +293,8 @@ const MediumCreateView: FunctionComponent = () => {
   }, [ router ])
 
   const loading = createLoading || updateLoading
+  const changed = hasChanges(medium, replicas, removingReplicas)
+  useBeforeUnload(changed)
 
   return (
     <Grid className={styles.container} container spacing={4}>

--- a/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
@@ -11,9 +11,23 @@ import type { SourceCreate } from '@/components/AutocompleteSourceBody'
 import { isSource } from '@/components/AutocompleteSourceBody'
 import MediumItemMetadataHeader from '@/components/MediumItemMetadataHeader'
 import MediumItemMetadataSourceGroupEdit from '@/components/MediumItemMetadataSourceGroupEdit'
-import { SOURCE_METADATA_DUPLICATE, useCreateSource, useError } from '@/hooks'
+import { SOURCE_METADATA_DUPLICATE, useBeforeUnload, useCreateSource, useError } from '@/hooks'
 import type { ExternalMetadataInput } from '@/hooks/types.generated'
 import type { ExternalService, Source } from '@/types'
+
+const hasChanges = (addingExternalServices: ExternalService[], addingSources: Map<ExternalServiceID, (Source | SourceCreate)[]>) => {
+  if (addingExternalServices.length > 0) {
+    return true
+  }
+
+  for (const tags of addingSources.values()) {
+    if (tags.length > 0) {
+      return true
+    }
+  }
+
+  return false
+}
 
 const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSourceCreateProps> = ({
   loading,
@@ -130,6 +144,9 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
       return newAddingSources
     })
   }, [ setResolveSourceIDs, resolveSourceIDs ])
+
+  const changed = hasChanges(addingExternalServices, addingSources)
+  useBeforeUnload(changed)
 
   return (
     <Stack>

--- a/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
@@ -15,9 +15,29 @@ import type { SourceCreate } from '@/components/AutocompleteSourceBody'
 import { isSource } from '@/components/AutocompleteSourceBody'
 import MediumItemMetadataHeader from '@/components/MediumItemMetadataHeader'
 import MediumItemMetadataSourceGroupEdit from '@/components/MediumItemMetadataSourceGroupEdit'
-import { SOURCE_METADATA_DUPLICATE, useCreateSource, useError } from '@/hooks'
+import { SOURCE_METADATA_DUPLICATE, useBeforeUnload, useCreateSource, useError } from '@/hooks'
 import type { ExternalMetadataInput } from '@/hooks/types.generated'
 import type { ExternalService, Medium, Source } from '@/types'
+
+const hasChanges = (addingExternalServices: ExternalService[], removingExternalServices: ExternalService[], addingSources: Map<ExternalServiceID, (Source | SourceCreate)[]>, removingSources: Map<ExternalServiceID, Source[]>) => {
+  if (addingExternalServices.length > 0 || removingExternalServices.length > 0) {
+    return true
+  }
+
+  for (const tags of addingSources.values()) {
+    if (tags.length > 0) {
+      return true
+    }
+  }
+
+  for (const tags of removingSources.values()) {
+    if (tags.length > 0) {
+      return true
+    }
+  }
+
+  return false
+}
 
 const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEditProps> = ({
   loading: mediumLoading,
@@ -228,6 +248,8 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
   }, [ createSource, graphQLError, save, medium, addingSources, removingSources, close ])
 
   const loading = sourceLoading || mediumLoading
+  const changed = hasChanges(addingExternalServices, removingExternalServices, addingSources, removingSources)
+  useBeforeUnload(changed)
 
   return (
     <Stack>

--- a/ui/src/components/MediumItemMetadataSummaryCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSummaryCreate/index.tsx
@@ -10,8 +10,11 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 
 import type { MediumCreate } from '@/components/MediumCreateView'
 import MediumItemMetadataHeader from '@/components/MediumItemMetadataHeader'
+import { useBeforeUnload } from '@/hooks'
 
 import styles from './styles.module.scss'
+
+const hasChanges = (medium: MediumCreate) => Boolean(medium.createdAt)
 
 const MediumItemMetadataSummaryCreate: FunctionComponent<MediumItemMetadataSummaryCreateProps> = ({
   loading,
@@ -22,11 +25,7 @@ const MediumItemMetadataSummaryCreate: FunctionComponent<MediumItemMetadataSumma
   })
 
   const handleChangeCreatedAt = useCallback((value: Date | null) => {
-    if (!value || isNaN(value.getTime())) {
-      return
-    }
-
-    const createdAt = value.toISOString()
+    const createdAt = value && !isNaN(value.getTime()) ? value.toISOString() : null
     setMedium(medium => ({
       ...medium,
       createdAt,
@@ -36,6 +35,9 @@ const MediumItemMetadataSummaryCreate: FunctionComponent<MediumItemMetadataSumma
   const handleClickSubmit = useCallback(() => {
     save(medium)
   }, [ save, medium ])
+
+  const changed = hasChanges(medium)
+  useBeforeUnload(changed)
 
   return (
     <Stack>

--- a/ui/src/components/MediumItemMetadataSummaryEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSummaryEdit/index.tsx
@@ -11,9 +11,12 @@ import CalendarMonthIcon from '@mui/icons-material/CalendarMonth'
 
 import MediumDeleteDialog from '@/components/MediumDeleteDialog'
 import MediumItemMetadataHeader from '@/components/MediumItemMetadataHeader'
+import { useBeforeUnload } from '@/hooks'
 import type { Medium } from '@/types'
 
 import styles from './styles.module.scss'
+
+const hasChanges = (a: Medium, b: Medium) => new Date(a.createdAt).getTime() !== new Date(b.createdAt).getTime()
 
 const MediumItemMetadataSummaryEdit: FunctionComponent<MediumItemMetadataSummaryEditProps> = ({
   loading,
@@ -56,6 +59,9 @@ const MediumItemMetadataSummaryEdit: FunctionComponent<MediumItemMetadataSummary
   const handleDeleteMedium = useCallback(() => {
     onDelete()
   }, [ onDelete ])
+
+  const changed = hasChanges(medium, current)
+  useBeforeUnload(changed)
 
   return (
     <Stack>

--- a/ui/src/components/MediumItemMetadataTagCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagCreate/index.tsx
@@ -8,8 +8,23 @@ import LabelIcon from '@mui/icons-material/Label'
 import AutocompleteTagType from '@/components/AutocompleteTagType'
 import MediumItemMetadataHeader from '@/components/MediumItemMetadataHeader'
 import MediumItemMetadataTagGroupEdit from '@/components/MediumItemMetadataTagGroupEdit'
+import { useBeforeUnload } from '@/hooks'
 import type { TagTagTypeInput } from '@/hooks/types.generated'
 import type { Tag, TagType } from '@/types'
+
+const hasChanges = (addingTagTypes: TagType[], addingTags: Map<TagTypeID, Tag[]>) => {
+  if (addingTagTypes.length > 0) {
+    return true
+  }
+
+  for (const tags of addingTags.values()) {
+    if (tags.length > 0) {
+      return true
+    }
+  }
+
+  return false
+}
 
 const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreateProps> = ({
   loading,
@@ -98,6 +113,9 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
     }
     return addTagTagTypeIDs
   }
+
+  const changed = hasChanges(addingTagTypes, addingTags)
+  useBeforeUnload(changed)
 
   return (
     <Stack>

--- a/ui/src/components/MediumItemMetadataTagEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagEdit/index.tsx
@@ -10,8 +10,29 @@ import LabelIcon from '@mui/icons-material/Label'
 import AutocompleteTagType from '@/components/AutocompleteTagType'
 import MediumItemMetadataHeader from '@/components/MediumItemMetadataHeader'
 import MediumItemMetadataTagGroupEdit from '@/components/MediumItemMetadataTagGroupEdit'
+import { useBeforeUnload } from '@/hooks'
+import type { TagTagTypeInput } from '@/hooks/types.generated'
 import type { Medium, Tag, TagType } from '@/types'
-import { TagTagTypeInput } from '@/hooks/types.generated'
+
+const hasChanges = (addingTagTypes: TagType[], removingTagTypes: TagType[], addingTags: Map<TagTypeID, Tag[]>, removingTags: Map<TagTypeID, Tag[]>) => {
+  if (addingTagTypes.length > 0 || removingTagTypes.length > 0) {
+    return true
+  }
+
+  for (const tags of addingTags.values()) {
+    if (tags.length > 0) {
+      return true
+    }
+  }
+
+  for (const tags of removingTags.values()) {
+    if (tags.length > 0) {
+      return true
+    }
+  }
+
+  return false
+}
 
 const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProps> = ({
   loading,
@@ -182,6 +203,9 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
       }
     )
   }, [ save, medium, addingTags, removingTags, close ])
+
+  const changed = hasChanges(addingTagTypes, removingTagTypes, addingTags, removingTags)
+  useBeforeUnload(changed)
 
   return (
     <Stack>

--- a/ui/src/components/MediumItemViewBody/index.tsx
+++ b/ui/src/components/MediumItemViewBody/index.tsx
@@ -23,11 +23,29 @@ import MediumItemMetadataSummaryShow from '@/components/MediumItemMetadataSummar
 import MediumItemMetadataTagEdit from '@/components/MediumItemMetadataTagEdit'
 import MediumItemMetadataTagList from '@/components/MediumItemMetadataTagList'
 import MediumItemReplicaDeleteDialog from '@/components/MediumItemReplicaDeleteDialog'
-import { useDeleteReplica, useMedium, useUpdateMedium } from '@/hooks'
+import { useBeforeUnload, useDeleteReplica, useMedium, useUpdateMedium } from '@/hooks'
 import type { TagTagTypeInput } from '@/hooks/types.generated'
 import type { Medium, Replica } from '@/types'
 
 import styles from './styles.module.scss'
+
+const hasChanges = (medium: Medium, replicas: (Replica | ReplicaCreate)[], removingReplicas: Replica[]) => {
+  if (medium.replicas?.length !== replicas.length || removingReplicas.length > 0) {
+    return true
+  }
+
+  for (const [ idx, replica ] of replicas.entries()) {
+    if (!isReplica(replica)) {
+      return true
+    }
+
+    if (medium.replicas[idx]?.id !== replica.id) {
+      return true
+    }
+  }
+
+  return false
+}
 
 const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
   id,
@@ -238,6 +256,9 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
   const handleDeleteMedium = useCallback(() => {
     router.replace('/')
   }, [ router ])
+
+  const changed = hasChanges(medium, replicas, removingReplicas)
+  useBeforeUnload(changed)
 
   return (
     <Grid className={styles.container} container spacing={4}>

--- a/ui/src/components/TagListColumnBodyCreate/index.tsx
+++ b/ui/src/components/TagListColumnBodyCreate/index.tsx
@@ -13,7 +13,7 @@ import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 
 import TagBreadcrumbsList from '@/components/TagBreadcrumbsList'
-import { useCreateTag } from '@/hooks'
+import { useBeforeUnload, useCreateTag } from '@/hooks'
 import type { Tag } from '@/types'
 
 import styles from './styles.module.scss'
@@ -21,6 +21,8 @@ import styles from './styles.module.scss'
 const extractKana = (history: string[]): string => {
   return historykana(history, { kanaRegexp: /^[ 　ぁ-ゔー]*[nｎ]?$/ }).replace(/[nｎ]$/, 'ん')
 }
+
+const hasChanges = (tag: TagCreate) => tag.name.length > 0 || tag.kana.length > 0 || tag.aliases.length > 0
 
 const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> = ({
   parent,
@@ -36,7 +38,7 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
     })
   }, [])
 
-  const [ tag, setTag ] = useState<Omit<Tag, 'id' | 'parent' | 'children'>>({
+  const [ tag, setTag ] = useState<TagCreate>({
     name: '',
     kana: '',
     aliases: [],
@@ -101,7 +103,8 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
     )
   }, [ tag, parent, onCreating, onCreate, createTag, close ])
 
-  const empty = tag.name.length === 0
+  const changed = hasChanges(tag)
+  useBeforeUnload(changed)
 
   return (
     <Stack className={styles.container} direction="column-reverse" justifyContent="flex-end">
@@ -154,7 +157,7 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
           )}
         </Stack>
         <Stack className={styles.buttons} spacing={1} direction="row-reverse">
-          <LoadingButton onClick={handleClickSubmit} loading={loading} disabled={empty}>
+          <LoadingButton onClick={handleClickSubmit} loading={loading} disabled={!changed}>
             <span>保存</span>
           </LoadingButton>
           <Button onClick={handleClickCancel}>
@@ -181,5 +184,7 @@ export interface TagListColumnBodyCreateProps {
   onCreating?: () => void
   onCreate?: (tag: Tag) => void
 }
+
+type TagCreate = Omit<Tag, 'id' | 'parent' | 'children'>
 
 export default TagListColumnBodyCreate

--- a/ui/src/components/TagListColumnBodyEdit/index.tsx
+++ b/ui/src/components/TagListColumnBodyEdit/index.tsx
@@ -13,10 +13,24 @@ import TextField from '@mui/material/TextField'
 
 import TagBreadcrumbsList from '@/components/TagBreadcrumbsList'
 import TagMoveDialog from '@/components/TagMoveDialog'
-import { useUpdateTag } from '@/hooks'
+import { useBeforeUnload, useUpdateTag } from '@/hooks'
 import type { Tag } from '@/types'
 
 import styles from './styles.module.scss'
+
+const hasChanges = (a: Tag, b: Tag) => {
+  if (a.name !== b.name || a.kana !== b.kana || a.aliases.length !== b.aliases.length) {
+    return true
+  }
+
+  for (const [ idx, alias ] of a.aliases.entries()) {
+    if (alias !== b.aliases[idx]) {
+      return true
+    }
+  }
+
+  return false
+}
 
 const TagListColumnBodyEdit: FunctionComponent<TagListColumnBodyEditProps> = ({
   tag: current,
@@ -89,6 +103,9 @@ const TagListColumnBodyEdit: FunctionComponent<TagListColumnBodyEditProps> = ({
       },
     )
   }, [ tag, current, updateTag, close ])
+
+  const changed = hasChanges(tag, current)
+  useBeforeUnload(changed)
 
   return (
     <Stack className={styles.container} direction="column-reverse" justifyContent="flex-end">

--- a/ui/src/components/TagTypeListColumnBodyCreate/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyCreate/index.tsx
@@ -9,10 +9,12 @@ import Snackbar from '@mui/material/Snackbar'
 import Stack from '@mui/material/Stack'
 import TextField from '@mui/material/TextField'
 
-import { TAG_TYPE_SLUG_DUPLICATE, useError, useCreateTagType } from '@/hooks'
+import { TAG_TYPE_SLUG_DUPLICATE, useError, useCreateTagType, useBeforeUnload } from '@/hooks'
 import type { TagType } from '@/types'
 
 import styles from './styles.module.scss'
+
+const hasChanges = (tagType: TagTypeCreate) => tagType.name.length > 0 || tagType.slug.length > 0
 
 const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreateProps> = ({
   close,
@@ -26,7 +28,7 @@ const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreate
     })
   }, [])
 
-  const [ tagType, setTagType ] = useState<Omit<TagType, 'id'>>({
+  const [ tagType, setTagType ] = useState<TagTypeCreate>({
     name: '',
     slug: '',
   })
@@ -67,7 +69,8 @@ const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreate
 
   const tagTypeSlugDuplicate = graphQLError(error, TAG_TYPE_SLUG_DUPLICATE)
   const isSlugDuplicate = tagTypeSlugDuplicate?.extensions.details.data.slug === tagType.slug
-  const empty = tagType.name.length === 0 || tagType.slug.length == 0
+  const changed = hasChanges(tagType)
+  useBeforeUnload(changed)
 
   return (
     <Stack className={styles.container} direction="column-reverse" justifyContent="flex-end">
@@ -102,7 +105,7 @@ const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreate
       </Stack>
       <Stack direction="row" justifyContent="flex-end">
         <Stack className={styles.buttons} spacing={1} direction="row-reverse">
-          <LoadingButton onClick={handleClickSubmit} loading={loading} disabled={empty || isSlugDuplicate}>
+          <LoadingButton onClick={handleClickSubmit} loading={loading} disabled={!changed || isSlugDuplicate}>
             <span>保存</span>
           </LoadingButton>
           <Button onClick={handleClickCancel}>
@@ -126,5 +129,7 @@ const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreate
 export interface TagTypeListColumnBodyCreateProps {
   close: () => void
 }
+
+type TagTypeCreate = Omit<TagType, 'id'>
 
 export default TagTypeListColumnBodyCreate

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useBeforeUnload'
 export * from './useError'
 export * from './useFilesize'
 export * from './useFileSystemEntry'

--- a/ui/src/hooks/useBeforeUnload/index.ts
+++ b/ui/src/hooks/useBeforeUnload/index.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+  e.preventDefault()
+}
+
+export function useBeforeUnload(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [ enabled ])
+}


### PR DESCRIPTION
This PR prevents users from leaving the page when they have pending changes. This implementation only handles `beforeunload` so in-app navigation would not be canceled.