### PR TITLE
Link with libjemalloc rather than building

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1450,7 +1450,6 @@ dependencies = [
  "icu_collator",
  "icu_locid",
  "icu_provider",
- "jemallocator",
  "log",
  "media",
  "normalizer",
@@ -1458,6 +1457,7 @@ dependencies = [
  "postgres",
  "storage",
  "thumbnails",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -1911,26 +1911,6 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "jobserver"
@@ -3791,6 +3771,26 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -64,7 +64,7 @@ opt-level = 3
 
 [features]
 default = ["jemallocator", "tls"]
-jemallocator = ["tikv-jemallocator"]
+jemallocator = ["tikv-jemallocator", "tikv-jemallocator/unprefixed_malloc_on_supported_platforms"]
 tls = ["application/tls"]
 test-postgres = []
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -64,6 +64,7 @@ opt-level = 3
 
 [features]
 default = ["jemallocator", "tls"]
+jemallocator = ["tikv-jemallocator"]
 tls = ["application/tls"]
 test-postgres = []
 
@@ -116,12 +117,12 @@ features = ["std"]
 version = "1.5.0"
 features = ["std", "sync"]
 
-[dependencies.jemallocator]
-version = "0.5.4"
-optional = true
-
 [dependencies.log]
 version = "0.4.22"
+
+[dependencies.tikv-jemallocator]
+version = "0.6.0"
+optional = true
 
 [dependencies.tokio]
 version = "1.42.0"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=type=cache,id=api:/usr/local/cargo/registry,target=/usr/local/cargo/
     cp -r target/release/hoarder /usr/local/bin/hoarder
 
 FROM base AS dev
+ENV JEMALLOC_OVERRIDE=/usr/lib/x86_64-linux-gnu/libjemalloc.so
 COPY --from=docker:cli /usr/local/bin/docker /usr/bin/docker
 RUN rustup component add clippy && \
     cargo install cargo-make

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,15 +1,22 @@
 # syntax = docker/dockerfile:1
 FROM rust:1.83.0-bookworm AS base
 WORKDIR /usr/src
+RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
+    --mount=type=cache,id=api:/var/lib/apt/lists,target=/var/lib/apt/lists \
+    apt-get -y update && \
+    apt-get -y install \
+        libjemalloc-dev
 COPY . ./
 
 FROM base AS debug
+ENV JEMALLOC_OVERRIDE=/usr/lib/x86_64-linux-gnu/libjemalloc.so
 RUN --mount=type=cache,id=api:/usr/local/cargo/registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=api:/usr/src/target,target=/usr/src/target \
     cargo build && \
     cp -r target/debug/hoarder /usr/local/bin/hoarder
 
 FROM base AS release
+ENV JEMALLOC_OVERRIDE=/usr/lib/x86_64-linux-gnu/libjemalloc.so
 RUN --mount=type=cache,id=api:/usr/local/cargo/registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=api:/usr/src/target,target=/usr/src/target \
     cargo build --release && \
@@ -24,12 +31,14 @@ FROM scratch AS production
 ARG PORT=80
 ENV PORT=$PORT
 ENV PATH=/
-COPY --link --from=release /lib/x86_64-linux-gnu/ld-linux-x86-64.* /lib/x86_64-linux-gnu/
-COPY --link --from=release /lib/x86_64-linux-gnu/libc.so* /lib/x86_64-linux-gnu/
-COPY --link --from=release /lib/x86_64-linux-gnu/libcrypto.so* /lib/x86_64-linux-gnu/
-COPY --link --from=release /lib/x86_64-linux-gnu/libgcc_s.so* /lib/x86_64-linux-gnu/
-COPY --link --from=release /lib/x86_64-linux-gnu/libm.so* /lib/x86_64-linux-gnu/
-COPY --link --from=release /lib/x86_64-linux-gnu/libssl.so* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/ld-linux-x86-64.so.* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/libc.so.* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/libcrypto.so.* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/libgcc_s.so.* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/libjemalloc.so.* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/libm.so.* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/libssl.so.* /lib/x86_64-linux-gnu/
+COPY --link --from=release /lib/x86_64-linux-gnu/libstdc++.so.* /lib/x86_64-linux-gnu/
 COPY --link --from=release /lib64 /lib64
 COPY --link --from=release /usr/local/bin/hoarder /hoarder
 COPY --link --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/api/crates/core/main.rs
+++ b/api/crates/core/main.rs
@@ -7,7 +7,7 @@ mod env;
 
 #[cfg(feature = "jemallocator")]
 #[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[tokio::main]
 async fn main() -> ExitCode {


### PR DESCRIPTION
This PR updates API to link with libjemalloc from Debian rather than jemallocator’s build. Also, it enables `tikv-jemallocator/unprefixed_malloc_on_supported_platforms` since Debian build of course does not have prefix (`_rjem_`) configured.

https://github.com/tikv/jemallocator/blob/f260a80f21b7f9eb1212809720d9a5f7f0cf0e8b/jemalloc-sys/README.md

> * `unprefixed_malloc_on_supported_platforms`: when disabled, configure `jemalloc` with `--with-jemalloc-prefix=_rjem_`. Enabling this causes symbols like `malloc` to be emitted without a prefix, overriding the ones defined by libc. This usually causes C and C++ code linked in the same program to use `jemalloc` as well. On some platforms prefixes are always used because unprefixing is known to cause segfaults due to allocator mismatches.