### PR TITLE
Fix the resolution of @apollo/client for @types/apollo-upload-client

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,9 @@
     "lint": "next lint",
     "codegen": "graphql-codegen --config=codegen.ts"
   },
+  "resolutions": {
+    "@types/apollo-upload-client/@apollo/client": "*"
+  },
   "dependencies": {
     "@apollo/client": "^3.11.8",
     "@apollo/experimental-nextjs-app-support": "^0.11.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -41,7 +41,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.11.8, @apollo/client@npm:^3.8.0":
+"@apollo/client@npm:*, @apollo/client@npm:^3.11.8":
   version: 3.11.8
   resolution: "@apollo/client@npm:3.11.8"
   dependencies:


### PR DESCRIPTION
The version range `^3.8.0` that `@types/apollo-upload-client` specifies has introduced version diversion against `@apollo/client`. This PR fixes the version to `*` so it automatically matches with the root one.