### PR TITLE
Add tests for GraphQLService

### DIFF
--- a/api/crates/graphql/src/lib.rs
+++ b/api/crates/graphql/src/lib.rs
@@ -103,3 +103,45 @@ impl Order {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use async_graphql::{EmptyMutation, Object, EmptySubscription};
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct Query;
+
+    #[Object]
+    impl Query {
+        async fn value(&self) -> &str {
+            "OK"
+        }
+    }
+
+    #[test]
+    fn graphql_endpoints() {
+        let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+        let service = GraphQLService::new(schema, "/graphql", "/graphql/subscriptions");
+
+        let actual = service.endpoints();
+        assert_eq!(actual.graphql, "/graphql");
+        assert_eq!(actual.subscriptions, "/graphql/subscriptions");
+    }
+
+    #[test]
+    fn graphql_definitions() {
+        let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
+        let service = GraphQLService::new(schema, "/graphql", "/graphql/subscriptions");
+
+        let actual = service.definitions();
+        assert!(actual.contains(indoc! {"
+            type Query {
+            	value: String!
+            }
+        "}));
+    }
+}


### PR DESCRIPTION
This PR adds some tests for GraphQLService in graphql crate. The methods that return `axum::response::Response` are not tested for now because it turned out that starting a server by calling `axum::serve()` is required in order to test a method that accepts WebSocket.