### PR TITLE
Delete a created file when creating or updating a replica fails

### DIFF
--- a/api/crates/domain/src/repository/objects.rs
+++ b/api/crates/domain/src/repository/objects.rs
@@ -22,13 +22,29 @@ impl ObjectOverwriteBehavior {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ObjectStatus {
+    Created,
+    Existing,
+}
+
+impl ObjectStatus {
+    pub const fn is_created(&self) -> bool {
+        matches!(self, ObjectStatus::Created)
+    }
+
+    pub const fn is_existing(&self) -> bool {
+        matches!(self, ObjectStatus::Existing)
+    }
+}
+
 pub trait ObjectsRepository: Send + Sync + 'static {
     type Read: Read + Seek + Send + Unpin + 'static;
     type Write: Write + Seek + Send + Unpin + 'static;
 
     fn scheme() -> &'static str;
 
-    fn put(&self, url: EntryUrl, overwrite: ObjectOverwriteBehavior) -> impl Future<Output = Result<(Entry, Self::Write)>> + Send;
+    fn put(&self, url: EntryUrl, overwrite: ObjectOverwriteBehavior) -> impl Future<Output = Result<(Entry, ObjectStatus, Self::Write)>> + Send;
 
     fn get(&self, url: EntryUrl) -> impl Future<Output = Result<(Entry, Self::Read)>> + Send;
 

--- a/api/crates/domain/src/repository/objects.rs
+++ b/api/crates/domain/src/repository/objects.rs
@@ -32,10 +32,9 @@ pub trait ObjectsRepository: Send + Sync + 'static {
 
     fn get(&self, url: EntryUrl) -> impl Future<Output = Result<(Entry, Self::Read)>> + Send;
 
-    fn copy<R, W>(&self, read: &mut R, write: &mut W) -> Result<u64>
+    fn copy<R>(&self, read: &mut R, write: &mut Self::Write) -> Result<u64>
     where
-        for<'a> R: Read + 'a,
-        for<'a> W: Write + 'a;
+        for<'a> R: Read + 'a;
 
     fn list(&self, prefix: EntryUrl) -> impl Future<Output = Result<Vec<Entry>>> + Send;
 

--- a/api/crates/domain/tests/media.rs
+++ b/api/crates/domain/tests/media.rs
@@ -13,7 +13,7 @@ use domain::{
         tags::{Tag, TagDepth, TagId},
     },
     error::{Error, ErrorKind},
-    repository::{objects::ObjectOverwriteBehavior, DeleteResult, Direction, Order},
+    repository::{objects::{ObjectOverwriteBehavior, ObjectStatus}, DeleteResult, Direction, Order},
     service::media::{MediaService, MediaServiceInterface, MediumOverwriteBehavior, MediumSource},
 };
 use futures::{future::{err, ok}, stream, StreamExt, TryFutureExt, TryStreamExt};
@@ -446,6 +446,65 @@ async fn create_replica_from_url_succeeds() {
 }
 
 #[tokio::test]
+async fn create_replica_from_url_fails() {
+    let mock_media_repository = MockMediaRepository::new();
+    let mock_sources_repository = MockSourcesRepository::new();
+    let task_tracker = TaskTracker::new();
+
+    let mut mock_medium_image_processor = MockMediumImageProcessor::new();
+    mock_medium_image_processor
+        .expect_clone()
+        .times(1)
+        .returning(MockMediumImageProcessor::new);
+
+    let mut mock_objects_repository = MockObjectsRepository::new();
+    mock_objects_repository
+        .expect_get()
+        .times(1)
+        .withf(|url| url == &EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string()))
+        .returning(|_| {
+            Box::pin(ok((
+                Entry::new(
+                    "77777777-7777-7777-7777-777777777777.png".to_string(),
+                    Some(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
+                    EntryKind::Object,
+                    Some(EntryMetadata::new(
+                        4096,
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
+                    )),
+                ),
+                Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),
+            )))
+        });
+
+    let mut mock_replicas_repository = MockReplicasRepository::new();
+    mock_replicas_repository
+        .expect_create()
+        .times(1)
+        .withf(|medium_id, thumbnail_image, original_url, original_image, status| {
+            (medium_id, thumbnail_image, original_url, original_image, status) == (
+                &MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
+                &None,
+                "file:///77777777-7777-7777-7777-777777777777.png",
+                &None,
+                &ReplicaStatus::Processing,
+            )
+        })
+        .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let actual = service.create_replica(
+        MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
+        MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
+    ).await.unwrap_err();
+
+    assert_matches!(actual.kind(), ErrorKind::Other);
+    assert!(task_tracker.is_empty());
+}
+
+#[tokio::test]
 #[serial]
 async fn create_replica_from_content_succeeds() {
     let mock_media_repository = MockMediaRepository::new();
@@ -492,6 +551,7 @@ async fn create_replica_from_content_succeeds() {
                         Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                     )),
                 ),
+                ObjectStatus::Created,
                 Cursor::new(Vec::new()),
             )))
         });
@@ -611,6 +671,91 @@ async fn create_replica_from_content_succeeds() {
 
 #[tokio::test]
 #[serial]
+async fn create_replica_from_content_fails() {
+    let mock_media_repository = MockMediaRepository::new();
+    let mock_sources_repository = MockSourcesRepository::new();
+    let task_tracker = TaskTracker::new();
+
+    let mut mock_objects_repository = MockObjectsRepository::new();
+    mock_objects_repository
+        .expect_put()
+        .times(1)
+        .withf(|path, overwrite| {
+            (path, overwrite) == (
+                &EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string()),
+                &ObjectOverwriteBehavior::Fail,
+            )
+        })
+        .returning(|_, _| {
+            Box::pin(ok((
+                Entry::new(
+                    "77777777-7777-7777-7777-777777777777.png".to_string(),
+                    Some(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
+                    EntryKind::Object,
+                    Some(EntryMetadata::new(
+                        4096,
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
+                    )),
+                ),
+                ObjectStatus::Created,
+                Cursor::new(Vec::new()),
+            )))
+        });
+
+    mock_objects_repository
+        .expect_delete()
+        .times(1)
+        .withf(|url| url == &EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string()))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    mock_objects_repository
+        .expect_clone()
+        .times(1)
+        .returning(MockObjectsRepository::new);
+
+    let mock_objects_repository_scheme = MockObjectsRepository::scheme_context();
+    mock_objects_repository_scheme
+        .expect()
+        .return_const("file");
+
+    let mut mock_replicas_repository = MockReplicasRepository::new();
+    mock_replicas_repository
+        .expect_create()
+        .times(1)
+        .withf(|medium_id, thumbnail_image, original_url, original_image, status| {
+            (medium_id, thumbnail_image, original_url, original_image, status) == (
+                &MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
+                &None,
+                "file:///77777777-7777-7777-7777-777777777777.png",
+                &None,
+                &ReplicaStatus::Processing,
+            )
+        })
+        .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
+
+    let mut mock_medium_image_processor = MockMediumImageProcessor::new();
+    mock_medium_image_processor
+        .expect_clone()
+        .returning(MockMediumImageProcessor::new);
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let actual = service.create_replica(
+        MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
+        MediumSource::Content(
+            EntryUrlPath::from("/77777777-7777-7777-7777-777777777777.png".to_string()),
+            Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
+            MediumOverwriteBehavior::Fail,
+        ),
+    ).await.unwrap_err();
+
+    assert_matches!(actual.kind(), ErrorKind::Other);
+    assert!(task_tracker.is_empty());
+}
+
+#[tokio::test]
+#[serial]
 async fn create_replica_from_content_fails_with_replica_already_exists() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
@@ -678,65 +823,6 @@ async fn create_replica_from_content_fails_with_replica_already_exists() {
     ).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ReplicaOriginalUrlDuplicate { original_url, .. } if original_url == "file:///77777777-7777-7777-7777-777777777777.png");
-    assert!(task_tracker.is_empty());
-}
-
-#[tokio::test]
-async fn create_replica_fails() {
-    let mock_media_repository = MockMediaRepository::new();
-    let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
-
-    let mut mock_medium_image_processor = MockMediumImageProcessor::new();
-    mock_medium_image_processor
-        .expect_clone()
-        .times(1)
-        .returning(MockMediumImageProcessor::new);
-
-    let mut mock_objects_repository = MockObjectsRepository::new();
-    mock_objects_repository
-        .expect_get()
-        .times(1)
-        .withf(|url| url == &EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string()))
-        .returning(|_| {
-            Box::pin(ok((
-                Entry::new(
-                    "77777777-7777-7777-7777-777777777777.png".to_string(),
-                    Some(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
-                    EntryKind::Object,
-                    Some(EntryMetadata::new(
-                        4096,
-                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
-                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
-                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
-                    )),
-                ),
-                Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),
-            )))
-        });
-
-    let mut mock_replicas_repository = MockReplicasRepository::new();
-    mock_replicas_repository
-        .expect_create()
-        .times(1)
-        .withf(|medium_id, thumbnail_image, original_url, original_image, status| {
-            (medium_id, thumbnail_image, original_url, original_image, status) == (
-                &MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
-                &None,
-                "file:///77777777-7777-7777-7777-777777777777.png",
-                &None,
-                &ReplicaStatus::Processing,
-            )
-        })
-        .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
-
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let actual = service.create_replica(
-        MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
-        MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
-    ).await.unwrap_err();
-
-    assert_matches!(actual.kind(), ErrorKind::Other);
     assert!(task_tracker.is_empty());
 }
 
@@ -2574,6 +2660,65 @@ async fn update_replica_by_id_from_url_succeeds() {
 }
 
 #[tokio::test]
+async fn update_replica_by_id_from_url_fails() {
+    let mock_media_repository = MockMediaRepository::new();
+    let mock_sources_repository = MockSourcesRepository::new();
+    let task_tracker = TaskTracker::new();
+
+    let mut mock_medium_image_processor = MockMediumImageProcessor::new();
+    mock_medium_image_processor
+        .expect_clone()
+        .times(1)
+        .returning(MockMediumImageProcessor::new);
+
+    let mut mock_objects_repository = MockObjectsRepository::new();
+    mock_objects_repository
+        .expect_get()
+        .times(1)
+        .withf(|url| url == &EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()))
+        .returning(|_| {
+            Box::pin(ok((
+                Entry::new(
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+                    Some(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
+                    EntryKind::Object,
+                    Some(EntryMetadata::new(
+                        4096,
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
+                    )),
+                ),
+                Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),
+            )))
+        });
+
+    let mut mock_replicas_repository = MockReplicasRepository::new();
+    mock_replicas_repository
+        .expect_update_by_id()
+        .times(1)
+        .withf(|id, thumbnail_image, original_url, original_image, status| {
+            (id, thumbnail_image, original_url, original_image, status) == (
+                &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+                &None,
+                &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
+                &None,
+                &Some(ReplicaStatus::Processing),
+            )
+        })
+        .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let actual = service.update_replica_by_id(
+        ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
+    ).await.unwrap_err();
+
+    assert_matches!(actual.kind(), ErrorKind::Other);
+    assert!(task_tracker.is_empty());
+}
+
+#[tokio::test]
 #[serial]
 async fn update_replica_by_id_from_content_succeeds() {
     let mock_media_repository = MockMediaRepository::new();
@@ -2620,6 +2765,7 @@ async fn update_replica_by_id_from_content_succeeds() {
                         Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
                     )),
                 ),
+                ObjectStatus::Created,
                 Cursor::new(Vec::new()),
             )))
         });
@@ -2739,6 +2885,91 @@ async fn update_replica_by_id_from_content_succeeds() {
 
 #[tokio::test]
 #[serial]
+async fn update_replica_by_id_from_content_fails() {
+    let mock_media_repository = MockMediaRepository::new();
+    let mock_sources_repository = MockSourcesRepository::new();
+    let task_tracker = TaskTracker::new();
+
+    let mut mock_objects_repository = MockObjectsRepository::new();
+    mock_objects_repository
+        .expect_put()
+        .times(1)
+        .withf(|path, overwrite| {
+            (path, overwrite) == (
+                &EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()),
+                &ObjectOverwriteBehavior::Overwrite,
+            )
+        })
+        .returning(|_, _| {
+            Box::pin(ok((
+                Entry::new(
+                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+                    Some(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
+                    EntryKind::Object,
+                    Some(EntryMetadata::new(
+                        4096,
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
+                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
+                    )),
+                ),
+                ObjectStatus::Created,
+                Cursor::new(Vec::new()),
+            )))
+        });
+
+    mock_objects_repository
+        .expect_delete()
+        .times(1)
+        .withf(|url| url == &EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()))
+        .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
+
+    mock_objects_repository
+        .expect_clone()
+        .times(1)
+        .returning(MockObjectsRepository::new);
+
+    let mock_objects_repository_scheme = MockObjectsRepository::scheme_context();
+    mock_objects_repository_scheme
+        .expect()
+        .return_const("file");
+
+    let mut mock_replicas_repository = MockReplicasRepository::new();
+    mock_replicas_repository
+        .expect_update_by_id()
+        .times(1)
+        .withf(|id, thumbnail_image, original_url, original_image, status| {
+            (id, thumbnail_image, original_url, original_image, status) == (
+                &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+                &None,
+                &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
+                &None,
+                &Some(ReplicaStatus::Processing),
+            )
+        })
+        .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
+
+    let mut mock_medium_image_processor = MockMediumImageProcessor::new();
+    mock_medium_image_processor
+        .expect_clone()
+        .returning(MockMediumImageProcessor::new);
+
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let actual = service.update_replica_by_id(
+        ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        MediumSource::Content(
+            EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()),
+            Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
+            MediumOverwriteBehavior::Overwrite,
+        ),
+    ).await.unwrap_err();
+
+    assert_matches!(actual.kind(), ErrorKind::Other);
+    assert!(task_tracker.is_empty());
+}
+
+#[tokio::test]
+#[serial]
 async fn update_replica_by_id_from_content_fails_with_replica_already_exists() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
@@ -2807,65 +3038,6 @@ async fn update_replica_by_id_from_content_fails_with_replica_already_exists() {
     ).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ReplicaOriginalUrlDuplicate { original_url, .. } if original_url == "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg");
-    assert!(task_tracker.is_empty());
-}
-
-#[tokio::test]
-async fn update_replica_by_id_fails() {
-    let mock_media_repository = MockMediaRepository::new();
-    let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
-
-    let mut mock_medium_image_processor = MockMediumImageProcessor::new();
-    mock_medium_image_processor
-        .expect_clone()
-        .times(1)
-        .returning(MockMediumImageProcessor::new);
-
-    let mut mock_objects_repository = MockObjectsRepository::new();
-    mock_objects_repository
-        .expect_get()
-        .times(1)
-        .withf(|url| url == &EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()))
-        .returning(|_| {
-            Box::pin(ok((
-                Entry::new(
-                    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
-                    Some(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
-                    EntryKind::Object,
-                    Some(EntryMetadata::new(
-                        4096,
-                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap()),
-                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 1).unwrap()),
-                        Some(Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 2).unwrap()),
-                    )),
-                ),
-                Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08][..]),
-            )))
-        });
-
-    let mut mock_replicas_repository = MockReplicasRepository::new();
-    mock_replicas_repository
-        .expect_update_by_id()
-        .times(1)
-        .withf(|id, thumbnail_image, original_url, original_image, status| {
-            (id, thumbnail_image, original_url, original_image, status) == (
-                &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                &None,
-                &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
-                &None,
-                &Some(ReplicaStatus::Processing),
-            )
-        })
-        .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
-
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let actual = service.update_replica_by_id(
-        ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-        MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
-    ).await.unwrap_err();
-
-    assert_matches!(actual.kind(), ErrorKind::Other);
     assert!(task_tracker.is_empty());
 }
 

--- a/api/crates/domain/tests/mocks/domain/repository/objects/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/objects/mod.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, io::{Cursor, Read, Write}};
+use std::{future::Future, io::{Cursor, Read}};
 
 use domain::{
     entity::objects::{Entry, EntryUrl},
@@ -19,10 +19,9 @@ mockall::mock! {
 
         fn get(&self, url: EntryUrl) -> impl Future<Output = Result<(Entry, Cursor<&'static [u8]>)>> + Send;
 
-        fn copy<R, W>(&self, read: &mut R, write: &mut W) -> Result<u64>
+        fn copy<R>(&self, read: &mut R, write: &mut Cursor<Vec<u8>>) -> Result<u64>
         where
-            R: Read + 'static,
-            W: Write + 'static;
+            R: Read + 'static;
 
         fn list(&self, prefix: EntryUrl) -> impl Future<Output = Result<Vec<Entry>>> + Send;
 

--- a/api/crates/domain/tests/mocks/domain/repository/objects/mod.rs
+++ b/api/crates/domain/tests/mocks/domain/repository/objects/mod.rs
@@ -3,7 +3,7 @@ use std::{future::Future, io::{Cursor, Read}};
 use domain::{
     entity::objects::{Entry, EntryUrl},
     error::Result,
-    repository::{objects::{ObjectsRepository, ObjectOverwriteBehavior}, DeleteResult},
+    repository::{objects::{ObjectOverwriteBehavior, ObjectStatus, ObjectsRepository}, DeleteResult},
 };
 
 mockall::mock! {
@@ -15,7 +15,7 @@ mockall::mock! {
 
         fn scheme() -> &'static str;
 
-        fn put(&self, url: EntryUrl, overwrite: ObjectOverwriteBehavior) -> impl Future<Output = Result<(Entry, Cursor<Vec<u8>>)>> + Send;
+        fn put(&self, url: EntryUrl, overwrite: ObjectOverwriteBehavior) -> impl Future<Output = Result<(Entry, ObjectStatus, Cursor<Vec<u8>>)>> + Send;
 
         fn get(&self, url: EntryUrl) -> impl Future<Output = Result<(Entry, Cursor<&'static [u8]>)>> + Send;
 

--- a/api/crates/storage/src/filesystem.rs
+++ b/api/crates/storage/src/filesystem.rs
@@ -1,4 +1,4 @@
-use std::{fs::File as StdFile, io::{self, Read, Write}, path::{Path, PathBuf}, sync::Arc};
+use std::{fs::File as StdFile, io::{self, Read}, path::{Path, PathBuf}, sync::Arc};
 
 use derive_more::Constructor;
 use domain::{
@@ -110,12 +110,14 @@ impl ObjectsRepository for FilesystemObjectsRepository {
         }
     }
 
-    fn copy<R, W>(&self, read: &mut R, write: &mut W) -> Result<u64>
+    fn copy<R>(&self, read: &mut R, write: &mut Self::Write) -> Result<u64>
     where
         R: Read,
-        W: Write,
     {
-        io::copy(read, write).map_err(Error::other)
+        write.set_len(0).map_err(Error::other)?;
+
+        let written = io::copy(read, write).map_err(Error::other)?;
+        Ok(written)
     }
 
     async fn list(&self, prefix: EntryUrl) -> Result<Vec<Entry>> {


### PR DESCRIPTION
This PR fixes API to truncate the existing file when overwriting it, and delete a created file when creating or updating a replica fails.