### PR TITLE
Use flex-grow for vertical alignment

### DIFF
--- a/ui/src/app/global.scss
+++ b/ui/src/app/global.scss
@@ -2,6 +2,11 @@
   scroll-padding-top: 64px;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 body {
   overflow-x: hidden;
 

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -26,11 +26,11 @@ const RootLayout: FunctionComponent<RootLayoutProps> = ({
       <LocalizationWrapper>
         <ApolloWrapper>
           <ThemeRegistry>
-            <Grid container>
+            <Grid container direction="column" height="100%" flexWrap="nowrap">
               <Grid size={12}>
                 <Header />
               </Grid>
-              <Grid size={12}>
+              <Grid size={12} flexGrow={1}>
                 {children}
               </Grid>
             </Grid>

--- a/ui/src/components/Content/index.tsx
+++ b/ui/src/components/Content/index.tsx
@@ -9,12 +9,10 @@ const Content: FunctionComponent<ContentProps> = ({
   children,
   ...props
 }) => (
-  <Grid container>
-    <Grid className={styles.main} {...props}>
-      <Toolbar />
-      <main>
-        {children}
-      </main>
+  <Grid className={styles.content} container direction="column" {...props}>
+    <Toolbar />
+    <Grid component="main" container direction="column" flexGrow={1}>
+      {children}
     </Grid>
   </Grid>
 )

--- a/ui/src/components/Content/styles.module.scss
+++ b/ui/src/components/Content/styles.module.scss
@@ -1,3 +1,5 @@
-.main {
-  flex-grow: 1;
+.content {
+  &:global(.MuiGrid2-root) {
+    height: 100%;
+  }
 }

--- a/ui/src/components/MediumItem/index.tsx
+++ b/ui/src/components/MediumItem/index.tsx
@@ -3,10 +3,12 @@ import Container from '@mui/material/Container'
 
 import MediumItemView from '@/components/MediumItemView'
 
+import styles from './styles.module.scss'
+
 const MediumItem: FunctionComponent<MediumItemProps> = ({
   id,
 }) => (
-  <Container>
+  <Container className={styles.container}>
     <MediumItemView id={id} />
   </Container>
 )

--- a/ui/src/components/MediumItem/styles.module.scss
+++ b/ui/src/components/MediumItem/styles.module.scss
@@ -1,0 +1,6 @@
+.container {
+  &:global(.MuiContainer-root) {
+    display: flex;
+    flex-grow: 1;
+  }
+}

--- a/ui/src/components/MediumItemView/index.tsx
+++ b/ui/src/components/MediumItemView/index.tsx
@@ -3,25 +3,20 @@
 import type { FunctionComponent } from 'react'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import Stack from '@mui/material/Stack'
 
 import type { MediumItemViewBodyProps } from '@/components/MediumItemViewBody'
 import MediumItemViewBody from '@/components/MediumItemViewBody'
 import MediumItemViewError from '@/components/MediumItemViewError'
 import MediumItemViewLoading from '@/components/MediumItemViewLoading'
 
-import styles from './styles.module.scss'
-
 const MediumItemView: FunctionComponent<MediumItemViewProps> = ({
   ...props
 }) => (
-  <Stack className={styles.container}>
-    <ErrorBoundary fallback={<MediumItemViewError />}>
-      <Suspense fallback={<MediumItemViewLoading />}>
-        <MediumItemViewBody {...props} />
-      </Suspense>
-    </ErrorBoundary>
-  </Stack>
+  <ErrorBoundary fallback={<MediumItemViewError />}>
+    <Suspense fallback={<MediumItemViewLoading />}>
+      <MediumItemViewBody {...props} />
+    </Suspense>
+  </ErrorBoundary>
 )
 
 export type MediumItemViewProps = MediumItemViewBodyProps

--- a/ui/src/components/MediumItemView/styles.module.scss
+++ b/ui/src/components/MediumItemView/styles.module.scss
@@ -1,5 +1,0 @@
-.container {
-  &:global(.MuiStack-root) {
-    min-height: calc(100vh - 64px);
-  }
-}

--- a/ui/src/components/MediumList/index.tsx
+++ b/ui/src/components/MediumList/index.tsx
@@ -3,10 +3,12 @@ import Container from '@mui/material/Container'
 
 import MediumListView from '@/components/MediumListView'
 
+import styles from './styles.module.scss'
+
 const MediumList: FunctionComponent<MediumListProps> = ({
   number,
 }) => (
-  <Container disableGutters>
+  <Container className={styles.container} disableGutters>
     <MediumListView number={number} />
   </Container>
 )

--- a/ui/src/components/MediumList/styles.module.scss
+++ b/ui/src/components/MediumList/styles.module.scss
@@ -1,0 +1,6 @@
+.container {
+  &:global(.MuiContainer-root) {
+    display: flex;
+    flex-grow: 1;
+  }
+}

--- a/ui/src/components/MediumListView/index.tsx
+++ b/ui/src/components/MediumListView/index.tsx
@@ -3,25 +3,20 @@
 import type { FunctionComponent } from 'react'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
-import Stack from '@mui/material/Stack'
 
 import type { MediumListViewBodyProps } from '@/components/MediumListViewBody'
 import MediumListViewBody from '@/components/MediumListViewBody'
 import MediumListViewError from '@/components/MediumListViewError'
 import MediumListViewLoading from '@/components/MediumListViewLoading'
 
-import styles from './styles.module.scss'
-
 const MediumListView: FunctionComponent<MediumListViewProps> = ({
   ...props
 }) => (
-  <Stack className={styles.container}>
-    <ErrorBoundary fallback={<MediumListViewError />}>
-      <Suspense fallback={<MediumListViewLoading />}>
-        <MediumListViewBody {...props} />
-      </Suspense>
-    </ErrorBoundary>
-  </Stack>
+  <ErrorBoundary fallback={<MediumListViewError />}>
+    <Suspense fallback={<MediumListViewLoading />}>
+      <MediumListViewBody {...props} />
+    </Suspense>
+  </ErrorBoundary>
 )
 
 export type MediumListViewProps = MediumListViewBodyProps

--- a/ui/src/components/MediumListView/styles.module.scss
+++ b/ui/src/components/MediumListView/styles.module.scss
@@ -1,5 +1,0 @@
-.container {
-  &:global(.MuiStack-root) {
-    min-height: calc(100vh - 64px);
-  }
-}


### PR DESCRIPTION
This PR updates layout by using `flex-grow: 1` to completely get rid of `min-height: calc(100vh - 64px);`.