### PR TITLE
Fix improper defaulting for destination field in upload dialog

### DIFF
--- a/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
@@ -85,7 +85,7 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
       }
 
       const pathname = decodeURIComponent(new URL(replica.originalUrl).pathname)
-      const dirpart = pathname.substring(pathname.indexOf('/') + 1, pathname.lastIndexOf('/'))
+      const dirpart = pathname.substring(1).substring(pathname.indexOf('/'), pathname.lastIndexOf('/') - 1)
       if (current && current !== dirpart) {
         return ''
       }
@@ -131,9 +131,8 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
   }, [ close ])
 
   const processReplicaUpload = useCallback(async (medium: Medium, replica: ReplicaCreate, observable: Observable<Replica>, overwrite?: boolean): Promise<Replica> => {
-    const path = container ? `/${container}` : ''
-    const url = `${path}/${replica.name}`.split('/').map(strictUriEncode).join('/')
-    const file = new File([ replica.blob ], url)
+    const path = `${container}/${replica.name}`.split('/').filter(c => c.length).map(strictUriEncode).join('/')
+    const file = new File([ replica.blob ], `/${path}`)
 
     try {
       const newReplica = await createReplica(


### PR DESCRIPTION
Previously leading slashes (`/`) were not removed from the destination when uploading files and even the defaulting used to have caused a single slash possibly being specified as the destination when the destination was inherited from the existing file(s). This PR fixes the upload dialog to trim the leading slashes correctly as well as fix the defaulting behavior.

This PR does not fix API; this behavior is not yet undocumented but looks correct.