### PR TITLE
Add axum to async-graphql group of Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
       patterns:
       - async-graphql
       - async-graphql-*
+      - axum
     icu:
       patterns:
       - icu_*


### PR DESCRIPTION
This PR updates configuration of Dependabot to update async-graphql and axum together since async-graphql-axum supports the limited range of versions of axum.