### PR TITLE
Rename build target development to debug in /ui

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -45,7 +45,7 @@ services:
   ui:
     build:
       context: ./ui
-      target: development
+      target: debug
     command: yarn dev
     ports:
       - '3000:3000'

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22.9.0-bookworm AS base
 WORKDIR /usr/src
 COPY package.json yarn.lock .yarnrc.yml /usr/src/
 
-FROM base AS development
+FROM base AS debug
 RUN --mount=type=tmpfs,target=/tmp \
     --mount=type=cache,id=ui:/usr/local/share/.cache/yarn,target=/usr/local/share/.cache/yarn \
     corepack enable && \


### PR DESCRIPTION
This PR aligns `ui/Dockerfile` with changes in #298.