### PR TITLE
Disable optimization for `profile.dev.package.*`

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -64,7 +64,7 @@ debug = false
 
 [features]
 default = ["jemallocator", "tls"]
-jemallocator = ["tikv-jemallocator", "tikv-jemallocator/unprefixed_malloc_on_supported_platforms"]
+jemallocator = ["dep:tikv-jemallocator", "tikv-jemallocator/unprefixed_malloc_on_supported_platforms"]
 tls = ["application/tls", "postgres/tls"]
 
 [dependencies.application]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -60,7 +60,6 @@ lto = true
 codegen-units = 1
 
 [profile.dev.package."*"]
-opt-level = 3
 debug = false
 
 [features]


### PR DESCRIPTION
This PR tries to reduce the time it took to optimize dependencies in dev profile.