### PR TITLE
Remove PUBLIC_URL from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ $ hoarder migration [OPTIONS] (apply | drop | list | revert)
 The following environment variables can be used to configure UI:
 
 - `API_URL`: URL for API (**required**)
-- `PUBLIC_URL`: Public URL for UI (**required**)
 - `BASE_URL`: Base URL for UI (**required**)
 
 ## Testing

--- a/compose.yaml
+++ b/compose.yaml
@@ -60,13 +60,13 @@ services:
 
   database:
     image: postgres:17.2
+    ports:
+      - '5432:5432'
     environment:
       PGUSER: hoarder
       POSTGRES_DB: hoarder
       POSTGRES_USER: hoarder
       POSTGRES_PASSWORD: hoarder
-    ports:
-      - '5432:5432'
     volumes:
       - type: volume
         source: database

--- a/compose.yaml
+++ b/compose.yaml
@@ -52,7 +52,6 @@ services:
     environment:
       PORT: '3000'
       API_URL: http://api:8080
-      PUBLIC_URL: http://localhost:3000
       BASE_URL: http://localhost:3000
     volumes:
       - type: bind

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -19,7 +19,6 @@ COPY . ./
 RUN --mount=type=bind,from=schema,target=/usr/schema \
     yarn codegen
 ENV API_URL=https://__HOARDER_API_URL__
-ENV PUBLIC_URL=https://__HOARDER_PUBLIC_URL__
 RUN --mount=type=tmpfs,target=/tmp \
     yarn build
 

--- a/ui/entrypoint.mjs
+++ b/ui/entrypoint.mjs
@@ -31,19 +31,8 @@ const envs = [
         throw new Error('API_URL must be set')
       }
       return s.replace(
-        /https?:\/\/__HOARDER_API_URL__/giu,
+        /https:\/\/__HOARDER_API_URL__/giu,
         process.env.API_URL,
-      )
-    },
-  },
-  {
-    substitute(s) {
-      if (!process.env.PUBLIC_URL) {
-        throw new Error('PUBLIC_URL must be set')
-      }
-      return s.replace(
-        /__HOARDER_PUBLIC_URL__/giu,
-        process.env.PUBLIC_URL.replace(/^https?:\/\//, ''),
       )
     },
   },

--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -1,25 +1,3 @@
-const getRemotePatterns = env => {
-  if (!URL.canParse(env)) {
-    return []
-  }
-
-  const { hostname, port, pathname } = new URL(env)
-  return [
-    {
-      protocol: 'http',
-      hostname,
-      port,
-      pathname: pathname.replace(/\/?$/, '/**'),
-    },
-    {
-      protocol: 'https',
-      hostname,
-      port,
-      pathname: pathname.replace(/\/?$/, '/**'),
-    },
-  ]
-}
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   productionBrowserSourceMaps: true,
@@ -29,9 +7,6 @@ const nextConfig = {
   },
   images: {
     minimumCacheTTL: 7 * 86_400,
-    remotePatterns: [
-      ...getRemotePatterns(process.env.PUBLIC_URL),
-    ],
   },
   output: 'standalone',
   rewrites: async () => [

--- a/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
@@ -37,7 +37,7 @@ const MediumItemFileOverwriteDialogBody: FunctionComponent<MediumItemFileOverwri
               <Stack spacing={2} direction="row">
                 <Image className={styles.imageWrapper}>
                   <Stack className={styles.imageWrapper} alignItems="center" justifyContent="center" flexShrink={0}>
-                    <ImageBodyNext className={styles.image} src={existing.url} fill sizes="128px" alt="" />
+                    <ImageBodyNext className={styles.image} src={existing.url} fill unoptimized alt="" />
                   </Stack>
                 </Image>
                 <Stack>


### PR DESCRIPTION
It is hardly possible for next/image to optimize images wherever it is deployed as a container:

For local, `localhost:8081` (`static`) must be resolvable from `ui` as it is the URL returned by API.
For production, `PUBLIC_URL` must be substituted **with its port number** when it starts up.

There is no way to set up that it satisfies both of them.