### PR TITLE
Replace date-fns-tz with @date-fns/tz

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     date-fns:
       patterns:
       - date-fns
-      - date-fns-tz
+      - "@date-fns/*"
     emotion:
       patterns:
       - "@emotion/*"

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@apollo/client": "^3.11.8",
     "@apollo/experimental-nextjs-app-support": "^0.11.3",
+    "@date-fns/tz": "^1.0.2",
     "@emotion/cache": "^11.13.1",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
@@ -40,7 +41,6 @@
     "axios": "^1.7.7",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "date-fns-tz": "^3.1.3",
     "deep-equal": "^2.2.3",
     "graphql": "^16.9.0",
     "historykana": "^1.0.6",

--- a/ui/src/components/DateTime/index.tsx
+++ b/ui/src/components/DateTime/index.tsx
@@ -3,19 +3,20 @@
 import type { ComponentPropsWithoutRef, FunctionComponent } from 'react'
 import Typography from '@mui/material/Typography'
 
-import { formatInTimeZone } from 'date-fns-tz'
+import { format } from 'date-fns'
 import { ja } from 'date-fns/locale/ja'
+import { TZDate } from '@date-fns/tz'
 
 const DateTime: FunctionComponent<DateTimeProps> = ({
   date = new Date(),
-  format,
+  format: formatStr,
 }) => (
   <Typography
     component={({ key, ...props }: ComponentPropsWithoutRef<'time'>) => (
       <time key={key} dateTime={date.toISOString()} {...props} />
     )}
   >
-    {formatInTimeZone(date, 'Asia/Tokyo', format, { locale: ja })}
+    {format(new TZDate(date, 'Asia/Tokyo'), formatStr, { locale: ja })}
   </Typography>
 )
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -760,6 +760,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@date-fns/tz@npm:1.0.2"
+  checksum: 10/6a4bf2a9d7c265a2cd471da510e7201adc00c37a9b59de933f4b9a2f688838ff14b6ba5229505dd8a3a55c6a6609c744724eb0bf887243e3f4912cabc0b6b96b
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:^1.2.0":
   version: 1.2.0
   resolution: "@emnapi/runtime@npm:1.2.0"
@@ -4345,15 +4352,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns-tz@npm:^3.1.3":
-  version: 3.1.3
-  resolution: "date-fns-tz@npm:3.1.3"
-  peerDependencies:
-    date-fns: ^3.0.0
-  checksum: 10/eb5cb3b2cd152340004efda9f7905e571cf5140b8e85267b1eaa36c2f1eaa54a0f2e3b26e19794f2aca4d3b15aa3d52a5b2dadb540fcec74b239049c7792a981
-  languageName: node
-  linkType: hard
-
 "date-fns@npm:^4.1.0":
   version: 4.1.0
   resolution: "date-fns@npm:4.1.0"
@@ -5736,6 +5734,7 @@ __metadata:
   dependencies:
     "@apollo/client": "npm:^3.11.8"
     "@apollo/experimental-nextjs-app-support": "npm:^0.11.3"
+    "@date-fns/tz": "npm:^1.0.2"
     "@emotion/cache": "npm:^11.13.1"
     "@emotion/react": "npm:^11.13.3"
     "@emotion/styled": "npm:^11.13.0"
@@ -5766,7 +5765,6 @@ __metadata:
     axios: "npm:^1.7.7"
     clsx: "npm:^2.1.1"
     date-fns: "npm:^4.1.0"
-    date-fns-tz: "npm:^3.1.3"
     deep-equal: "npm:^2.2.3"
     eslint: "npm:^9.10.0"
     eslint-config-next: "npm:^14.2.13"


### PR DESCRIPTION
This PR migrates the library for timezone support from `date-fns-tz` to `@date-fns/tz` available since `date-fns` v4.0 (https://blog.date-fns.org/v40-with-time-zone-support/).