### PR TITLE
Fix alignment of items in media view

### DIFF
--- a/ui/src/components/MediumListViewBody/index.tsx
+++ b/ui/src/components/MediumListViewBody/index.tsx
@@ -34,7 +34,7 @@ const MediumListViewBody: FunctionComponent<MediumListViewBodyProps> = ({
   }, [ fetchMore ])
 
   return media.length ? (
-    <Stack>
+    <Stack flexGrow={1}>
       <ImageList className={styles.container} gap={40}>
         {media.map(medium => (
           <MediumListItem key={medium.id} medium={medium} size={160} />


### PR DESCRIPTION
This PR fixes alignment of items in media view where they were not centralized when all media were portrait.