### PR TITLE
 Read database fixtures relative to the $CARGO_MANIFEST_DIR in `postgres`

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1350,12 +1350,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "graphql"
 version = "0.0.0"
 dependencies = [
@@ -1836,7 +1830,6 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
 dependencies = [
- "glob",
  "include_dir_macros",
 ]
 

--- a/api/crates/postgres/Cargo.toml
+++ b/api/crates/postgres/Cargo.toml
@@ -70,7 +70,6 @@ version = "1.10.0"
 
 [dev-dependencies.include_dir]
 version = "0.7.4"
-features = ["glob"]
 
 [dev-dependencies.pretty_assertions]
 version = "1.3.0"

--- a/api/crates/postgres/tests/common/mod.rs
+++ b/api/crates/postgres/tests/common/mod.rs
@@ -10,7 +10,7 @@ use sqlx_migrator::migrator::{Migrate, Plan};
 use test_context::AsyncTestContext;
 use uuid::Uuid;
 
-static FIXTURES: Dir = include_dir!("crates/postgres/tests/fixtures");
+static FIXTURES: Dir = include_dir!("$CARGO_MANIFEST_DIR/tests/fixtures");
 
 type BoxDynError = Box<dyn Error + Send + Sync + 'static>;
 

--- a/api/scripts/setup-postgres.bash
+++ b/api/scripts/setup-postgres.bash
@@ -8,7 +8,7 @@ export PGPASSWORD=hoarder_test
 echo -n 'starting postgres ... ' >&2
 pushd "$(git rev-parse --show-toplevel)" &> /dev/null
 
-POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:16.2}"
+POSTGRES_IMAGE="${POSTGRES_IMAGE:-postgres:16.3}"
 POSTGRES_OPTIONS=(
     -c fsync=off
     -c full_page_writes=off


### PR DESCRIPTION
This PR fixes unit testing facilities for our `postgres` crate.