### PR TITLE
Use service containers on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,26 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run --rm --volume=/var/run/docker.sock:/var/run/docker.sock:ro ${{ steps.build.outputs.imageid }} \
+          docker run --rm ${{ steps.build.outputs.imageid }} \
             cargo clippy --tests --workspace --quiet --message-format=short --color=never 2>&1 |
             reviewdog -f=clippy -reporter=github-pr-annotations -filter-mode=nofilter -fail-level=any -tee
 
   api-test:
     name: API Test
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17.2
+        env:
+          PGDATA: /dev/shm/pgdata/data
+          POSTGRES_DB: hoarder_test
+          POSTGRES_USER: hoarder_test
+          POSTGRES_PASSWORD: hoarder_test
+        ports:
+          - "5432:5432"
+        options: >-
+          --shm-size=512m
+          --tmpfs=/var/lib/postgresql/data
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -51,15 +64,23 @@ jobs:
         id: build
         with:
           context: ./api
-          target: dev
+          target: base
           cache-from: type=gha,scope=${{ github.ref_name }}-test
           cache-to: type=gha,scope=${{ github.ref_name }}-test,mode=max
           load: true
       - name: Run tests
         working-directory: api
         run: |
-          docker run --rm --volume=/var/run/docker.sock:/var/run/docker.sock:ro --network=host ${{ steps.build.outputs.imageid }} \
-            cargo make test --workspace
+          docker run \
+            --rm \
+            --env=PGHOST=localhost \
+            --env=PGPORT=5432 \
+            --env=PGDATABASE=hoarder_test \
+            --env=PGUSER=hoarder_test \
+            --env=PGPASSWORD=hoarder_test \
+            --network=host \
+            ${{ steps.build.outputs.imageid }} \
+            cargo test --workspace
 
   build:
     name: Build

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -23,11 +23,6 @@ RUN --mount=type=cache,id=api:/usr/local/cargo/registry,target=/usr/local/cargo/
     cargo build --release && \
     cp -r target/release/hoarder /usr/local/bin/hoarder
 
-FROM base AS dev
-ENV JEMALLOC_OVERRIDE=/usr/lib/x86_64-linux-gnu/libjemalloc.so
-COPY --from=docker:cli /usr/local/bin/docker /usr/bin/docker
-RUN cargo install --no-default-features cargo-make
-
 FROM scratch AS production
 ARG PORT=80
 ENV PORT=$PORT


### PR DESCRIPTION
This PR uses service containers for PostgreSQL on GitHub Actions instead of `cargo make` and `api/scripts/setup-postgres.bash`:

Creating PostgreSQL service containers - GitHub Docs
https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/creating-postgresql-service-containers