### PR TITLE
Remove `Sync` and `'static` from trait bounds for arguments

### DIFF
--- a/api/crates/domain/src/processor/media.rs
+++ b/api/crates/domain/src/processor/media.rs
@@ -9,5 +9,5 @@ pub trait MediumImageProcessor: Send + Sync + 'static {
     /// Generates a thumbnail for image on the given path.
     fn generate_thumbnail<R>(&self, read: R) -> impl Future<Output = Result<(OriginalImage, ThumbnailImage)>> + Send
     where
-        R: BufRead + Seek + Send + 'static;
+        for<'a> R: BufRead + Seek + Send + 'a;
 }

--- a/api/crates/domain/src/repository/external_services.rs
+++ b/api/crates/domain/src/repository/external_services.rs
@@ -13,7 +13,7 @@ pub trait ExternalServicesRepository: Send + Sync + 'static {
     /// Fetches the external services by their IDs.
     fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send
     where
-        for<'a> T: IntoIterator<Item = ExternalServiceId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = ExternalServiceId> + Send + 'a;
 
     /// Fetches all external services.
     fn fetch_all(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;

--- a/api/crates/domain/src/repository/media.rs
+++ b/api/crates/domain/src/repository/media.rs
@@ -18,13 +18,13 @@ pub trait MediaRepository: Send + Sync + 'static {
     /// Creates a medium.
     fn create<T, U>(&self, source_ids: T, created_at: Option<DateTime<Utc>>, tag_tag_type_ids: U, tag_depth: Option<TagDepth>, sources: bool) -> impl Future<Output = Result<Medium>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> U: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a;
 
     /// Fetches media by IDs.
     fn fetch_by_ids<T>(&self, ids: T, tag_depth: Option<TagDepth>, replicas: bool, sources: bool) -> impl Future<Output = Result<Vec<Medium>>> + Send
     where
-        for<'a> T: IntoIterator<Item = MediumId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = MediumId> + Send + 'a;
 
     /// Fetches media by their associated source IDs.
     fn fetch_by_source_ids<T>(
@@ -39,7 +39,7 @@ pub trait MediaRepository: Send + Sync + 'static {
         limit: u64,
     ) -> impl Future<Output = Result<Vec<Medium>>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a;
 
     /// Fetches media by their associated tag IDs.
     fn fetch_by_tag_ids<T>(
@@ -54,7 +54,7 @@ pub trait MediaRepository: Send + Sync + 'static {
         limit: u64,
     ) -> impl Future<Output = Result<Vec<Medium>>> + Send
     where
-        for<'a> T: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a;
 
     /// Fetches all media.
     fn fetch_all(
@@ -83,11 +83,11 @@ pub trait MediaRepository: Send + Sync + 'static {
         sources: bool,
     ) -> impl Future<Output = Result<Medium>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> V: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
-        for<'a> W: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
-        for<'a> X: IntoIterator<Item = ReplicaId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> U: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> V: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
+        for<'a> W: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
+        for<'a> X: IntoIterator<Item = ReplicaId> + Send + 'a;
 
     /// Deletes the medium by ID.
     fn delete_by_id(&self, id: MediumId) -> impl Future<Output = Result<DeleteResult>> + Send;

--- a/api/crates/domain/src/repository/replicas.rs
+++ b/api/crates/domain/src/repository/replicas.rs
@@ -16,7 +16,7 @@ pub trait ReplicasRepository: Send + Sync + 'static {
     /// Fetches the replicas by IDs.
     fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Replica>>> + Send
     where
-        for<'a> T: IntoIterator<Item = ReplicaId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = ReplicaId> + Send + 'a;
 
     /// Fetches the replica by its original URL.
     fn fetch_by_original_url(&self, original_url: &str) -> impl Future<Output = Result<Replica>> + Send;

--- a/api/crates/domain/src/repository/sources.rs
+++ b/api/crates/domain/src/repository/sources.rs
@@ -16,7 +16,7 @@ pub trait SourcesRepository: Send + Sync + 'static {
     /// Fetches the sources by their IDs.
     fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Source>>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a;
 
     /// Fetches the source by its external metadata.
     fn fetch_by_external_metadata(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> impl Future<Output = Result<Option<Source>>> + Send;

--- a/api/crates/domain/src/repository/tag_types.rs
+++ b/api/crates/domain/src/repository/tag_types.rs
@@ -13,7 +13,7 @@ pub trait TagTypesRepository: Send + Sync + 'static {
     /// Fetches the tag types by their IDs.
     fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<TagType>>> + Send
     where
-        for<'a> T: IntoIterator<Item = TagTypeId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = TagTypeId> + Send + 'a;
 
     /// Fetches all tag types.
     fn fetch_all(&self) -> impl Future<Output = Result<Vec<TagType>>> + Send;

--- a/api/crates/domain/src/repository/tags.rs
+++ b/api/crates/domain/src/repository/tags.rs
@@ -10,12 +10,12 @@ pub trait TagsRepository: Send + Sync + 'static {
     /// Creates a tag.
     fn create<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send
     where
-        for<'a> T: IntoIterator<Item = String> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = String> + Send + 'a;
 
     /// Fetches tags by their IDs.
     fn fetch_by_ids<T>(&self, ids: T, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send
     where
-        for<'a> T: IntoIterator<Item = TagId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = TagId> + Send + 'a;
 
     /// Fetches tags by their names like the given parameter.
     fn fetch_by_name_or_alias_like(&self, name_or_alias_like: &str, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send;
@@ -34,8 +34,8 @@ pub trait TagsRepository: Send + Sync + 'static {
         depth: TagDepth,
     ) -> impl Future<Output = Result<Tag>> + Send
     where
-        for<'a> T: IntoIterator<Item = String> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = String> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = String> + Send + 'a,
+        for<'a> U: IntoIterator<Item = String> + Send + 'a;
 
     /// Attaches the tag to the existing tag by ID.
     fn attach_by_id(&self, id: TagId, parent_id: TagId, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send;

--- a/api/crates/domain/src/service/external_services.rs
+++ b/api/crates/domain/src/service/external_services.rs
@@ -19,7 +19,7 @@ pub trait ExternalServicesServiceInterface: Send + Sync + 'static {
     /// Gets the external services by their IDs.
     fn get_external_services_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send
     where
-        for<'a> T: IntoIterator<Item = ExternalServiceId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = ExternalServiceId> + Send + 'a;
 
     /// Gets the external services and metadata by URL.
     fn get_external_services_by_url(&self, url: &str) -> impl Future<Output = Result<Vec<(ExternalService, ExternalMetadata)>>> + Send;
@@ -80,7 +80,7 @@ where
 
     async fn get_external_services_by_ids<T>(&self, ids: T) -> Result<Vec<ExternalService>>
     where
-        for<'a> T: IntoIterator<Item = ExternalServiceId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = ExternalServiceId> + Send + 'a,
     {
         match self.external_services_repository.fetch_by_ids(ids).await {
             Ok(services) => Ok(services),

--- a/api/crates/domain/src/service/media.rs
+++ b/api/crates/domain/src/service/media.rs
@@ -221,7 +221,7 @@ where
 {
     async fn generate_thumbnail_image<R>(&self, read: R) -> Result<(OriginalImage, ThumbnailImage)>
     where
-        R: BufRead + Seek + Send + 'static,
+        for<'a> R: BufRead + Seek + Send + 'a,
     {
         match self.medium_image_processor.generate_thumbnail(read).await {
             Ok((original_image, thumbnail_image)) => Ok((original_image, thumbnail_image)),

--- a/api/crates/domain/src/service/media.rs
+++ b/api/crates/domain/src/service/media.rs
@@ -45,8 +45,8 @@ pub trait MediaServiceInterface: Send + Sync + 'static {
     /// Creates a medium.
     fn create_medium<T, U>(&self, source_ids: T, created_at: Option<DateTime<Utc>>, tag_tag_type_ids: U, tag_depth: Option<TagDepth>, sources: bool) -> impl Future<Output = Result<Medium>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> U: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a;
 
     /// Creates a replica.
     fn create_replica(&self, medium_id: MediumId, medium_source: MediumSource) -> impl Future<Output = Result<Replica>> + Send;
@@ -69,7 +69,7 @@ pub trait MediaServiceInterface: Send + Sync + 'static {
     /// Gets the media by their IDs.
     fn get_media_by_ids<T>(&self, ids: T, tag_depth: Option<TagDepth>, replicas: bool, sources: bool) -> impl Future<Output = Result<Vec<Medium>>> + Send
     where
-        for<'a> T: IntoIterator<Item = MediumId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = MediumId> + Send + 'a;
 
     /// Gets the media by their source IDs.
     fn get_media_by_source_ids<T>(
@@ -84,7 +84,7 @@ pub trait MediaServiceInterface: Send + Sync + 'static {
         limit: u64,
     ) -> impl Future<Output = Result<Vec<Medium>>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a;
 
     /// Gets the media by their tag IDs.
     fn get_media_by_tag_ids<T>(
@@ -99,12 +99,12 @@ pub trait MediaServiceInterface: Send + Sync + 'static {
         limit: u64,
     ) -> impl Future<Output = Result<Vec<Medium>>> + Send
     where
-        for<'a> T: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a;
 
     /// Gets the replicas by their IDs.
     fn get_replicas_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Replica>>> + Send
     where
-        for<'a> T: IntoIterator<Item = ReplicaId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = ReplicaId> + Send + 'a;
 
     /// Gets the replica by original URL.
     fn get_replica_by_original_url(&self, original_url: &str) -> impl Future<Output = Result<Replica>> + Send;
@@ -112,7 +112,7 @@ pub trait MediaServiceInterface: Send + Sync + 'static {
     /// Gets the sourecs by their IDs.
     fn get_sources_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Source>>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a;
 
     /// Gets the source by its external metadata.
     fn get_source_by_external_metadata(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> impl Future<Output = Result<Option<Source>>> + Send;
@@ -144,11 +144,11 @@ pub trait MediaServiceInterface: Send + Sync + 'static {
         sources: bool,
     ) -> impl Future<Output = Result<Medium>> + Send
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> V: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
-        for<'a> W: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
-        for<'a> X: IntoIterator<Item = ReplicaId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> U: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> V: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
+        for<'a> W: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
+        for<'a> X: IntoIterator<Item = ReplicaId> + Send + 'a;
 
     /// Updates the replica by ID.
     fn update_replica_by_id(&self, id: ReplicaId, medium_source: MediumSource) -> impl Future<Output = Result<Replica>> + Send;
@@ -297,8 +297,8 @@ where
 {
     async fn create_medium<T, U>(&self, source_ids: T, created_at: Option<DateTime<Utc>>, tag_tag_type_ids: U, tag_depth: Option<TagDepth>, sources: bool) -> Result<Medium>
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> U: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
     {
         match self.media_repository.create(source_ids, created_at, tag_tag_type_ids, tag_depth, sources).await {
             Ok(medium) => Ok(medium),
@@ -351,7 +351,7 @@ where
 
     async fn get_media_by_ids<T>(&self, ids: T, tag_depth: Option<TagDepth>, replicas: bool, sources: bool) -> Result<Vec<Medium>>
     where
-        for<'a> T: IntoIterator<Item = MediumId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = MediumId> + Send + 'a,
     {
         match self.media_repository.fetch_by_ids(ids, tag_depth, replicas, sources).await {
             Ok(media) => Ok(media),
@@ -374,7 +374,7 @@ where
         limit: u64,
     ) -> Result<Vec<Medium>>
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
     {
         match self.media_repository.fetch_by_source_ids(source_ids, tag_depth, replicas, sources, cursor, order, direction, limit).await {
             Ok(media) => Ok(media),
@@ -397,7 +397,7 @@ where
         limit: u64,
     ) -> Result<Vec<Medium>>
     where
-        for<'a> T: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
     {
         match self.media_repository.fetch_by_tag_ids(tag_tag_type_ids, tag_depth, replicas, sources, cursor, order, direction, limit).await {
             Ok(media) => Ok(media),
@@ -410,7 +410,7 @@ where
 
     async fn get_replicas_by_ids<T>(&self, ids: T) -> Result<Vec<Replica>>
     where
-        for<'a> T: IntoIterator<Item = ReplicaId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = ReplicaId> + Send + 'a,
     {
         match self.replicas_repository.fetch_by_ids(ids).await {
             Ok(replicas) => Ok(replicas),
@@ -433,7 +433,7 @@ where
 
     async fn get_sources_by_ids<T>(&self, ids: T) -> Result<Vec<Source>>
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
     {
         match self.sources_repository.fetch_by_ids(ids).await {
             Ok(sources) => Ok(sources),
@@ -514,11 +514,11 @@ where
         sources: bool,
     ) -> Result<Medium>
     where
-        for<'a> T: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = SourceId> + Send + Sync + 'a,
-        for<'a> V: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
-        for<'a> W: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'a,
-        for<'a> X: IntoIterator<Item = ReplicaId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> U: IntoIterator<Item = SourceId> + Send + 'a,
+        for<'a> V: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
+        for<'a> W: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'a,
+        for<'a> X: IntoIterator<Item = ReplicaId> + Send + 'a,
     {
         match self.media_repository.update_by_id(id, add_source_ids, remove_source_ids, add_tag_tag_type_ids, remove_tag_tag_type_ids, replica_orders, created_at, tag_depth, replicas, sources).await {
             Ok(medium) => Ok(medium),

--- a/api/crates/domain/src/service/tags.rs
+++ b/api/crates/domain/src/service/tags.rs
@@ -15,7 +15,7 @@ pub trait TagsServiceInterface: Send + Sync + 'static {
     /// Creates a tag.
     fn create_tag<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send
     where
-        for<'a> T: IntoIterator<Item = String> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = String> + Send + 'a;
 
     /// Creates a tag type.
     fn create_tag_type(&self, slug: &str, name: &str, kana: &str) -> impl Future<Output = Result<TagType>> + Send;
@@ -34,7 +34,7 @@ pub trait TagsServiceInterface: Send + Sync + 'static {
     /// Gets the tags by their IDs.
     fn get_tags_by_ids<T>(&self, ids: T, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send
     where
-        for<'a> T: IntoIterator<Item = TagId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = TagId> + Send + 'a;
 
     /// Gets the tags by their name or alias.
     fn get_tags_by_name_or_alias_like(&self, name_or_alias_like: &str, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send;
@@ -45,13 +45,13 @@ pub trait TagsServiceInterface: Send + Sync + 'static {
     /// Gets the tag types by their IDs.
     fn get_tag_types_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<TagType>>> + Send
     where
-        for<'a> T: IntoIterator<Item = TagTypeId> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = TagTypeId> + Send + 'a;
 
     /// Updates the tag by ID.
     fn update_tag_by_id<T, U>(&self, id: TagId, name: Option<String>, kana: Option<String>, add_aliases: T, remove_aliases: U, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send
     where
-        for<'a> T: IntoIterator<Item = String> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = String> + Send + Sync + 'a;
+        for<'a> T: IntoIterator<Item = String> + Send + 'a,
+        for<'a> U: IntoIterator<Item = String> + Send + 'a;
 
     /// Updates the tag type by ID.
     fn update_tag_type_by_id(&self, id: TagTypeId, slug: Option<&str>, name: Option<&str>, kana: Option<&str>) -> impl Future<Output = Result<TagType>> + Send;
@@ -82,7 +82,7 @@ where
 {
     async fn create_tag<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> Result<Tag>
     where
-        for<'a> T: IntoIterator<Item = String> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = String> + Send + 'a,
     {
         match self.tags_repository.create(name, kana, aliases, parent_id, depth).await {
             Ok(tag) => Ok(tag),
@@ -123,7 +123,7 @@ where
 
     async fn get_tags_by_ids<T>(&self, ids: T, depth: TagDepth) -> Result<Vec<Tag>>
     where
-        for<'a> T: IntoIterator<Item = TagId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = TagId> + Send + 'a,
     {
         match self.tags_repository.fetch_by_ids(ids, depth).await {
             Ok(tags) => Ok(tags),
@@ -156,7 +156,7 @@ where
 
     async fn get_tag_types_by_ids<T>(&self, ids: T) -> Result<Vec<TagType>>
     where
-        for<'a> T: IntoIterator<Item = TagTypeId> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = TagTypeId> + Send + 'a,
     {
         match self.tag_types_repository.fetch_by_ids(ids).await {
             Ok(tag_types) => Ok(tag_types),
@@ -169,8 +169,8 @@ where
 
     async fn update_tag_by_id<T, U>(&self, id: TagId, name: Option<String>, kana: Option<String>, add_aliases: T, remove_aliases: U, depth: TagDepth) -> Result<Tag>
     where
-        for<'a> T: IntoIterator<Item = String> + Send + Sync + 'a,
-        for<'a> U: IntoIterator<Item = String> + Send + Sync + 'a,
+        for<'a> T: IntoIterator<Item = String> + Send + 'a,
+        for<'a> U: IntoIterator<Item = String> + Send + 'a,
     {
         match self.tags_repository.update_by_id(id, name, kana, add_aliases, remove_aliases, depth).await {
             Ok(tag) => Ok(tag),

--- a/api/crates/domain/tests/mocks/domain/repository/external_services/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/external_services/mod.rs
@@ -14,7 +14,7 @@ mockall::mock! {
 
         fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send
         where
-            T: IntoIterator<Item = ExternalServiceId> + Send + Sync + 'static;
+            T: IntoIterator<Item = ExternalServiceId> + Send + 'static;
 
         fn fetch_all(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;
 

--- a/api/crates/domain/tests/mocks/domain/repository/media/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/media/mod.rs
@@ -19,12 +19,12 @@ mockall::mock! {
     impl MediaRepository for MediaRepository {
         fn create<T, U>(&self, source_ids: T, created_at: Option<DateTime<Utc>>, tag_tag_type_ids: U, tag_depth: Option<TagDepth>, sources: bool) -> impl Future<Output = Result<Medium>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static,
-            U: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static,
+            U: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static;
 
         fn fetch_by_ids<T>(&self, ids: T, tag_depth: Option<TagDepth>, replicas: bool, sources: bool) -> impl Future<Output = Result<Vec<Medium>>> + Send
         where
-            T: IntoIterator<Item = MediumId> + Send + Sync + 'static;
+            T: IntoIterator<Item = MediumId> + Send + 'static;
 
         fn fetch_by_source_ids<T>(
             &self,
@@ -38,7 +38,7 @@ mockall::mock! {
             limit: u64,
         ) -> impl Future<Output = Result<Vec<Medium>>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static;
 
         fn fetch_by_tag_ids<T>(
             &self,
@@ -52,7 +52,7 @@ mockall::mock! {
             limit: u64,
         ) -> impl Future<Output = Result<Vec<Medium>>> + Send
         where
-            T: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static;
+            T: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static;
 
         fn fetch_all(
             &self,
@@ -79,11 +79,11 @@ mockall::mock! {
             sources: bool,
         ) -> impl Future<Output = Result<Medium>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static,
-            U: IntoIterator<Item = SourceId> + Send + Sync + 'static,
-            V: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static,
-            W: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static,
-            X: IntoIterator<Item = ReplicaId> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static,
+            U: IntoIterator<Item = SourceId> + Send + 'static,
+            V: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static,
+            W: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static,
+            X: IntoIterator<Item = ReplicaId> + Send + 'static;
 
         fn delete_by_id(&self, id: MediumId) -> impl Future<Output = Result<DeleteResult>> + Send;
     }

--- a/api/crates/domain/tests/mocks/domain/repository/replicas/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/replicas/mod.rs
@@ -17,7 +17,7 @@ mockall::mock! {
 
         fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Replica>>> + Send
         where
-            T: IntoIterator<Item = ReplicaId> + Send + Sync + 'static;
+            T: IntoIterator<Item = ReplicaId> + Send + 'static;
 
         fn fetch_by_original_url(&self, original_url: &str) -> impl Future<Output = Result<Replica>> + Send;
 

--- a/api/crates/domain/tests/mocks/domain/repository/sources/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/sources/mod.rs
@@ -17,7 +17,7 @@ mockall::mock! {
 
         fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Source>>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static;
 
         fn fetch_by_external_metadata(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> impl Future<Output = Result<Option<Source>>> + Send;
 

--- a/api/crates/domain/tests/mocks/domain/repository/tag_types/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/tag_types/mod.rs
@@ -14,7 +14,7 @@ mockall::mock! {
 
         fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<TagType>>> + Send
         where
-            T: IntoIterator<Item = TagTypeId> + Send + Sync + 'static;
+            T: IntoIterator<Item = TagTypeId> + Send + 'static;
 
         fn fetch_all(&self) -> impl Future<Output = Result<Vec<TagType>>> + Send;
 

--- a/api/crates/domain/tests/mocks/domain/repository/tags/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/tags/mod.rs
@@ -12,11 +12,11 @@ mockall::mock! {
     impl TagsRepository for TagsRepository {
         fn create<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send
         where
-            T: IntoIterator<Item = String> + Send + Sync + 'static;
+            T: IntoIterator<Item = String> + Send + 'static;
 
         fn fetch_by_ids<T>(&self, ids: T, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send
         where
-            T: IntoIterator<Item = TagId> + Send + Sync + 'static;
+            T: IntoIterator<Item = TagId> + Send + 'static;
 
         fn fetch_by_name_or_alias_like(&self, name_or_alias_like: &str, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send;
 
@@ -32,8 +32,8 @@ mockall::mock! {
             depth: TagDepth,
         ) -> impl Future<Output = Result<Tag>> + Send
         where
-            T: IntoIterator<Item = String> + Send + Sync + 'static,
-            U: IntoIterator<Item = String> + Send + Sync + 'static;
+            T: IntoIterator<Item = String> + Send + 'static,
+            U: IntoIterator<Item = String> + Send + 'static;
 
         fn attach_by_id(&self, id: TagId, parent_id: TagId, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send;
 

--- a/api/crates/graphql/tests/mocks/domain/service/external_services/mod.rs
+++ b/api/crates/graphql/tests/mocks/domain/service/external_services/mod.rs
@@ -17,7 +17,7 @@ mockall::mock! {
 
         fn get_external_services_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send
         where
-            T: IntoIterator<Item = ExternalServiceId> + Send + Sync + 'static;
+            T: IntoIterator<Item = ExternalServiceId> + Send + 'static;
 
         fn get_external_services_by_url(&self, url: &str) -> impl Future<Output = Result<Vec<(ExternalService, ExternalMetadata)>>> + Send;
 

--- a/api/crates/graphql/tests/mocks/domain/service/media/mod.rs
+++ b/api/crates/graphql/tests/mocks/domain/service/media/mod.rs
@@ -22,8 +22,8 @@ mockall::mock! {
     impl MediaServiceInterface for MediaServiceInterface {
         fn create_medium<T, U>(&self, source_ids: T, created_at: Option<DateTime<Utc>>, tag_tag_type_ids: U, tag_depth: Option<TagDepth>, sources: bool) -> impl Future<Output = Result<Medium>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static,
-            U: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static,
+            U: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static;
 
         fn create_replica(&self, medium_id: MediumId, medium_source: MediumSource) -> impl Future<Output = Result<Replica>> + Send;
 
@@ -42,7 +42,7 @@ mockall::mock! {
 
         fn get_media_by_ids<T>(&self, ids: T, tag_depth: Option<TagDepth>, replicas: bool, sources: bool) -> impl Future<Output = Result<Vec<Medium>>> + Send
         where
-            T: IntoIterator<Item = MediumId> + Send + Sync + 'static;
+            T: IntoIterator<Item = MediumId> + Send + 'static;
 
         fn get_media_by_source_ids<T>(
             &self,
@@ -56,7 +56,7 @@ mockall::mock! {
             limit: u64,
         ) -> impl Future<Output = Result<Vec<Medium>>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static;
 
         fn get_media_by_tag_ids<T>(
             &self,
@@ -70,17 +70,17 @@ mockall::mock! {
             limit: u64,
         ) -> impl Future<Output = Result<Vec<Medium>>> + Send
         where
-            T: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static;
+            T: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static;
 
         fn get_replicas_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Replica>>> + Send
         where
-            T: IntoIterator<Item = ReplicaId> + Send + Sync + 'static;
+            T: IntoIterator<Item = ReplicaId> + Send + 'static;
 
         fn get_replica_by_original_url(&self, original_url: &str) -> impl Future<Output = Result<Replica>> + Send;
 
         fn get_sources_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<Source>>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static;
 
         fn get_source_by_external_metadata(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> impl Future<Output = Result<Option<Source>>> + Send;
 
@@ -106,11 +106,11 @@ mockall::mock! {
             sources: bool,
         ) -> impl Future<Output = Result<Medium>> + Send
         where
-            T: IntoIterator<Item = SourceId> + Send + Sync + 'static,
-            U: IntoIterator<Item = SourceId> + Send + Sync + 'static,
-            V: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static,
-            W: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync + 'static,
-            X: IntoIterator<Item = ReplicaId> + Send + Sync + 'static;
+            T: IntoIterator<Item = SourceId> + Send + 'static,
+            U: IntoIterator<Item = SourceId> + Send + 'static,
+            V: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static,
+            W: IntoIterator<Item = (TagId, TagTypeId)> + Send + 'static,
+            X: IntoIterator<Item = ReplicaId> + Send + 'static;
 
         fn update_replica_by_id(&self, id: ReplicaId, medium_source: MediumSource) -> impl Future<Output = Result<Replica>> + Send;
 

--- a/api/crates/graphql/tests/mocks/domain/service/tags/mod.rs
+++ b/api/crates/graphql/tests/mocks/domain/service/tags/mod.rs
@@ -16,7 +16,7 @@ mockall::mock! {
     impl TagsServiceInterface for TagsServiceInterface {
         fn create_tag<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send
         where
-            T: IntoIterator<Item = String> + Send + Sync + 'static;
+            T: IntoIterator<Item = String> + Send + 'static;
 
         fn create_tag_type(&self, slug: &str, name: &str, kana: &str) -> impl Future<Output = Result<TagType>> + Send;
 
@@ -32,7 +32,7 @@ mockall::mock! {
 
         fn get_tags_by_ids<T>(&self, ids: T, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send
         where
-            T: IntoIterator<Item = TagId> + Send + Sync + 'static;
+            T: IntoIterator<Item = TagId> + Send + 'static;
 
         fn get_tags_by_name_or_alias_like(&self, name_or_alias_like: &str, depth: TagDepth) -> impl Future<Output = Result<Vec<Tag>>> + Send;
 
@@ -40,12 +40,12 @@ mockall::mock! {
 
         fn get_tag_types_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<TagType>>> + Send
         where
-            T: IntoIterator<Item = TagTypeId> + Send + Sync + 'static;
+            T: IntoIterator<Item = TagTypeId> + Send + 'static;
 
         fn update_tag_by_id<T, U>(&self, id: TagId, name: Option<String>, kana: Option<String>, add_aliases: T, remove_aliases: U, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send
         where
-            T: IntoIterator<Item = String> + Send + Sync + 'static,
-            U: IntoIterator<Item = String> + Send + Sync + 'static;
+            T: IntoIterator<Item = String> + Send + 'static,
+            U: IntoIterator<Item = String> + Send + 'static;
 
         fn update_tag_type_by_id<'a>(&self, id: TagTypeId, slug: Option<&'a str>, name: Option<&'a str>, kana: Option<&'a str>) -> impl Future<Output = Result<TagType>> + Send;
 

--- a/api/crates/postgres/src/external_services.rs
+++ b/api/crates/postgres/src/external_services.rs
@@ -97,7 +97,7 @@ impl ExternalServicesRepository for PostgresExternalServicesRepository {
 
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<ExternalService>>
     where
-        T: IntoIterator<Item = ExternalServiceId> + Send + Sync,
+        T: IntoIterator<Item = ExternalServiceId> + Send,
     {
         let (sql, values) = Query::select()
             .columns([

--- a/api/crates/postgres/src/media.rs
+++ b/api/crates/postgres/src/media.rs
@@ -420,8 +420,8 @@ async fn eager_load(conn: &mut PgConnection, media: &mut [Medium], tag_depth: Op
 impl MediaRepository for PostgresMediaRepository {
     async fn create<T, U>(&self, source_ids: T, created_at: Option<DateTime<Utc>>, tag_tag_type_ids: U, tag_depth: Option<TagDepth>, sources: bool) -> Result<Medium>
     where
-        T: IntoIterator<Item = SourceId> + Send + Sync,
-        U: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync,
+        T: IntoIterator<Item = SourceId> + Send,
+        U: IntoIterator<Item = (TagId, TagTypeId)> + Send,
     {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 
@@ -532,7 +532,7 @@ impl MediaRepository for PostgresMediaRepository {
 
     async fn fetch_by_ids<T>(&self, ids: T, tag_depth: Option<TagDepth>, replicas: bool, sources: bool) -> Result<Vec<Medium>>
     where
-        T: IntoIterator<Item = MediumId> + Send + Sync,
+        T: IntoIterator<Item = MediumId> + Send,
     {
         let mut conn = self.pool.acquire().await.map_err(Error::other)?;
 
@@ -570,7 +570,7 @@ impl MediaRepository for PostgresMediaRepository {
         limit: u64,
     ) -> Result<Vec<Medium>>
     where
-        T: IntoIterator<Item = SourceId> + Send + Sync,
+        T: IntoIterator<Item = SourceId> + Send,
     {
         let mut conn = self.pool.acquire().await.map_err(Error::other)?;
 
@@ -639,7 +639,7 @@ impl MediaRepository for PostgresMediaRepository {
         limit: u64,
     ) -> Result<Vec<Medium>>
     where
-        T: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync,
+        T: IntoIterator<Item = (TagId, TagTypeId)> + Send,
     {
         let tag_tag_type_ids: Vec<_> = tag_tag_type_ids
             .into_iter()
@@ -791,11 +791,11 @@ impl MediaRepository for PostgresMediaRepository {
         sources: bool,
     ) -> Result<Medium>
     where
-        T: IntoIterator<Item = SourceId> + Send + Sync,
-        U: IntoIterator<Item = SourceId> + Send + Sync,
-        V: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync,
-        W: IntoIterator<Item = (TagId, TagTypeId)> + Send + Sync,
-        X: IntoIterator<Item = ReplicaId> + Send + Sync,
+        T: IntoIterator<Item = SourceId> + Send,
+        U: IntoIterator<Item = SourceId> + Send,
+        V: IntoIterator<Item = (TagId, TagTypeId)> + Send,
+        W: IntoIterator<Item = (TagId, TagTypeId)> + Send,
+        X: IntoIterator<Item = ReplicaId> + Send,
     {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 

--- a/api/crates/postgres/src/replicas.rs
+++ b/api/crates/postgres/src/replicas.rs
@@ -323,7 +323,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
 
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<Replica>>
     where
-        T: IntoIterator<Item = ReplicaId> + Send + Sync,
+        T: IntoIterator<Item = ReplicaId> + Send,
     {
         let (sql, values) = Query::select()
             .expr_as(Expr::col((PostgresReplica::Table, PostgresReplica::Id)), PostgresReplicaThumbnail::ReplicaId)

--- a/api/crates/postgres/src/sources.rs
+++ b/api/crates/postgres/src/sources.rs
@@ -312,7 +312,7 @@ impl SourcesRepository for PostgresSourcesRepository {
 
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<Source>>
     where
-        T: IntoIterator<Item = SourceId> + Send + Sync,
+        T: IntoIterator<Item = SourceId> + Send,
     {
         let (sql, values) = Query::select()
             .expr_as(Expr::col((PostgresSource::Table, PostgresSource::Id)), PostgresSourceExternalService::SourceId)

--- a/api/crates/postgres/src/tag_types.rs
+++ b/api/crates/postgres/src/tag_types.rs
@@ -87,7 +87,7 @@ impl TagTypesRepository for PostgresTagTypesRepository {
 
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<TagType>>
     where
-        T: IntoIterator<Item = TagTypeId> + Send + Sync,
+        T: IntoIterator<Item = TagTypeId> + Send,
     {
         let (sql, values) = Query::select()
             .columns([

--- a/api/crates/postgres/src/tags.rs
+++ b/api/crates/postgres/src/tags.rs
@@ -462,7 +462,7 @@ async fn detach_parent(tx: &mut Transaction<'_, Postgres>, id: TagId) -> Result<
 impl TagsRepository for PostgresTagsRepository {
     async fn create<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> Result<Tag>
     where
-        T: IntoIterator<Item = String> + Send + Sync,
+        T: IntoIterator<Item = String> + Send,
     {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 
@@ -530,7 +530,7 @@ impl TagsRepository for PostgresTagsRepository {
 
     async fn fetch_by_ids<T>(&self, ids: T, depth: TagDepth) -> Result<Vec<Tag>>
     where
-        T: IntoIterator<Item = TagId> + Send + Sync,
+        T: IntoIterator<Item = TagId> + Send,
     {
         let mut conn = self.pool.acquire().await.map_err(Error::other)?;
 
@@ -670,8 +670,8 @@ impl TagsRepository for PostgresTagsRepository {
 
     async fn update_by_id<T, U>(&self, id: TagId, name: Option<String>, kana: Option<String>, add_aliases: T, remove_aliases: U, depth: TagDepth) -> Result<Tag>
     where
-        T: IntoIterator<Item = String> + Send + Sync,
-        U: IntoIterator<Item = String> + Send + Sync,
+        T: IntoIterator<Item = String> + Send,
+        U: IntoIterator<Item = String> + Send,
     {
         if id.is_root() {
             return Err(ErrorKind::TagUpdatingRoot)?;

--- a/api/crates/thumbnails/src/processor.rs
+++ b/api/crates/thumbnails/src/processor.rs
@@ -21,7 +21,7 @@ pub struct InMemoryImageProcessor {
 impl MediumImageProcessor for InMemoryImageProcessor {
     async fn generate_thumbnail<R>(&self, read: R) -> Result<(OriginalImage, ThumbnailImage)>
     where
-        R: BufRead + Seek + Send + 'static,
+        for<'a> R: BufRead + Seek + Send + 'a,
     {
         let thumbnail_size = self.thumbnail_size;
         let thumbnail_filter = self.thumbnail_filter;


### PR DESCRIPTION
This PR removes `Sync` and `'static' trait bounds that are unnecessary for arguments.