### PR TITLE
Remove work around for warnings from material-ui

### DIFF
--- a/ui/src/components/TagListColumnBodyCreate/index.tsx
+++ b/ui/src/components/TagListColumnBodyCreate/index.tsx
@@ -141,12 +141,6 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
               label="別名"
             />
           )}
-          renderTags={(value, getCustomizedTagProps) => value.map((option, index) => {
-            const { key, ...props } = getCustomizedTagProps({ index })
-            return (
-              <Chip key={key} label={option} size="medium" {...props} />
-            )
-          })}
           onChange={handleChangeAliases}
         />
       </Stack>

--- a/ui/src/components/TagListColumnBodyEdit/index.tsx
+++ b/ui/src/components/TagListColumnBodyEdit/index.tsx
@@ -142,12 +142,6 @@ const TagListColumnBodyEdit: FunctionComponent<TagListColumnBodyEditProps> = ({
               label="別名"
             />
           )}
-          renderTags={(value, getCustomizedTagProps) => value.map((option, index) => {
-            const { key, ...props } = getCustomizedTagProps({ index })
-            return (
-              <Chip key={key} label={option} size="medium" {...props} />
-            )
-          })}
           onChange={handleChangeAliases}
         />
       </Stack>


### PR DESCRIPTION
This PR removes work around for the warning: `A props object containing a "key" prop is being spread into JSX` as it is now fixed in material-ui.