### PR TITLE
Replace `dyn_clone::clone_box` with `CloneableIterator::clone_box()`

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -890,7 +890,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "derive_more",
- "dyn-clone",
  "futures",
  "log",
  "mockall",
@@ -917,12 +916,6 @@ name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "either"
@@ -1308,7 +1301,6 @@ dependencies = [
  "chrono",
  "derive_more",
  "domain",
- "dyn-clone",
  "futures",
  "indoc",
  "mockall",

--- a/api/crates/domain/Cargo.toml
+++ b/api/crates/domain/Cargo.toml
@@ -16,9 +16,6 @@ features = ["clock", "std"]
 version = "1.0.0"
 features = ["constructor", "deref", "display", "from"]
 
-[dependencies.dyn-clone]
-version = "1.0.17"
-
 [dependencies.futures]
 version = "0.3.31"
 

--- a/api/crates/domain/src/iter.rs
+++ b/api/crates/domain/src/iter.rs
@@ -1,9 +1,17 @@
-use dyn_clone::DynClone;
-
-pub trait CloneableIterator: DynClone + Iterator {}
+pub trait CloneableIterator: Iterator {
+    fn clone_box<'a>(&self) -> Box<dyn CloneableIterator<Item = Self::Item> + 'a>
+    where
+        Self: 'a;
+}
 
 impl<T> CloneableIterator for T
 where
     T: Clone + Iterator,
 {
+    fn clone_box<'a>(&self) -> Box<dyn CloneableIterator<Item = Self::Item> + 'a>
+    where
+        Self: 'a,
+    {
+        Box::new(self.clone())
+    }
 }

--- a/api/crates/domain/tests/external_services.rs
+++ b/api/crates/domain/tests/external_services.rs
@@ -5,7 +5,6 @@ use domain::{
     repository::DeleteResult,
     service::external_services::{ExternalServicesService, ExternalServicesServiceInterface},
 };
-use dyn_clone::clone_box;
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
 use uuid::uuid;
@@ -185,7 +184,7 @@ async fn get_external_services_by_ids_succeeds() {
     mock_external_services_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
         ]))
@@ -242,7 +241,7 @@ async fn get_external_services_by_ids_fails() {
     mock_external_services_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
         ]))

--- a/api/crates/domain/tests/media.rs
+++ b/api/crates/domain/tests/media.rs
@@ -16,7 +16,6 @@ use domain::{
     repository::{objects::{ObjectOverwriteBehavior, ObjectStatus}, DeleteResult, Direction, Order},
     service::media::{MediaService, MediaServiceInterface, MediumOverwriteBehavior, MediumSource},
 };
-use dyn_clone::clone_box;
 use futures::{future::{err, ok}, stream, StreamExt, TryFutureExt, TryStreamExt};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
@@ -42,11 +41,11 @@ async fn create_medium_succeeds() {
         .expect_create()
         .times(1)
         .withf(|source_ids, created_at, tag_tag_type_ids, tag_depth, sources| {
-            clone_box(source_ids).eq([
+            source_ids.clone_box().eq([
                 SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             ]) &&
-            clone_box(tag_tag_type_ids).eq([
+            tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
@@ -261,11 +260,11 @@ async fn create_medium_fails() {
         .expect_create()
         .times(1)
         .withf(|source_ids, created_at, tag_tag_type_ids, tag_depth, sources| {
-            clone_box(source_ids).eq([
+            source_ids.clone_box().eq([
                 SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             ]) &&
-            clone_box(tag_tag_type_ids).eq([
+            tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
@@ -1050,7 +1049,7 @@ async fn get_media_by_ids_succeeds() {
         .expect_fetch_by_ids()
         .times(1)
         .withf(|ids, tag_depth, replicas, sources| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 MediumId::from(uuid!("88888888-8888-8888-8888-888888888888")),
                 MediumId::from(uuid!("99999999-9999-9999-9999-999999999999")),
             ]) &&
@@ -1125,7 +1124,7 @@ async fn get_media_by_ids_fails() {
         .expect_fetch_by_ids()
         .times(1)
         .withf(|ids, tag_depth, replicas, sources| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 MediumId::from(uuid!("88888888-8888-8888-8888-888888888888")),
                 MediumId::from(uuid!("99999999-9999-9999-9999-999999999999")),
             ]) &&
@@ -1164,7 +1163,7 @@ async fn get_media_by_source_ids_succeeds() {
         .expect_fetch_by_source_ids()
         .times(1)
         .withf(|source_ids, tag_depth, replicas, sources, since, until, order, limit| {
-            clone_box(source_ids).eq([
+            source_ids.clone_box().eq([
                 SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             ]) &&
@@ -1247,7 +1246,7 @@ async fn get_media_by_source_ids_fails() {
         .expect_fetch_by_source_ids()
         .times(1)
         .withf(|source_ids, tag_depth, replicas, sources, since, until, order, limit| {
-            clone_box(source_ids).eq([
+            source_ids.clone_box().eq([
                 SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             ]) &&
@@ -1294,7 +1293,7 @@ async fn get_media_by_tag_ids_succeeds() {
         .expect_fetch_by_tag_ids()
         .times(1)
         .withf(|tag_tag_type_ids, tag_depth, replicas, sources, since, until, order, limit| {
-            clone_box(tag_tag_type_ids).eq([
+            tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
@@ -1389,7 +1388,7 @@ async fn get_media_by_tag_ids_fails() {
         .expect_fetch_by_tag_ids()
         .times(1)
         .withf(|tag_tag_type_ids, tag_depth, replicas, sources, since, until, order, limit| {
-            clone_box(tag_tag_type_ids).eq([
+            tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
@@ -1453,7 +1452,7 @@ async fn get_replicas_by_ids_succeeds() {
     mock_replicas_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
             ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         ]))
@@ -1548,7 +1547,7 @@ async fn get_replicas_by_ids_fails() {
     mock_replicas_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
             ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         ]))
@@ -1649,7 +1648,7 @@ async fn get_sources_by_ids_succeeds() {
     mock_sources_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
         ]))
@@ -1736,7 +1735,7 @@ async fn get_sources_by_ids_fails() {
     mock_sources_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
         ]))
@@ -2323,25 +2322,25 @@ async fn update_medium_by_id_succeeds() {
             replicas,
             sources,
         | {
-            clone_box(add_source_ids).eq([
+            add_source_ids.clone_box().eq([
                 SourceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
             ]) &&
-            clone_box(remove_source_ids).eq([
+            remove_source_ids.clone_box().eq([
                 SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             ]) &&
-            clone_box(add_tag_tag_type_ids).eq([
+            add_tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
                 ),
             ]) &&
-            clone_box(remove_tag_tag_type_ids).eq([
+            remove_tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
                 ),
             ]) &&
-            clone_box(replica_orders).eq([
+            replica_orders.clone_box().eq([
                 ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")),
                 ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
             ]) &&
@@ -2435,25 +2434,25 @@ async fn update_medium_by_id_fails() {
             replicas,
             sources,
         | {
-            clone_box(add_source_ids).eq([
+            add_source_ids.clone_box().eq([
                 SourceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
             ]) &&
-            clone_box(remove_source_ids).eq([
+            remove_source_ids.clone_box().eq([
                 SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             ]) &&
-            clone_box(add_tag_tag_type_ids).eq([
+            add_tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
                 ),
             ]) &&
-            clone_box(remove_tag_tag_type_ids).eq([
+            remove_tag_tag_type_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
                 ),
             ]) &&
-            clone_box(replica_orders).eq([
+            replica_orders.clone_box().eq([
                 ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")),
                 ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
             ]) &&
@@ -3146,7 +3145,7 @@ async fn delete_medium_by_id_with_delete_objects_succeeds() {
         .expect_fetch_by_ids()
         .times(1)
         .withf(|ids, tag_depth, replicas, sources| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 MediumId::from(uuid!("77777777-7777-7777-7777-777777777777"))
             ]) &&
             (tag_depth, replicas, sources) == (
@@ -3303,7 +3302,7 @@ async fn delete_replica_by_id_with_delete_object_succeeds() {
     mock_replicas_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666"))]))
+        .withf(|ids| ids.clone_box().eq([ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666"))]))
         .returning(|_| {
             Box::pin(ok(vec![
                 Replica {

--- a/api/crates/domain/tests/tags.rs
+++ b/api/crates/domain/tests/tags.rs
@@ -11,7 +11,6 @@ use domain::{
     repository::{DeleteResult, Direction, Order},
     service::tags::{TagsService, TagsServiceInterface},
 };
-use dyn_clone::clone_box;
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
 use uuid::uuid;
@@ -26,7 +25,7 @@ async fn create_tag_succeeds() {
         .expect_create()
         .times(1)
         .withf(|name, kana, aliases, parent_id, depth| {
-            clone_box(aliases).eq(["アッカリーン".to_string()]) &&
+            aliases.clone_box().eq(["アッカリーン".to_string()]) &&
             (name, kana, parent_id, depth) == (
                 "赤座あかり",
                 "あかざあかり",
@@ -95,7 +94,7 @@ async fn create_tag_fails() {
         .expect_create()
         .times(1)
         .withf(|name, kana, aliases, parent_id, depth| {
-            clone_box(aliases).eq(["アッカリーン".to_string()]) &&
+            aliases.clone_box().eq(["アッカリーン".to_string()]) &&
             (name, kana, parent_id, depth) == (
                 "赤座あかり",
                 "あかざあかり",
@@ -328,7 +327,7 @@ async fn get_tags_by_ids_succeeds() {
         .expect_fetch_by_ids()
         .times(1)
         .withf(|ids, depth| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 TagId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 TagId::from(uuid!("55555555-5555-5555-5555-555555555555")),
             ]) &&
@@ -443,7 +442,7 @@ async fn get_tags_by_ids_fails() {
         .expect_fetch_by_ids()
         .times(1)
         .withf(|ids, depth| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 TagId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                 TagId::from(uuid!("55555555-5555-5555-5555-555555555555")),
             ]) &&
@@ -650,7 +649,7 @@ async fn get_tag_types_by_ids_succeeds() {
     mock_tag_types_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
             TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
         ]))
@@ -700,7 +699,7 @@ async fn get_tag_types_by_ids_fails() {
     mock_tag_types_repository
         .expect_fetch_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
             TagTypeId::from(uuid!("55555555-5555-5555-5555-555555555555")),
         ]))
@@ -722,8 +721,8 @@ async fn update_tag_by_id_succeeds() {
         .expect_update_by_id()
         .times(1)
         .withf(|id, name, kana, add_aliases, remove_aliases, depth| {
-            clone_box(add_aliases).eq(["アッカリーン".to_string()]) &&
-            clone_box(remove_aliases).eq([] as [String; 0]) &&
+            add_aliases.clone_box().eq(["アッカリーン".to_string()]) &&
+            remove_aliases.clone_box().eq([] as [String; 0]) &&
             (id, name, kana, depth) == (
                 &TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 &Some("赤座あかり".to_string()),
@@ -793,8 +792,8 @@ async fn update_tag_by_id_fails() {
         .expect_update_by_id()
         .times(1)
         .withf(|id, name, kana, add_aliases, remove_aliases, depth| {
-            clone_box(add_aliases).eq(["アッカリーン".to_string()]) &&
-            clone_box(remove_aliases).eq([] as [String; 0]) &&
+            add_aliases.clone_box().eq(["アッカリーン".to_string()]) &&
+            remove_aliases.clone_box().eq([] as [String; 0]) &&
             (id, name, kana, depth) == (
                 &TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 &Some("赤座あかり".to_string()),

--- a/api/crates/graphql/Cargo.toml
+++ b/api/crates/graphql/Cargo.toml
@@ -70,9 +70,6 @@ version = "1.12.1"
 [dev-dependencies.application]
 workspace = true
 
-[dev-dependencies.dyn-clone]
-version = "1.0.17"
-
 [dev-dependencies.indoc]
 version = "2.0.5"
 

--- a/api/crates/graphql/tests/all_media.rs
+++ b/api/crates/graphql/tests/all_media.rs
@@ -9,7 +9,6 @@ use domain::{
     },
     repository::{Direction, Order},
 };
-use dyn_clone::clone_box;
 use futures::future::ok;
 use graphql::query::Query;
 use indoc::indoc;
@@ -36,7 +35,7 @@ async fn by_source_ids_succeeds() {
         .expect_get_media_by_source_ids()
         .times(1)
         .withf(|source_ids, tag_depth, replicas, sources, cursor, order, direction, limit| {
-            clone_box(source_ids).eq([
+            source_ids.clone_box().eq([
                 SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 SourceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
             ]) &&
@@ -134,7 +133,7 @@ async fn by_tag_ids_succeeds() {
         .expect_get_media_by_tag_ids()
         .times(1)
         .withf(|tag_ids, tag_depth, replicas, sources, cursor, order, direction, limit| {
-            clone_box(tag_ids).eq([
+            tag_ids.clone_box().eq([
                 (
                     TagId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                     TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),

--- a/api/crates/graphql/tests/external_services.rs
+++ b/api/crates/graphql/tests/external_services.rs
@@ -1,6 +1,5 @@
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use domain::entity::external_services::{ExternalService, ExternalServiceId};
-use dyn_clone::clone_box;
 use futures::future::ok;
 use graphql::query::Query;
 use indoc::indoc;
@@ -23,7 +22,7 @@ async fn succeeds() {
     external_services_service
         .expect_get_external_services_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
         ]))

--- a/api/crates/graphql/tests/media-with.rs
+++ b/api/crates/graphql/tests/media-with.rs
@@ -11,7 +11,6 @@ use domain::entity::{
     tag_types::{TagType, TagTypeId},
     tags::{AliasSet, Tag, TagDepth, TagId},
 };
-use dyn_clone::clone_box;
 use futures::future::ok;
 use graphql::query::Query;
 use indoc::indoc;
@@ -39,7 +38,7 @@ async fn tags_succeeds() {
         .expect_get_media_by_ids()
         .times(1)
         .withf(|ids, tag_depth, replicas, sources| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
                 MediumId::from(uuid!("99999999-9999-9999-9999-999999999999")),
             ]) &&
@@ -484,7 +483,7 @@ async fn replicas_succeeds() {
         .expect_get_media_by_ids()
         .times(1)
         .withf(|ids, tag_depth, replicas, sources| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
                 MediumId::from(uuid!("99999999-9999-9999-9999-999999999999")),
             ]) &&
@@ -690,7 +689,7 @@ async fn sources_succeeds() {
         .expect_get_media_by_ids()
         .times(1)
         .withf(|ids, tag_depth, replicas, sources| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
                 MediumId::from(uuid!("99999999-9999-9999-9999-999999999999")),
             ]) &&

--- a/api/crates/graphql/tests/media.rs
+++ b/api/crates/graphql/tests/media.rs
@@ -1,7 +1,6 @@
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::media::{Medium, MediumId};
-use dyn_clone::clone_box;
 use futures::future::ok;
 use graphql::query::Query;
 use indoc::indoc;
@@ -28,7 +27,7 @@ async fn succeeds() {
         .expect_get_media_by_ids()
         .times(1)
         .withf(|ids, tag_depth, replicas, sources| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
                 MediumId::from(uuid!("99999999-9999-9999-9999-999999999999")),
             ]) &&

--- a/api/crates/graphql/tests/sources.rs
+++ b/api/crates/graphql/tests/sources.rs
@@ -4,7 +4,6 @@ use domain::entity::{
     external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
     sources::{Source, SourceId},
 };
-use dyn_clone::clone_box;
 use futures::future::ok;
 use graphql::query::Query;
 use indoc::indoc;
@@ -28,7 +27,7 @@ async fn succeeds() {
     media_service
         .expect_get_sources_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
         ]))

--- a/api/crates/graphql/tests/tag_types.rs
+++ b/api/crates/graphql/tests/tag_types.rs
@@ -1,6 +1,5 @@
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use domain::entity::tag_types::{TagType, TagTypeId};
-use dyn_clone::clone_box;
 use futures::future::ok;
 use graphql::query::Query;
 use indoc::indoc;
@@ -26,7 +25,7 @@ async fn succeeds() {
     tags_service
         .expect_get_tag_types_by_ids()
         .times(1)
-        .withf(|ids| clone_box(ids).eq([
+        .withf(|ids| ids.clone_box().eq([
             TagTypeId::from(uuid!("44444444-4444-4444-4444-444444444444")),
             TagTypeId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         ]))

--- a/api/crates/graphql/tests/tags.rs
+++ b/api/crates/graphql/tests/tags.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeSet;
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::tags::{AliasSet, Tag, TagDepth, TagId};
-use dyn_clone::clone_box;
 use futures::future::ok;
 use graphql::query::Query;
 use indoc::indoc;
@@ -30,7 +29,7 @@ async fn succeeds() {
         .expect_get_tags_by_ids()
         .times(1)
         .withf(|ids, depth| {
-            clone_box(ids).eq([
+            ids.clone_box().eq([
                 TagId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 TagId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             ]) && depth == &TagDepth::new(2, 2)


### PR DESCRIPTION
Follow up for #576: this use case does not require `dyn-clone`.