### PR TITLE
Enable browser source maps on production

### DIFF
--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -22,6 +22,7 @@ const getRemotePatterns = env => {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  productionBrowserSourceMaps: true,
   reactStrictMode: true,
   experimental: {
     proxyTimeout: 300_000,


### PR DESCRIPTION
This PR enables sources maps on production as well. This should help analyze runtime errors when they occur.