### PR TITLE
Publish `latest` images on push to master branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,13 +30,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/bake-action@v6
-        env:
-          TAG: ${{ github.ref_name }}
         with:
           source: .
           files: docker-bake.hcl
           push: true
           set: |
+            api.tags=ghcr.io/chitoku-k/hoarder/api:${{ github.ref_name }}
+            ui.tags=ghcr.io/chitoku-k/hoarder/ui:${{ github.ref_name }}
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
         with:
           source: .
           files: docker-bake.hcl
+          push: ${{ github.ref_name == 'master' }}
           set: |
+            api.tags=ghcr.io/chitoku-k/hoarder/api:latest
+            ui.tags=ghcr.io/chitoku-k/hoarder/ui:latest
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,17 +1,9 @@
-variable "TAG" {
-    default = "latest"
-}
-
 group "default" {
     targets = ["api", "ui"]
 }
 
 target "api" {
     context = "./api"
-    tags = [
-        "ghcr.io/chitoku-k/hoarder/api:latest",
-        "ghcr.io/chitoku-k/hoarder/api:${TAG}",
-    ]
 }
 
 target "ui" {
@@ -19,8 +11,4 @@ target "ui" {
     contexts = {
         schema = "./schema"
     }
-    tags = [
-        "ghcr.io/chitoku-k/hoarder/ui:latest",
-        "ghcr.io/chitoku-k/hoarder/ui:${TAG}",
-    ]
 }


### PR DESCRIPTION
This PR changes CI/CD to publish `latest` images on push to master branch. The `latest` tag is no longer stable.