### PR TITLE
Add sources and tag types by ID in GraphQL API

### DIFF
--- a/api/crates/domain/src/repository/sources.rs
+++ b/api/crates/domain/src/repository/sources.rs
@@ -14,6 +14,11 @@ pub trait SourcesRepository: Send + Sync + 'static {
     /// Creates a source.
     fn create(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> impl Future<Output = Result<Source>> + Send;
 
+    /// Fetches the sources by their IDs.
+    fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Source>>> + Send
+    where
+        T: IntoIterator<Item = SourceId> + Send + Sync + 'static;
+
     /// Fetches the source by its external metadata.
     fn fetch_by_external_metadata(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> impl Future<Output = Result<Option<Source>>> + Send;
 

--- a/api/crates/domain/src/repository/tag_types.rs
+++ b/api/crates/domain/src/repository/tag_types.rs
@@ -11,6 +11,11 @@ pub trait TagTypesRepository: Send + Sync + 'static {
     /// Creates a tag type.
     fn create(&self, slug: &str, name: &str, kana: &str) -> impl Future<Output = Result<TagType>> + Send;
 
+    /// Fetches the tag types by their IDs.
+    fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<TagType>>> + Send
+    where
+        T: IntoIterator<Item = TagTypeId> + Send + Sync + 'static;
+
     /// Fetches all tag types.
     fn fetch_all(&self) -> impl Future<Output = Result<Vec<TagType>>> + Send;
 

--- a/api/crates/domain/src/service/media.rs
+++ b/api/crates/domain/src/service/media.rs
@@ -110,6 +110,11 @@ pub trait MediaServiceInterface: Send + Sync + 'static {
     /// Gets the replica by original URL.
     fn get_replica_by_original_url(&self, original_url: &str) -> impl Future<Output = Result<Replica>> + Send;
 
+    /// Gets the sourecs by their IDs.
+    fn get_sources_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Source>>> + Send
+    where
+        T: IntoIterator<Item = SourceId> + Send + Sync + 'static;
+
     /// Gets the source by its external metadata.
     fn get_source_by_external_metadata(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> impl Future<Output = Result<Option<Source>>> + Send;
 
@@ -395,6 +400,19 @@ where
             Ok(replica) => Ok(replica),
             Err(e) => {
                 log::error!("failed to get the replica\nError: {e:?}");
+                Err(e)
+            },
+        }
+    }
+
+    async fn get_sources_by_ids<T>(&self, ids: T) -> Result<Vec<Source>>
+    where
+        T: IntoIterator<Item = SourceId> + Send + Sync + 'static,
+    {
+        match self.sources_repository.fetch_by_ids(ids).await {
+            Ok(sources) => Ok(sources),
+            Err(e) => {
+                log::error!("failed to get the sources\nError: {e:?}");
                 Err(e)
             },
         }

--- a/api/crates/domain/src/service/tags.rs
+++ b/api/crates/domain/src/service/tags.rs
@@ -43,6 +43,11 @@ pub trait TagsServiceInterface: Send + Sync + 'static {
     /// Gets tag types.
     fn get_tag_types(&self) -> impl Future<Output = Result<Vec<TagType>>> + Send;
 
+    /// Gets the tag types by their IDs.
+    fn get_tag_types_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<TagType>>> + Send
+    where
+        T: IntoIterator<Item = TagTypeId> + Send + Sync + 'static;
+
     /// Updates the tag by ID.
     fn update_tag_by_id<T, U>(&self, id: TagId, name: Option<String>, kana: Option<String>, add_aliases: T, remove_aliases: U, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send
     where
@@ -111,7 +116,7 @@ where
         match self.tags_repository.fetch_all(depth, root, cursor, order, direction, limit).await {
             Ok(tags) => Ok(tags),
             Err(e) => {
-                log::error!("failed to get tags\nError: {e:?}");
+                log::error!("failed to get the tags\nError: {e:?}");
                 Err(e)
             },
         }
@@ -124,7 +129,7 @@ where
         match self.tags_repository.fetch_by_ids(ids, depth).await {
             Ok(tags) => Ok(tags),
             Err(e) => {
-                log::error!("failed to get tags\nError: {e:?}");
+                log::error!("failed to get the tags\nError: {e:?}");
                 Err(e)
             },
         }
@@ -134,7 +139,7 @@ where
         match self.tags_repository.fetch_by_name_or_alias_like(name_or_alias_like, depth).await {
             Ok(tags) => Ok(tags),
             Err(e) => {
-                log::error!("failed to get tags\nError: {e:?}");
+                log::error!("failed to get the tags\nError: {e:?}");
                 Err(e)
             },
         }
@@ -144,7 +149,20 @@ where
         match self.tag_types_repository.fetch_all().await {
             Ok(tag_types) => Ok(tag_types),
             Err(e) => {
-                log::error!("failed to get tag types\nError: {e:?}");
+                log::error!("failed to get the tag types\nError: {e:?}");
+                Err(e)
+            },
+        }
+    }
+
+    async fn get_tag_types_by_ids<T>(&self, ids: T) -> Result<Vec<TagType>>
+    where
+        T: IntoIterator<Item = TagTypeId> + Send + Sync + 'static,
+    {
+        match self.tag_types_repository.fetch_by_ids(ids).await {
+            Ok(tag_types) => Ok(tag_types),
+            Err(e) => {
+                log::error!("failed to get the tag types\nError: {e:?}");
                 Err(e)
             },
         }

--- a/api/crates/domain/tests/media.rs
+++ b/api/crates/domain/tests/media.rs
@@ -1358,6 +1358,118 @@ async fn get_replica_by_original_url_fails() {
 }
 
 #[tokio::test]
+async fn get_sources_by_ids_succeeds() {
+    let mock_media_repository = MockMediaRepository::new();
+    let mock_objects_repository = MockObjectsRepository::new();
+    let mock_replicas_repository = MockReplicasRepository::new();
+    let mock_medium_image_processor = MockMediumImageProcessor::new();
+
+    let mut mock_sources_repository = MockSourcesRepository::new();
+    mock_sources_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids: &[_; 2]| ids == &[
+            SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+        ])
+        .returning(|_| {
+            Box::pin(ok(vec![
+                Source {
+                    id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
+                        slug: "x".to_string(),
+                        kind: "x".to_string(),
+                        name: "X".to_string(),
+                        base_url: Some("https://x.com".to_string()),
+                        url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) },
+                    created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 1).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                        slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
+                        name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
+                        url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
+                    created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 1).unwrap(),
+                },
+            ]))
+        });
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let actual = service.get_sources_by_ids([
+        SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+    ]).await.unwrap();
+
+    assert_eq!(actual, vec![
+        Source {
+            id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
+                slug: "x".to_string(),
+                kind: "x".to_string(),
+                name: "X".to_string(),
+                base_url: Some("https://x.com".to_string()),
+                url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
+            },
+            external_metadata: ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) },
+            created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 1).unwrap(),
+        },
+        Source {
+            id: SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                slug: "pixiv".to_string(),
+                kind: "pixiv".to_string(),
+                name: "pixiv".to_string(),
+                base_url: Some("https://www.pixiv.net".to_string()),
+                url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+            },
+            external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
+            created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 1).unwrap(),
+        },
+    ]);
+}
+
+#[tokio::test]
+async fn get_sources_by_ids_fails() {
+    let mock_media_repository = MockMediaRepository::new();
+    let mock_objects_repository = MockObjectsRepository::new();
+    let mock_replicas_repository = MockReplicasRepository::new();
+    let mock_medium_image_processor = MockMediumImageProcessor::new();
+
+    let mut mock_sources_repository = MockSourcesRepository::new();
+    mock_sources_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids: &[_; 2]| ids == &[
+            SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+        ])
+        .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let actual = service.get_sources_by_ids([
+        SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+    ]).await.unwrap_err();
+
+    assert_matches!(actual.kind(), ErrorKind::Other);
+}
+
+#[tokio::test]
 async fn get_source_by_external_metadata_succeeds() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_objects_repository = MockObjectsRepository::new();

--- a/api/crates/domain/tests/tags.rs
+++ b/api/crates/domain/tests/tags.rs
@@ -648,6 +648,78 @@ async fn get_tag_types_fails() {
 }
 
 #[tokio::test]
+async fn get_tag_types_by_ids_succeeds() {
+    let mock_tags_repository = MockTagsRepository::new();
+    let mut mock_tag_types_repository = MockTagTypesRepository::new();
+    mock_tag_types_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids: &[_; 2]| ids == &[
+            TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+            TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
+        ])
+        .returning(|_| {
+            Box::pin(ok(vec![
+                TagType {
+                    id: TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+                    slug: "character".to_string(),
+                    name: "キャラクター".to_string(),
+                    kana: "キャラクター".to_string(),
+                },
+                TagType {
+                    id: TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
+                    slug: "illustrator".to_string(),
+                    name: "イラストレーター".to_string(),
+                    kana: "イラストレーター".to_string(),
+                },
+            ]))
+        });
+
+    let service = TagsService::new(mock_tags_repository, mock_tag_types_repository);
+    let actual = service.get_tag_types_by_ids([
+        TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+        TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
+    ]).await.unwrap();
+
+    assert_eq!(actual, vec![
+        TagType {
+            id: TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+            slug: "character".to_string(),
+            name: "キャラクター".to_string(),
+            kana: "キャラクター".to_string(),
+        },
+        TagType {
+            id: TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
+            slug: "illustrator".to_string(),
+            name: "イラストレーター".to_string(),
+            kana: "イラストレーター".to_string(),
+        },
+    ]);
+}
+
+#[tokio::test]
+async fn get_tag_types_by_ids_fails() {
+    let mock_tags_repository = MockTagsRepository::new();
+    let mut mock_tag_types_repository = MockTagTypesRepository::new();
+    mock_tag_types_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids: &[_; 2]| ids == &[
+            TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+            TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
+        ])
+        .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
+
+    let service = TagsService::new(mock_tags_repository, mock_tag_types_repository);
+    let actual = service.get_tag_types_by_ids([
+        TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+        TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
+    ]).await.unwrap_err();
+
+    assert_matches!(actual.kind(), ErrorKind::Other);
+}
+
+#[tokio::test]
 async fn update_tag_by_id_succeeds() {
     let mut mock_tags_repository = MockTagsRepository::new();
     mock_tags_repository

--- a/api/crates/graphql/src/query.rs
+++ b/api/crates/graphql/src/query.rs
@@ -337,4 +337,13 @@ where
         let tag_types = tags_service.get_tag_types().await?;
         Ok(tag_types.into_iter().map(Into::into).collect())
     }
+
+    async fn tag_types(&self, ctx: &Context<'_>, ids: Vec<Uuid>) -> Result<Vec<TagType>> {
+        let tags_service = ctx.data_unchecked::<TagsService>();
+
+        let ids: Map<_, _, _> = ids.into_iter().map(Into::into);
+
+        let tag_types = tags_service.get_tag_types_by_ids(ids).await?;
+        Ok(tag_types.into_iter().map(Into::into).collect())
+    }
 }

--- a/api/crates/graphql/src/query.rs
+++ b/api/crates/graphql/src/query.rs
@@ -209,6 +209,15 @@ where
         }
     }
 
+    async fn sources(&self, ctx: &Context<'_>, ids: Vec<Uuid>) -> Result<Vec<Source>> {
+        let media_service = ctx.data_unchecked::<MediaService>();
+
+        let ids: Map<_, _, _> = ids.into_iter().map(Into::into);
+
+        let sources = media_service.get_sources_by_ids(ids).await?;
+        sources.into_iter().map(|source| source.try_into().map_err(Error::new)).collect()
+    }
+
     async fn source(&self, ctx: &Context<'_>, external_service_id: Uuid, external_metadata: ExternalMetadata) -> Result<Option<Source>> {
         let media_service = ctx.data_unchecked::<MediaService>();
 

--- a/api/crates/graphql/tests/sources.rs
+++ b/api/crates/graphql/tests/sources.rs
@@ -1,0 +1,141 @@
+use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
+use chrono::{TimeZone, Utc};
+use domain::{
+    entity::{
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        sources::{Source, SourceId},
+    },
+    service::{
+        external_services::MockExternalServicesServiceInterface,
+        media::MockMediaServiceInterface,
+        tags::MockTagsServiceInterface,
+    },
+};
+use futures::future::ok;
+use graphql::query::Query;
+use indoc::indoc;
+use normalizer::MockNormalizerInterface;
+use pretty_assertions::assert_eq;
+use uuid::{uuid, Uuid};
+
+// Concrete type is required both in implementation and expectation.
+type IntoIterMap<T, U> = std::iter::Map<std::vec::IntoIter<T>, fn(T) -> U>;
+
+#[tokio::test]
+async fn succeeds() {
+    let external_services_service = MockExternalServicesServiceInterface::new();
+    let mut media_service = MockMediaServiceInterface::new();
+    media_service
+        .expect_get_sources_by_ids::<IntoIterMap<Uuid, SourceId>>()
+        .times(1)
+        .withf(|ids| ids.clone().eq([
+            SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+        ]))
+        .returning(|_| {
+            Box::pin(ok(vec![
+                Source {
+                    id: SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
+                        slug: "x".to_string(),
+                        kind: "x".to_string(),
+                        name: "X".to_string(),
+                        base_url: Some("https://x.com".to_string()),
+                        url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) },
+                    created_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 0).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2016, 5, 4, 7, 5, 1).unwrap(),
+                },
+                Source {
+                    id: SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
+                    external_service: ExternalService {
+                        id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                        slug: "pixiv".to_string(),
+                        kind: "pixiv".to_string(),
+                        name: "pixiv".to_string(),
+                        base_url: Some("https://www.pixiv.net".to_string()),
+                        url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+                    },
+                    external_metadata: ExternalMetadata::Pixiv { id: 56736941 },
+                    created_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 0).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2016, 5, 6, 5, 14, 1).unwrap(),
+                },
+            ]))
+        });
+
+    let tags_service = MockTagsServiceInterface::new();
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface, MockNormalizerInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
+    let req = indoc! {r#"
+        query {
+            sources(ids: ["11111111-1111-1111-1111-111111111111", "22222222-2222-2222-2222-222222222222"]) {
+                id
+                externalService {
+                    id
+                    slug
+                    kind
+                    name
+                    baseUrl
+                    urlPattern
+                }
+                externalMetadata
+                url
+                createdAt
+                updatedAt
+            }
+        }
+    "#};
+
+    let actual = schema.execute(req).await.into_result().unwrap();
+
+    assert_eq!(actual.data, value!({
+        "sources": [
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "externalService": {
+                    "id": "33333333-3333-3333-3333-333333333333",
+                    "slug": "x",
+                    "kind": "x",
+                    "name": "X",
+                    "baseUrl": "https://x.com",
+                    "urlPattern": r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$",
+                },
+                "externalMetadata": {
+                    "x": {
+                        "id": "727620202049900544",
+                        "creatorId": "_namori_",
+                    },
+                },
+                "url": "https://x.com/_namori_/status/727620202049900544",
+                "createdAt": "2016-05-04T07:05:00+00:00",
+                "updatedAt": "2016-05-04T07:05:01+00:00",
+            },
+            {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "externalService": {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "slug": "pixiv",
+                    "kind": "pixiv",
+                    "name": "pixiv",
+                    "baseUrl": "https://www.pixiv.net",
+                    "urlPattern": r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$",
+                },
+                "externalMetadata": {
+                    "pixiv": {
+                        "id": "56736941",
+                    },
+                },
+                "url": "https://www.pixiv.net/artworks/56736941",
+                "createdAt": "2016-05-06T05:14:00+00:00",
+                "updatedAt": "2016-05-06T05:14:01+00:00",
+            },
+        ],
+    }));
+}

--- a/api/crates/graphql/tests/tag_types.rs
+++ b/api/crates/graphql/tests/tag_types.rs
@@ -1,0 +1,85 @@
+use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
+use domain::{
+    entity::tag_types::{TagType, TagTypeId},
+    service::{
+        external_services::MockExternalServicesServiceInterface,
+        media::MockMediaServiceInterface,
+        tags::MockTagsServiceInterface,
+    },
+};
+use futures::future::ok;
+use graphql::query::Query;
+use indoc::indoc;
+use normalizer::MockNormalizerInterface;
+use pretty_assertions::assert_eq;
+use uuid::{uuid, Uuid};
+
+// Concrete type is required both in implementation and expectation.
+type IntoIterMap<T, U> = std::iter::Map<std::vec::IntoIter<T>, fn(T) -> U>;
+
+#[tokio::test]
+async fn succeeds() {
+    let external_services_service = MockExternalServicesServiceInterface::new();
+    let media_service = MockMediaServiceInterface::new();
+
+    let mut tags_service = MockTagsServiceInterface::new();
+    tags_service
+        .expect_get_tag_types_by_ids::<IntoIterMap<Uuid, TagTypeId>>()
+        .times(1)
+        .withf(|ids| ids.clone().eq([
+            TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+            TagTypeId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        ]))
+        .returning(|_| {
+            Box::pin(ok(vec![
+                TagType {
+                    id: TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
+                    slug: "character".to_string(),
+                    name: "キャラクター".to_string(),
+                    kana: "キャラクター".to_string(),
+                },
+                TagType {
+                    id: TagTypeId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+                    slug: "work".to_string(),
+                    name: "作品".to_string(),
+                    kana: "さくひん".to_string(),
+                },
+            ]))
+        });
+
+    let query = Query::<MockExternalServicesServiceInterface, MockMediaServiceInterface, MockTagsServiceInterface, MockNormalizerInterface>::new();
+    let schema = Schema::build(query, EmptyMutation, EmptySubscription)
+        .data(external_services_service)
+        .data(media_service)
+        .data(tags_service)
+        .finish();
+
+    let req = indoc! {r#"
+        query {
+            tagTypes(ids: ["44444444-4444-4444-4444-444444444444", "66666666-6666-6666-6666-666666666666"]) {
+                id
+                slug
+                name
+                kana
+            }
+        }
+    "#};
+    let actual = schema.execute(req).await.into_result().unwrap();
+
+    assert_eq!(actual.data, value!({
+        "tagTypes": [
+            {
+                "id": "44444444-4444-4444-4444-444444444444",
+                "slug": "character",
+                "name": "キャラクター",
+                "kana": "キャラクター",
+            },
+            {
+                "id": "66666666-6666-6666-6666-666666666666",
+                "slug": "work",
+                "name": "作品",
+                "kana": "さくひん",
+            },
+        ],
+    }))
+}

--- a/api/crates/postgres/tests/sources-fetch_by_ids.rs
+++ b/api/crates/postgres/tests/sources-fetch_by_ids.rs
@@ -1,0 +1,57 @@
+use chrono::{TimeZone, Utc};
+use domain::{
+    entity::{
+        external_services::{ExternalService, ExternalServiceId, ExternalMetadata},
+        sources::{Source, SourceId},
+    },
+    repository::sources::SourcesRepository,
+};
+use postgres::sources::PostgresSourcesRepository;
+use pretty_assertions::assert_eq;
+use test_context::test_context;
+use uuid::uuid;
+
+mod common;
+use common::DatabaseContext;
+
+#[test_context(DatabaseContext)]
+#[tokio::test]
+#[cfg_attr(not(feature = "test-postgres"), ignore)]
+async fn succeeds(ctx: &DatabaseContext) {
+    let repository = PostgresSourcesRepository::new(ctx.pool.clone());
+    let actual = repository.fetch_by_ids([
+        SourceId::from(uuid!("76a94241-1736-4823-bb59-bef097c687e1")),
+        SourceId::from(uuid!("94055dd8-7a22-4137-b8eb-3a374df5e5d1")),
+    ]).await.unwrap();
+
+    assert_eq!(actual, vec![
+        Source {
+            id: SourceId::from(uuid!("94055dd8-7a22-4137-b8eb-3a374df5e5d1")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
+                slug: "pixiv".to_string(),
+                kind: "pixiv".to_string(),
+                name: "pixiv".to_string(),
+                base_url: Some("https://www.pixiv.net".to_string()),
+                url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+            },
+            external_metadata: ExternalMetadata::Pixiv { id: 8888888 },
+            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 8).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 14).unwrap(),
+        },
+        Source {
+            id: SourceId::from(uuid!("76a94241-1736-4823-bb59-bef097c687e1")),
+            external_service: ExternalService {
+                id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
+                slug: "x".to_string(),
+                kind: "x".to_string(),
+                name: "X".to_string(),
+                base_url: Some("https://x.com".to_string()),
+                url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
+            },
+            external_metadata: ExternalMetadata::X { id: 222222222222, creator_id: None },
+            created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 14).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 15).unwrap(),
+        },
+    ]);
+}

--- a/api/crates/postgres/tests/tag_types-fetch_by_ids.rs
+++ b/api/crates/postgres/tests/tag_types-fetch_by_ids.rs
@@ -1,0 +1,37 @@
+use domain::{
+    entity::tag_types::{TagType, TagTypeId},
+    repository::tag_types::TagTypesRepository,
+};
+use postgres::tag_types::PostgresTagTypesRepository;
+use pretty_assertions::assert_eq;
+use test_context::test_context;
+use uuid::uuid;
+
+mod common;
+use common::DatabaseContext;
+
+#[test_context(DatabaseContext)]
+#[tokio::test]
+#[cfg_attr(not(feature = "test-postgres"), ignore)]
+async fn succeeds(ctx: &DatabaseContext) {
+    let repository = PostgresTagTypesRepository::new(ctx.pool.clone());
+    let actual = repository.fetch_by_ids([
+        TagTypeId::from(uuid!("67738231-9b3a-4f45-94dc-1ba302e50e38")),
+        TagTypeId::from(uuid!("1e5021f0-d8ef-4859-815a-747bf3175724")),
+    ]).await.unwrap();
+
+    assert_eq!(actual, vec![
+        TagType {
+            id: TagTypeId::from(uuid!("67738231-9b3a-4f45-94dc-1ba302e50e38")),
+            slug: "character".to_string(),
+            name: "キャラクター".to_string(),
+            kana: "キャラクター".to_string(),
+        },
+        TagType {
+            id: TagTypeId::from(uuid!("1e5021f0-d8ef-4859-815a-747bf3175724")),
+            slug: "work".to_string(),
+            name: "作品".to_string(),
+            kana: "さくひん".to_string(),
+        },
+    ]);
+}

--- a/schema/hoarder.gql
+++ b/schema/hoarder.gql
@@ -183,12 +183,14 @@ type Query {
 	media(ids: [UUID!]!): [Medium!]!
 	replica(originalUrl: String!): Replica!
 	allSourcesLike(externalMetadataLike: ExternalMetadataLikeInput!): [Source!]!
+	sources(ids: [UUID!]!): [Source!]!
 	source(externalServiceId: UUID!, externalMetadata: ExternalMetadataInput!): Source
 	objects(prefix: String!, kind: ObjectKind): [ObjectEntry!]!
 	allTags(root: Boolean! = false, after: String, before: String, first: Int, last: Int): TagConnection!
 	allTagsLike(nameOrAliasLike: String!): [Tag!]!
 	tags(ids: [UUID!]!): [Tag!]!
 	allTagTypes: [TagType!]!
+	tagTypes(ids: [UUID!]!): [TagType!]!
 }
 
 type Replica {


### PR DESCRIPTION
This PR adds query APIs in GraphQL: `sources` and `tagTypes`, which allow to retrieve entities by their IDs.