### PR TITLE
Fix a bug on OBJECT_ALREADY_EXISTS error not having metadata

### DIFF
--- a/api/crates/domain/src/entity/objects.rs
+++ b/api/crates/domain/src/entity/objects.rs
@@ -22,9 +22,9 @@ pub struct Entry {
 #[derive(Clone, Constructor, Debug, Eq, PartialEq)]
 pub struct EntryMetadata {
     pub size: u64,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-    pub accessed_at: DateTime<Utc>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub accessed_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/api/crates/domain/tests/media.rs
+++ b/api/crates/domain/tests/media.rs
@@ -340,9 +340,9 @@ async fn create_replica_from_url_succeeds() {
                     EntryKind::Object,
                     Some(EntryMetadata::new(
                         4096,
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap(),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                     )),
                 ),
                 Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),
@@ -437,9 +437,9 @@ async fn create_replica_from_content_succeeds() {
                 EntryKind::Object,
                 Some(EntryMetadata::new(
                     4096,
-                    Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
-                    Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap(),
-                    Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap(),
+                    Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                    Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                    Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                 )),
             )))
         });
@@ -535,9 +535,9 @@ async fn create_replica_fails() {
                     EntryKind::Object,
                     Some(EntryMetadata::new(
                         4096,
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap(),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                     )),
                 ),
                 Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),
@@ -2135,9 +2135,9 @@ async fn update_replica_by_id_from_url_succeeds() {
                     EntryKind::Object,
                     Some(EntryMetadata::new(
                         4096,
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap(),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                     )),
                 ),
                 Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),
@@ -2233,9 +2233,9 @@ async fn update_replica_by_id_from_content_succeeds() {
                     EntryKind::Object,
                     Some(EntryMetadata::new(
                         4096,
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap(),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                     )),
                 ),
             ))
@@ -2332,9 +2332,9 @@ async fn update_replica_by_id_fails() {
                     EntryKind::Object,
                     Some(EntryMetadata::new(
                         4096,
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap(),
-                        Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap(),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                     )),
                 ),
                 Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),

--- a/api/crates/graphql/src/objects.rs
+++ b/api/crates/graphql/src/objects.rs
@@ -15,9 +15,9 @@ pub(crate) struct ObjectEntry {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ObjectEntryMetadata {
     size: u64,
-    created_at: DateTime<Utc>,
-    updated_at: DateTime<Utc>,
-    accessed_at: DateTime<Utc>,
+    created_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
+    accessed_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Enum, Copy, Clone, Debug, Eq, PartialEq, Serialize)]

--- a/schema/hoarder.gql
+++ b/schema/hoarder.gql
@@ -138,9 +138,9 @@ type ObjectEntry {
 
 type ObjectEntryMetadata {
 	size: Int!
-	createdAt: DateTime!
-	updatedAt: DateTime!
-	accessedAt: DateTime!
+	createdAt: DateTime
+	updatedAt: DateTime
+	accessedAt: DateTime
 }
 
 enum ObjectKind {

--- a/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
@@ -42,10 +42,14 @@ const MediumItemFileOverwriteDialogBody: FunctionComponent<MediumItemFileOverwri
                 </Image>
                 <Stack>
                   <Typography component="strong" fontWeight="bold">{existing.name}</Typography>
-                  <Typography className={styles.description}>サイズ: {filesize(existing.size)}</Typography>
-                  <Typography className={styles.description}>
-                    更新日時: <DateTime date={existing.lastModified} format="Pp" />
-                  </Typography>
+                  {typeof existing.size === 'number' ? (
+                    <Typography className={styles.description}>サイズ: {filesize(existing.size)}</Typography>
+                  ) : null}
+                  {existing.lastModified ? (
+                    <Typography className={styles.description}>
+                      更新日時: <DateTime date={existing.lastModified} format="Pp" />
+                    </Typography>
+                  ) : null}
                 </Stack>
               </Stack>
             </Stack>
@@ -86,8 +90,8 @@ export interface MediumItemFileOverwriteDialogBodyProps {
   }
   existing: {
     name: string
-    size: number
-    lastModified: Date
+    size: number | null
+    lastModified: Date | null
     url: string
   } | null
   overwrite: () => void

--- a/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
@@ -141,8 +141,8 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
         const entry = objectAlreadyExists.extensions.details.data.entry
         const existing = entry ? {
           name: entry.name,
-          size: entry.metadata.size,
-          lastModified: new Date(entry.metadata.updatedAt),
+          size: entry.metadata?.size ?? null,
+          lastModified: entry.metadata?.updatedAt ? new Date(entry.metadata.updatedAt) : null,
           url: (() => {
             const url = new URL('/objects', location.href)
             url.searchParams.set('url', entry.url)
@@ -375,8 +375,8 @@ interface ReplicaUploadOverwrite {
 
 interface ReplicaUploadOverwritingFile {
   name: string
-  size: number
-  lastModified: Date
+  size: number | null
+  lastModified: Date | null
   url: string
 }
 

--- a/ui/src/hooks/useError/ObjectAlreadyExists.ts
+++ b/ui/src/hooks/useError/ObjectAlreadyExists.ts
@@ -14,10 +14,10 @@ export interface ObjectAlreadyExists extends GraphQLError {
           kind: string
           metadata: {
             size: number
-            createdAt: string
-            updatedAt: string
-            accessedAt: string
-          }
+            createdAt: string | null
+            updatedAt: string | null
+            accessedAt: string | null
+          } | null
         } | null
       }
     }


### PR DESCRIPTION
This PR fixes API to include metadata of objects as long as they are available (some filesystems in WSL do not support `btime`) and fixes UI to handle them correctly.