### PR TITLE
Ensure that setters of `useState()` are pure

### DIFF
--- a/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
@@ -117,35 +117,29 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
   const addSource = useCallback((externalService: ExternalService, source: Source | SourceCreate) => {
     setFocusedExternalService(externalService)
 
-    setAddingSources(addingSources => {
-      const newSources = addingSources.get(externalService.id) ?? []
-      if (newSources.some(newSource => deepEqual(newSource.externalMetadata, source.externalMetadata))) {
-        return addingSources
-      }
+    const newSources = addingSources.get(externalService.id) ?? []
+    if (newSources.some(newSource => deepEqual(newSource.externalMetadata, source.externalMetadata))) {
+      return
+    }
 
-      newSources.push(source)
-
-      const newAddingSources = new Map(addingSources).set(externalService.id, newSources)
-      setResolveSourceIDs(() => resolveSourceIDs(newAddingSources))
-      return newAddingSources
-    })
-  }, [ setResolveSourceIDs, resolveSourceIDs ])
+    const newAddingSources = new Map(addingSources).set(externalService.id, [ ...newSources, source ])
+    setAddingSources(newAddingSources)
+    setResolveSourceIDs(() => resolveSourceIDs(newAddingSources))
+  }, [ addingSources, setResolveSourceIDs, resolveSourceIDs ])
 
   const removeSource = useCallback((externalService: ExternalService, source: Source | SourceCreate) => {
     setFocusedExternalService(null)
 
-    setAddingSources(addingSources => {
-      const newSources = addingSources.get(externalService.id) ?? []
-      const idx = newSources.findIndex(newSource => deepEqual(newSource.externalMetadata, source.externalMetadata))
-      if (idx < 0) {
-        return addingSources
-      }
+    const newSources = addingSources.get(externalService.id) ?? []
+    const idx = newSources.findIndex(newSource => deepEqual(newSource.externalMetadata, source.externalMetadata))
+    if (idx < 0) {
+      return
+    }
 
-      const newAddingSources = new Map(addingSources).set(externalService.id, newSources.toSpliced(idx, 1))
-      setResolveSourceIDs(() => resolveSourceIDs(newAddingSources))
-      return newAddingSources
-    })
-  }, [ setResolveSourceIDs, resolveSourceIDs ])
+    const newAddingSources = new Map(addingSources).set(externalService.id, newSources.toSpliced(idx, 1))
+    setAddingSources(newAddingSources)
+    setResolveSourceIDs(() => resolveSourceIDs(newAddingSources))
+  }, [ addingSources, setResolveSourceIDs, resolveSourceIDs ])
 
   const renderExternalServiceOption = useCallback(({ key, ...props }: ComponentPropsWithoutRef<'li'>, option: ExternalService) => (
     <li key={key} {...props}>

--- a/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
@@ -132,8 +132,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
         return addingSources
       }
 
-      newSources.push(source)
-      return new Map(addingSources).set(externalService.id, newSources)
+      return new Map(addingSources).set(externalService.id, [ ...newSources, source ])
     })
 
     setRemovingSources(removingSources => {
@@ -174,8 +173,7 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
         return removingSources
       }
 
-      newSources.push(source)
-      return new Map(removingSources).set(externalService.id, newSources)
+      return new Map(removingSources).set(externalService.id, [ ...newSources, source ])
     })
   }, [ groups ])
 

--- a/ui/src/components/MediumItemMetadataTagCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagCreate/index.tsx
@@ -76,35 +76,29 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
   const addTag = useCallback((type: TagType, tag: Tag) => {
     setFocusedTagType(type)
 
-    setAddingTags(addingTags => {
-      const newTags = addingTags.get(type.id) ?? []
-      if (newTags.some(({ id }) => id === tag.id)) {
-        return addingTags
-      }
+    const newTags = addingTags.get(type.id) ?? []
+    if (newTags.some(({ id }) => id === tag.id)) {
+      return
+    }
 
-      newTags.push(tag)
-
-      const newAddingTags = new Map(addingTags).set(type.id, newTags)
-      setTagTagTypeIDs(() => resolveTagTagTypeIDs(newAddingTags))
-      return newAddingTags
-    })
-  }, [ setTagTagTypeIDs ])
+    const newAddingTags = new Map(addingTags).set(type.id, [ ...newTags, tag ])
+    setAddingTags(newAddingTags)
+    setTagTagTypeIDs(() => resolveTagTagTypeIDs(newAddingTags))
+  }, [ addingTags, setTagTagTypeIDs ])
 
   const removeTag = useCallback((type: TagType, tag: Tag) => {
     setFocusedTagType(null)
 
-    setAddingTags(addingTags => {
-      const newTags = addingTags.get(type.id) ?? []
-      const idx = newTags.findIndex(({ id }) => id === tag.id)
-      if (idx < 0) {
-        return addingTags
-      }
+    const newTags = addingTags.get(type.id) ?? []
+    const idx = newTags.findIndex(({ id }) => id === tag.id)
+    if (idx < 0) {
+      return
+    }
 
-      const newAddingTags = new Map(addingTags).set(type.id, newTags.toSpliced(idx, 1))
-      setTagTagTypeIDs(() => resolveTagTagTypeIDs(newAddingTags))
-      return newAddingTags
-    })
-  }, [ setTagTagTypeIDs ])
+    const newAddingTags = new Map(addingTags).set(type.id, newTags.toSpliced(idx, 1))
+    setAddingTags(newAddingTags)
+    setTagTagTypeIDs(() => resolveTagTagTypeIDs(newAddingTags))
+  }, [ addingTags, setTagTagTypeIDs ])
 
   const restoreTag = useCallback(() => {}, [])
 

--- a/ui/src/components/MediumItemMetadataTagEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagEdit/index.tsx
@@ -124,8 +124,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
         return addingTags
       }
 
-      newTags.push(tag)
-      return new Map(addingTags).set(type.id, newTags)
+      return new Map(addingTags).set(type.id, [ ...newTags, tag ])
     })
 
     setRemovingTags(removingTags => {
@@ -162,8 +161,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
         return removingTags
       }
 
-      newTags.push(tag)
-      return new Map(removingTags).set(type.id, newTags)
+      return new Map(removingTags).set(type.id, [ ...newTags, tag ])
     })
   }, [ groups ])
 


### PR DESCRIPTION
This PR fixes non-pure callback passed to the setters of `useState()`. It is mandatory that they are pure:

https://react.dev/reference/react/useState#setstate

> If you pass a function as `nextState`, it will be treated as an *updater function*. It must be pure, should take the pending state as its only argument, and should return the next state. 