### PR TITLE
Show an error dialog when the replica with the same original_url is already registered.

### DIFF
--- a/api/crates/domain/src/error.rs
+++ b/api/crates/domain/src/error.rs
@@ -128,7 +128,7 @@ pub enum ErrorKind {
     ReplicaNotFoundByUrl { original_url: String },
 
     #[error("the replica with the same original_url is already registered")]
-    ReplicaOriginalUrlDuplicate { original_url: String },
+    ReplicaOriginalUrlDuplicate { original_url: String, entry: Option<Box<Entry>> },
 
     #[error("the source with the same metadata is already registered")]
     SourceMetadataDuplicate { id: Option<SourceId> },

--- a/api/crates/graphql/src/error.rs
+++ b/api/crates/graphql/src/error.rs
@@ -97,7 +97,7 @@ pub(crate) enum ErrorKind {
     ReplicaNotFoundByUrl { original_url: String },
 
     #[error("the replica with the same original_url is already registered")]
-    ReplicaOriginalUrlDuplicate { original_url: String },
+    ReplicaOriginalUrlDuplicate { original_url: String, entry: Option<Box<ObjectEntry>> },
 
     #[error("the source with the same metadata is already registered")]
     SourceMetadataDuplicate { id: Option<SourceId> },
@@ -195,7 +195,10 @@ impl From<domain::error::ErrorKind> for ErrorKind {
             ObjectUrlUnsupported { url } => ErrorKind::ObjectUrlUnsupported { url },
             ReplicaNotFound { id } => ErrorKind::ReplicaNotFound { id },
             ReplicaNotFoundByUrl { original_url } => ErrorKind::ReplicaNotFoundByUrl { original_url },
-            ReplicaOriginalUrlDuplicate { original_url } => ErrorKind::ReplicaOriginalUrlDuplicate { original_url },
+            ReplicaOriginalUrlDuplicate { original_url, entry } => ErrorKind::ReplicaOriginalUrlDuplicate {
+                original_url,
+                entry: entry.map(|e| Box::new(ObjectEntry::from(*e))),
+            },
             SourceMetadataDuplicate { id } => ErrorKind::SourceMetadataDuplicate { id },
             SourceMetadataInvalid => ErrorKind::SourceMetadataInvalid,
             SourceMetadataNotMatch { kind } => ErrorKind::SourceMetadataNotMatch { kind },

--- a/api/crates/postgres/src/replicas.rs
+++ b/api/crates/postgres/src/replicas.rs
@@ -276,7 +276,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
         let mut replica = match sqlx::query_as_with::<_, PostgresReplicaRow, _>(&sql, values).fetch_one(&mut *tx).await {
             Ok(row) => Replica::from(row),
             Err(sqlx::Error::Database(e)) if e.is_foreign_key_violation() => return Err(ErrorKind::MediumNotFound { id: medium_id })?,
-            Err(sqlx::Error::Database(e)) if e.is_unique_violation() => return Err(ErrorKind::ReplicaOriginalUrlDuplicate { original_url: original_url.to_string() })?,
+            Err(sqlx::Error::Database(e)) if e.is_unique_violation() => return Err(ErrorKind::ReplicaOriginalUrlDuplicate { original_url: original_url.to_string(), entry: None })?,
             Err(e) => return Err(Error::other(e)),
         };
 
@@ -474,7 +474,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
             Ok(row) => Replica::from(row),
             Err(sqlx::Error::Database(e)) if e.is_unique_violation() => {
                 if let Some(original_url) = original_url {
-                    return Err(ErrorKind::ReplicaOriginalUrlDuplicate { original_url: original_url.to_string() })?;
+                    return Err(ErrorKind::ReplicaOriginalUrlDuplicate { original_url: original_url.to_string(), entry: None })?;
                 }
                 return Err(Error::other(e));
             },

--- a/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
@@ -27,9 +27,15 @@ const MediumItemFileOverwriteDialogBody: FunctionComponent<MediumItemFileOverwri
   return (
     <>
       <DialogContent>
-        <DialogContentText>
-          同じファイル名のメディアを置き換えますか？
-        </DialogContentText>
+        {overwrite ? (
+          <DialogContentText>
+            同じファイル名のメディアを置き換えますか？
+          </DialogContentText>
+        ) : (
+          <DialogContentText>
+            同じファイル名のメディアがすでに登録されています
+          </DialogContentText>
+        )}
         <Stack className={styles.files} spacing={2}>
           {existing ? (
             <Stack spacing={1}>
@@ -73,10 +79,16 @@ const MediumItemFileOverwriteDialogBody: FunctionComponent<MediumItemFileOverwri
           </Stack>
         </Stack>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={close} autoFocus>キャンセル</Button>
-        <Button onClick={overwrite}>置き換える</Button>
-      </DialogActions>
+      {overwrite ? (
+        <DialogActions>
+          <Button onClick={close} autoFocus>キャンセル</Button>
+          <Button onClick={overwrite}>置き換える</Button>
+        </DialogActions>
+      ) : (
+        <DialogActions>
+          <Button onClick={close} autoFocus>閉じる</Button>
+        </DialogActions>
+      )}
     </>
   )
 }
@@ -94,7 +106,7 @@ export interface MediumItemFileOverwriteDialogBodyProps {
     lastModified: Date | null
     url: string
   } | null
-  overwrite: () => void
+  overwrite?: () => void
   close: () => void
 }
 

--- a/ui/src/components/MediumItemFileUploadDialogBodyItem/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBodyItem/index.tsx
@@ -14,7 +14,7 @@ import CloudUploadOutlinedIcon from '@mui/icons-material/CloudUploadOutlined'
 
 import Image from '@/components/Image'
 import ImageBodyBlob from '@/components/ImageBodyBlob'
-import { MEDIUM_REPLICA_DECODE_FAILED, MEDIUM_REPLICA_UNSUPPORTED, useError, useFilesize } from '@/hooks'
+import { MEDIUM_REPLICA_DECODE_FAILED, MEDIUM_REPLICA_UNSUPPORTED, REPLICA_ORIGINAL_URL_DUPLICATE, useError, useFilesize } from '@/hooks'
 import type { ReplicaUploadProgress, ReplicaUploadStatus } from '@/components/MediumItemFileUploadDialogBody'
 import type { ReplicaCreate } from '@/components/MediumItemImageEdit'
 
@@ -37,6 +37,7 @@ const MediumItemFileUploadDialogBodyItem: FunctionComponent<MediumItemFileUpload
 
   const mediumReplicaDecodeFailed = graphQLError(error, MEDIUM_REPLICA_DECODE_FAILED)
   const mediumReplicaUnsupported = graphQLError(error, MEDIUM_REPLICA_UNSUPPORTED)
+  const replicaOriginalUrlDuplicate = graphQLError(error, REPLICA_ORIGINAL_URL_DUPLICATE)
 
   return (
     <>
@@ -103,6 +104,8 @@ const MediumItemFileUploadDialogBodyItem: FunctionComponent<MediumItemFileUpload
                   <Typography>エラー: メディアが読み込めません</Typography>
                 ) : mediumReplicaUnsupported ? (
                   <Typography>エラー: サポートされていません</Typography>
+                ) : replicaOriginalUrlDuplicate ? (
+                  <Typography>エラー: 登録済みのメディア</Typography>
                 ) : (
                   <Typography>エラー</Typography>
                 )}

--- a/ui/src/hooks/useError/ReplicaOriginalUrlDuplicate.ts
+++ b/ui/src/hooks/useError/ReplicaOriginalUrlDuplicate.ts
@@ -8,6 +8,17 @@ export interface ReplicaOriginalUrlDuplicate extends GraphQLError {
       code: typeof REPLICA_ORIGINAL_URL_DUPLICATE
       data: {
         originalUrl: string
+        entry: {
+          name: string
+          url: string
+          kind: string
+          metadata: {
+            size: number
+            createdAt: string | null
+            updatedAt: string | null
+            accessedAt: string | null
+          } | null
+        } | null
       }
     }
   }


### PR DESCRIPTION
This PR fixes error handling when the replica with the same original_url is already registered. 