### PR TITLE
Sort media sources by the slug of external service and their metadata

### DIFF
--- a/api/crates/postgres/src/media.rs
+++ b/api/crates/postgres/src/media.rs
@@ -363,7 +363,8 @@ where
         )
         .and_where(Expr::col((PostgresMediumSource::Table, PostgresMediumSource::MediumId)).is_in(ids.into_iter().map(PostgresMediumId::from)))
         .order_by((PostgresMediumSource::Table, PostgresMediumSource::MediumId), Order::Asc)
-        .order_by((PostgresMediumSource::Table, PostgresMediumSource::SourceId), Order::Asc)
+        .order_by((PostgresExternalService::Table, PostgresExternalService::Slug), Order::Asc)
+        .order_by((PostgresSource::Table, PostgresSource::ExternalMetadata), Order::Asc)
         .build_sqlx(PostgresQueryBuilder);
 
     let sources = sqlx::query_as_with::<_, PostgresMediumSourceExternalServiceRow, _>(&sql, values)

--- a/api/crates/postgres/tests/media-create.rs
+++ b/api/crates/postgres/tests/media-create.rs
@@ -95,19 +95,6 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
     let actual_id = *actual.id;
     assert_eq!(actual.sources, vec![
         Source {
-            id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
-            external_service: ExternalService {
-                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                slug: "x".to_string(),
-                kind: "x".to_string(),
-                name: "X".to_string(),
-                base_url: Some("https://x.com".to_string()),
-            },
-            external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
-            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
-            updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
-        },
-        Source {
             id: SourceId::from(uuid!("3e1150b0-144a-4fcf-a202-b93a5f3274db")),
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -119,6 +106,19 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
+        },
+        Source {
+            id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                slug: "x".to_string(),
+                kind: "x".to_string(),
+                name: "X".to_string(),
+                base_url: Some("https://x.com".to_string()),
+            },
+            external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
+            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
         },
     ]);
     assert_eq!(actual.tags, OrderMap::<TagType, Vec<Tag>>::new());
@@ -386,19 +386,6 @@ async fn with_sources_tags_succeeds(ctx: &DatabaseContext) {
     let actual_id = *actual.id;
     assert_eq!(actual.sources, vec![
         Source {
-            id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
-            external_service: ExternalService {
-                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                slug: "x".to_string(),
-                kind: "x".to_string(),
-                name: "X".to_string(),
-                base_url: Some("https://x.com".to_string()),
-            },
-            external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
-            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
-            updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
-        },
-        Source {
             id: SourceId::from(uuid!("3e1150b0-144a-4fcf-a202-b93a5f3274db")),
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -410,6 +397,19 @@ async fn with_sources_tags_succeeds(ctx: &DatabaseContext) {
             external_metadata: ExternalMetadata::Pixiv { id: 2222222 },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 5).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
+        },
+        Source {
+            id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                slug: "x".to_string(),
+                kind: "x".to_string(),
+                name: "X".to_string(),
+                base_url: Some("https://x.com".to_string()),
+            },
+            external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
+            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
         },
     ]);
     assert_eq!(actual.tags, {

--- a/api/crates/postgres/tests/media-fetch_all-with-sources.rs
+++ b/api/crates/postgres/tests/media-fetch_all-with-sources.rs
@@ -155,19 +155,6 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             id: MediumId::from(uuid!("a8c1a9d2-0d17-422b-9c02-632cb7712b5b")),
             sources: vec![
                 Source {
-                    id: SourceId::from(uuid!("2a82a031-e27a-443e-9f22-bb190f70633a")),
-                    external_service: ExternalService {
-                        id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
-                        slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
-                        name: "Skeb".to_string(),
-                        base_url: Some("https://skeb.jp".to_string()),
-                    },
-                    external_metadata: ExternalMetadata::Skeb { id: 4444, creator_id: "creator_01".to_string() },
-                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 10).unwrap(),
-                    updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
-                },
-                Source {
                     id: SourceId::from(uuid!("e607c6f5-af17-4f65-9868-b3e72f692f4d")),
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -180,6 +167,19 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 9).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 13).unwrap(),
                 },
+                Source {
+                    id: SourceId::from(uuid!("2a82a031-e27a-443e-9f22-bb190f70633a")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
+                        slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
+                        name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::Skeb { id: 4444, creator_id: "creator_01".to_string() },
+                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 10).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
+                },
             ],
             tags: OrderMap::new(),
             replicas: Vec::new(),
@@ -189,19 +189,6 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Medium {
             id: MediumId::from(uuid!("348ffaa9-624b-488f-9c63-d61f78db06a7")),
             sources: vec![
-                Source {
-                    id: SourceId::from(uuid!("725792bf-dbf0-4af1-b639-a147f0b327b2")),
-                    external_service: ExternalService {
-                        id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
-                        slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
-                        name: "Skeb".to_string(),
-                        base_url: Some("https://skeb.jp".to_string()),
-                    },
-                    external_metadata: ExternalMetadata::Skeb { id: 2222, creator_id: "creator_02".to_string() },
-                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 12).unwrap(),
-                    updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
-                },
                 Source {
                     id: SourceId::from(uuid!("da2e3cc8-5b12-45fc-b720-815e74fb8fe6")),
                     external_service: ExternalService {
@@ -214,6 +201,19 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_metadata: ExternalMetadata::Pixiv { id: 6666666 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 9).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("725792bf-dbf0-4af1-b639-a147f0b327b2")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
+                        slug: "skeb".to_string(),
+                        kind: "skeb".to_string(),
+                        name: "Skeb".to_string(),
+                        base_url: Some("https://skeb.jp".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::Skeb { id: 2222, creator_id: "creator_02".to_string() },
+                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 12).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
                 },
             ],
             tags: OrderMap::new(),
@@ -244,19 +244,6 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             id: MediumId::from(uuid!("43b77865-c05d-4733-b336-95b5522a8a46")),
             sources: vec![
                 Source {
-                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
-                    external_service: ExternalService {
-                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                        slug: "x".to_string(),
-                        kind: "x".to_string(),
-                        name: "X".to_string(),
-                        base_url: Some("https://x.com".to_string()),
-                    },
-                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
-                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
-                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
-                },
-                Source {
                     id: SourceId::from(uuid!("3a8f9940-08bc-48bf-a6dd-e9ceaf685dfd")),
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -268,6 +255,19 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 16).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                        slug: "x".to_string(),
+                        kind: "x".to_string(),
+                        name: "X".to_string(),
+                        base_url: Some("https://x.com".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
+                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
                 },
             ],
             tags: OrderMap::new(),
@@ -599,19 +599,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             id: MediumId::from(uuid!("43b77865-c05d-4733-b336-95b5522a8a46")),
             sources: vec![
                 Source {
-                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
-                    external_service: ExternalService {
-                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                        slug: "x".to_string(),
-                        kind: "x".to_string(),
-                        name: "X".to_string(),
-                        base_url: Some("https://x.com".to_string()),
-                    },
-                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
-                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
-                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
-                },
-                Source {
                     id: SourceId::from(uuid!("3a8f9940-08bc-48bf-a6dd-e9ceaf685dfd")),
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -623,6 +610,19 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 16).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                        slug: "x".to_string(),
+                        kind: "x".to_string(),
+                        name: "X".to_string(),
+                        base_url: Some("https://x.com".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
+                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
                 },
             ],
             tags: OrderMap::new(),

--- a/api/crates/postgres/tests/media-fetch_by_tag_ids-with-sources.rs
+++ b/api/crates/postgres/tests/media-fetch_by_tag_ids-with-sources.rs
@@ -161,19 +161,6 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             id: MediumId::from(uuid!("43b77865-c05d-4733-b336-95b5522a8a46")),
             sources: vec![
                 Source {
-                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
-                    external_service: ExternalService {
-                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                        slug: "x".to_string(),
-                        kind: "x".to_string(),
-                        name: "X".to_string(),
-                        base_url: Some("https://x.com".to_string()),
-                    },
-                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
-                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
-                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
-                },
-                Source {
                     id: SourceId::from(uuid!("3a8f9940-08bc-48bf-a6dd-e9ceaf685dfd")),
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -185,6 +172,19 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 16).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                        slug: "x".to_string(),
+                        kind: "x".to_string(),
+                        name: "X".to_string(),
+                        base_url: Some("https://x.com".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
+                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
                 },
             ],
             tags: OrderMap::new(),
@@ -335,19 +335,6 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             id: MediumId::from(uuid!("43b77865-c05d-4733-b336-95b5522a8a46")),
             sources: vec![
                 Source {
-                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
-                    external_service: ExternalService {
-                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                        slug: "x".to_string(),
-                        kind: "x".to_string(),
-                        name: "X".to_string(),
-                        base_url: Some("https://x.com".to_string()),
-                    },
-                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
-                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
-                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
-                },
-                Source {
                     id: SourceId::from(uuid!("3a8f9940-08bc-48bf-a6dd-e9ceaf685dfd")),
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -359,6 +346,19 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 16).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                        slug: "x".to_string(),
+                        kind: "x".to_string(),
+                        name: "X".to_string(),
+                        base_url: Some("https://x.com".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
+                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
                 },
             ],
             tags: OrderMap::new(),
@@ -550,19 +550,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             id: MediumId::from(uuid!("43b77865-c05d-4733-b336-95b5522a8a46")),
             sources: vec![
                 Source {
-                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
-                    external_service: ExternalService {
-                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                        slug: "x".to_string(),
-                        kind: "x".to_string(),
-                        name: "X".to_string(),
-                        base_url: Some("https://x.com".to_string()),
-                    },
-                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
-                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
-                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
-                },
-                Source {
                     id: SourceId::from(uuid!("3a8f9940-08bc-48bf-a6dd-e9ceaf685dfd")),
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
@@ -574,6 +561,19 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_metadata: ExternalMetadata::Pixiv { id: 7777777 },
                     created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 7).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 16).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("082bdad0-46a9-4637-af44-3c91a605a5f1")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                        slug: "x".to_string(),
+                        kind: "x".to_string(),
+                        name: "X".to_string(),
+                        base_url: Some("https://x.com".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::X { id: 111111111111, creator_id: Some("creator_01".to_string()) },
+                    created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 15).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 17).unwrap(),
                 },
             ],
             tags: OrderMap::new(),

--- a/api/crates/postgres/tests/media-update_by_id.rs
+++ b/api/crates/postgres/tests/media-update_by_id.rs
@@ -464,19 +464,6 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.sources, vec![
         Source {
-            id: SourceId::from(uuid!("5c872f82-2ad0-47c4-8c6f-64efc9443128")),
-            external_service: ExternalService {
-                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                slug: "x".to_string(),
-                kind: "x".to_string(),
-                name: "X".to_string(),
-                base_url: Some("https://x.com".to_string()),
-            },
-            external_metadata: ExternalMetadata::X { id: 333333333333, creator_id: Some("creator_03".to_string()) },
-            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
-            updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
-        },
-        Source {
             id: SourceId::from(uuid!("6807b3f6-6325-4212-bba5-bdb48150bb69")),
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
@@ -488,6 +475,19 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_metadata: ExternalMetadata::Skeb { id: 1111, creator_id: "creator_02".to_string() },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 13).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 11).unwrap(),
+        },
+        Source {
+            id: SourceId::from(uuid!("5c872f82-2ad0-47c4-8c6f-64efc9443128")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                slug: "x".to_string(),
+                kind: "x".to_string(),
+                name: "X".to_string(),
+                base_url: Some("https://x.com".to_string()),
+            },
+            external_metadata: ExternalMetadata::X { id: 333333333333, creator_id: Some("creator_03".to_string()) },
+            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
     assert_eq!(actual.tags, OrderMap::<TagType, Vec<Tag>>::new());
@@ -1021,19 +1021,6 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.sources, vec![
         Source {
-            id: SourceId::from(uuid!("5c872f82-2ad0-47c4-8c6f-64efc9443128")),
-            external_service: ExternalService {
-                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
-                slug: "x".to_string(),
-                kind: "x".to_string(),
-                name: "X".to_string(),
-                base_url: Some("https://x.com".to_string()),
-            },
-            external_metadata: ExternalMetadata::X { id: 333333333333, creator_id: Some("creator_03".to_string()) },
-            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
-            updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
-        },
-        Source {
             id: SourceId::from(uuid!("6807b3f6-6325-4212-bba5-bdb48150bb69")),
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
@@ -1045,6 +1032,19 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
             external_metadata: ExternalMetadata::Skeb { id: 1111, creator_id: "creator_02".to_string() },
             created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 13).unwrap(),
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 11).unwrap(),
+        },
+        Source {
+            id: SourceId::from(uuid!("5c872f82-2ad0-47c4-8c6f-64efc9443128")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                slug: "x".to_string(),
+                kind: "x".to_string(),
+                name: "X".to_string(),
+                base_url: Some("https://x.com".to_string()),
+            },
+            external_metadata: ExternalMetadata::X { id: 333333333333, creator_id: Some("creator_03".to_string()) },
+            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 16).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
     assert_eq!(actual.tags, OrderMap::<TagType, Vec<Tag>>::new());


### PR DESCRIPTION
This PR fixes media sources to be sorted by the slug of external service and their metadata.