### PR TITLE
Remove an unused dependency from graphql

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1182,7 +1182,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
- "tokio-stream",
  "tower-service",
  "uuid",
 ]

--- a/api/crates/graphql/Cargo.toml
+++ b/api/crates/graphql/Cargo.toml
@@ -57,9 +57,6 @@ version = "1.0.138"
 [dependencies.thiserror]
 version = "2.0.11"
 
-[dependencies.tokio-stream]
-version = "0.1.17"
-
 [dependencies.tower-service]
 version = "0.3.3"
 


### PR DESCRIPTION
This PR removes `tokio-stream` from `graphql` crate which was introduced for testing `impl Stream`, but is no longer referenced from `graphql` crate.