### PR TITLE
Fix a bug where updating a replica caused inconsistent status

### DIFF
--- a/api/crates/domain/src/repository/replicas.rs
+++ b/api/crates/domain/src/repository/replicas.rs
@@ -26,7 +26,7 @@ pub trait ReplicasRepository: Send + Sync + 'static {
     fn fetch_thumbnail_by_id(&self, id: ThumbnailId) -> impl Future<Output = Result<Vec<u8>>> + Send;
 
     /// Updates the replica.
-    fn update_by_id(&self, id: ReplicaId, thumbnail_image: Option<ThumbnailImage>, original_url: Option<&str>, original_image: Option<OriginalImage>, status: Option<ReplicaStatus>) -> impl Future<Output = Result<Replica>> + Send;
+    fn update_by_id(&self, id: ReplicaId, thumbnail_image: Option<Option<ThumbnailImage>>, original_url: Option<&str>, original_image: Option<Option<OriginalImage>>, status: Option<ReplicaStatus>) -> impl Future<Output = Result<Replica>> + Send;
 
     /// Deletes the replica.
     fn delete_by_id(&self, id: ReplicaId) -> impl Future<Output = Result<DeleteResult>> + Send;

--- a/api/crates/domain/src/service/media.rs
+++ b/api/crates/domain/src/service/media.rs
@@ -312,7 +312,7 @@ where
             };
 
             tracker.spawn(async move {
-                if let Err(e) = replicas_repository.update_by_id(id, thumbnail_image, None, original_image, Some(status)).await {
+                if let Err(e) = replicas_repository.update_by_id(id, Some(thumbnail_image), None, Some(original_image), Some(status)).await {
                     log::error!("failed to update the replica\nError: {e:?}");
                 }
             });
@@ -591,7 +591,7 @@ where
         for<'a> R: Read + Seek + Send + 'a,
     {
         let (url, status, process) = self.create_replica_source(medium_source).await?;
-        match self.replicas_repository.update_by_id(id, None, Some(&url), None, Some(ReplicaStatus::Processing)).await {
+        match self.replicas_repository.update_by_id(id, Some(None), Some(&url), Some(None), Some(ReplicaStatus::Processing)).await {
             Ok(replica) => {
                 self.process_replica_by_id(replica.id, process);
                 Ok(replica)

--- a/api/crates/domain/src/tests/mocks/domain/repository/replicas.rs
+++ b/api/crates/domain/src/tests/mocks/domain/repository/replicas.rs
@@ -25,7 +25,7 @@ mockall::mock! {
 
         fn fetch_thumbnail_by_id(&self, id: ThumbnailId) -> impl Future<Output = Result<Vec<u8>>> + Send;
 
-        fn update_by_id<'a>(&self, id: ReplicaId, thumbnail_image: Option<ThumbnailImage>, original_url: Option<&'a str>, original_image: Option<OriginalImage>, status: Option<ReplicaStatus>) -> impl Future<Output = Result<Replica>> + Send;
+        fn update_by_id<'a>(&self, id: ReplicaId, thumbnail_image: Option<Option<ThumbnailImage>>, original_url: Option<&'a str>, original_image: Option<Option<OriginalImage>>, status: Option<ReplicaStatus>) -> impl Future<Output = Result<Replica>> + Send;
 
         fn delete_by_id(&self, id: ReplicaId) -> impl Future<Output = Result<DeleteResult>> + Send;
     }

--- a/api/crates/domain/src/tests/service/media.rs
+++ b/api/crates/domain/src/tests/service/media.rs
@@ -395,9 +395,9 @@ async fn create_replica_from_url_succeeds() {
                 .withf(|id, thumbnail_image, original_url, original_image, status| {
                     (id, thumbnail_image, original_url, original_image, status) == (
                         &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                        &Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240))),
+                        &Some(Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240)))),
                         &None,
-                        &Some(OriginalImage::new("image/png", Size::new(720, 720))),
+                        &Some(Some(OriginalImage::new("image/png", Size::new(720, 720)))),
                         &Some(ReplicaStatus::Ready),
                     )
                 })
@@ -615,9 +615,9 @@ async fn create_replica_from_content_succeeds() {
                 .withf(|id, thumbnail_image, original_url, original_image, status| {
                     (id, thumbnail_image, original_url, original_image, status) == (
                         &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                        &Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240))),
+                        &Some(Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240)))),
                         &None,
-                        &Some(OriginalImage::new("image/png", Size::new(720, 720))),
+                        &Some(Some(OriginalImage::new("image/png", Size::new(720, 720)))),
                         &Some(ReplicaStatus::Ready),
                     )
                 })
@@ -2564,9 +2564,9 @@ async fn update_replica_by_id_from_url_succeeds() {
         .withf(|id, thumbnail_image, original_url, original_image, status| {
             (id, thumbnail_image, original_url, original_image, status) == (
                 &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                &None,
+                &Some(None),
                 &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
-                &None,
+                &Some(None),
                 &Some(ReplicaStatus::Processing),
             )
         })
@@ -2595,9 +2595,9 @@ async fn update_replica_by_id_from_url_succeeds() {
                 .withf(|id, thumbnail_image, original_url, original_image, status| {
                     (id, thumbnail_image, original_url, original_image, status) == (
                         &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                        &Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240))),
-                        &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
-                        &Some(OriginalImage::new("image/jpeg", Size::new(720, 720))),
+                        &Some(Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240)))),
+                        &None,
+                        &Some(Some(OriginalImage::new("image/jpeg", Size::new(720, 720)))),
                         &Some(ReplicaStatus::Ready),
                     )
                 })
@@ -2686,9 +2686,9 @@ async fn update_replica_by_id_from_url_fails() {
         .withf(|id, thumbnail_image, original_url, original_image, status| {
             (id, thumbnail_image, original_url, original_image, status) == (
                 &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                &None,
+                &Some(None),
                 &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
-                &None,
+                &Some(None),
                 &Some(ReplicaStatus::Processing),
             )
         })
@@ -2784,9 +2784,9 @@ async fn update_replica_by_id_from_content_succeeds() {
         .withf(|id, thumbnail_image, original_url, original_image, status| {
             (id, thumbnail_image, original_url, original_image, status) == (
                 &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                &None,
+                &Some(None),
                 &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
-                &None,
+                &Some(None),
                 &Some(ReplicaStatus::Processing),
             )
         })
@@ -2815,9 +2815,9 @@ async fn update_replica_by_id_from_content_succeeds() {
                 .withf(|id, thumbnail_image, original_url, original_image, status| {
                     (id, thumbnail_image, original_url, original_image, status) == (
                         &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                        &Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240))),
-                        &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
-                        &Some(OriginalImage::new("image/jpeg", Size::new(720, 720))),
+                        &Some(Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(240, 240)))),
+                        &None,
+                        &Some(Some(OriginalImage::new("image/jpeg", Size::new(720, 720)))),
                         &Some(ReplicaStatus::Ready),
                     )
                 })
@@ -2927,9 +2927,9 @@ async fn update_replica_by_id_from_content_fails() {
         .withf(|id, thumbnail_image, original_url, original_image, status| {
             (id, thumbnail_image, original_url, original_image, status) == (
                 &ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
-                &None,
+                &Some(None),
                 &Some("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg"),
-                &None,
+                &Some(None),
                 &Some(ReplicaStatus::Processing),
             )
         })

--- a/api/crates/postgres/tests/integration/replicas/update_by_id.rs
+++ b/api/crates/postgres/tests/integration/replicas/update_by_id.rs
@@ -26,9 +26,9 @@ async fn succeeds(ctx: &DatabaseContext) {
     let repository = PostgresReplicasRepository::new(ctx.pool.clone());
     let actual_replica = repository.update_by_id(
         ReplicaId::from(uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be")),
-        Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(1, 1))),
+        Some(Some(ThumbnailImage::new(vec![0x01, 0x02, 0x03, 0x04], Size::new(1, 1)))),
         Some("file:///replica_new.jpg"),
-        Some(OriginalImage::new("image/jpeg", Size::new(720, 720))),
+        Some(Some(OriginalImage::new("image/jpeg", Size::new(720, 720)))),
         None,
     ).await.unwrap();
     let actual_thumbnail = actual_replica.thumbnail.unwrap();


### PR DESCRIPTION
This PR fixes a bug where updating a replica caused only its status to be updated while it is in progress, and might end up in its old state remains as error when it fails.