### PR TITLE
Track tasks returned from domain service in graphql crate

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -790,7 +790,6 @@ dependencies = [
  "serial_test",
  "thiserror 2.0.11",
  "tokio",
- "tokio-util",
  "uuid",
 ]
 
@@ -1182,6 +1181,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.11",
  "tokio",
+ "tokio-util",
  "tower-service",
  "uuid",
 ]

--- a/api/crates/core/di/container.rs
+++ b/api/crates/core/di/container.rs
@@ -114,8 +114,8 @@ fn external_services_service(external_services_repository: ExternalServicesRepos
     ExternalServicesService::new(external_services_repository)
 }
 
-fn media_service(media_repository: MediaRepositoryImpl, objects_repository: ObjectsRepositoryImpl, replicas_repository: ReplicasRepositoryImpl, sources_repository: SourcesRepositoryImpl, medium_image_processor: MediumImageProcessorImpl, task_tracker: TaskTracker) -> MediaServiceImpl {
-    MediaService::new(media_repository, objects_repository, replicas_repository, sources_repository, medium_image_processor, task_tracker)
+fn media_service(media_repository: MediaRepositoryImpl, objects_repository: ObjectsRepositoryImpl, replicas_repository: ReplicasRepositoryImpl, sources_repository: SourcesRepositoryImpl, medium_image_processor: MediumImageProcessorImpl) -> MediaServiceImpl {
+    MediaService::new(media_repository, objects_repository, replicas_repository, sources_repository, medium_image_processor)
 }
 
 fn tags_service(tags_repository: TagsRepositoryImpl, tag_types_repository: TagTypesRepositoryImpl) -> TagsServiceImpl {
@@ -190,7 +190,7 @@ impl Application {
                 let medium_image_processor = medium_image_processor();
 
                 let external_services_service = external_services_service(external_services_repository);
-                let media_service = media_service(media_repository, objects_repository, replicas_repository, sources_repository, medium_image_processor, task_tracker.clone());
+                let media_service = media_service(media_repository, objects_repository, replicas_repository, sources_repository, medium_image_processor);
                 let tags_service = tags_service(tags_repository, tag_types_repository);
 
                 let normalizer = Arc::new(normalizer());
@@ -214,6 +214,7 @@ impl Application {
                     .data(normalizer)
                     .data(media_url_factory)
                     .data(thumbnail_url_factory)
+                    .data(task_tracker.clone())
                     .finish();
 
                 let graphql_service = graphql_service(schema);

--- a/api/crates/domain/Cargo.toml
+++ b/api/crates/domain/Cargo.toml
@@ -44,10 +44,6 @@ version = "2.0.11"
 version = "1.43.0"
 features = ["macros", "rt-multi-thread"]
 
-[dependencies.tokio-util]
-version = "0.7.13"
-features = ["rt"]
-
 [dependencies.uuid]
 version = "1.12.1"
 features = ["serde", "v4"]

--- a/api/crates/domain/src/tests/service/media/create_medium.rs
+++ b/api/crates/domain/src/tests/service/media/create_medium.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -142,9 +141,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_medium(
         [
             SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
@@ -280,9 +278,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_medium(
         [
             SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),

--- a/api/crates/domain/src/tests/service/media/create_replica_from_content.rs
+++ b/api/crates/domain/src/tests/service/media/create_replica_from_content.rs
@@ -5,7 +5,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
 use serial_test::serial;
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -34,7 +33,6 @@ use super::mocks::domain::{
 async fn succeeds() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -168,8 +166,8 @@ async fn succeeds() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.create_replica(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
             EntryUrlPath::from("/77777777-7777-7777-7777-777777777777.png".to_string()),
@@ -190,10 +188,24 @@ async fn succeeds() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: Some(Thumbnail {
+            id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+            size: Size::new(240, 240),
+            created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+        }),
+        original_url: "file:///77777777-7777-7777-7777-777777777777.png".to_string(),
+        mime_type: Some("image/png".to_string()),
+        size: Some(Size::new(720, 720)),
+        status: ReplicaStatus::Ready,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
@@ -201,7 +213,6 @@ async fn succeeds() {
 async fn succeeds_and_copy_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -319,8 +330,8 @@ async fn succeeds_and_copy_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.create_replica(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
             EntryUrlPath::from("/77777777-7777-7777-7777-777777777777.png".to_string()),
@@ -341,10 +352,19 @@ async fn succeeds_and_copy_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: None,
+        original_url: "file:///77777777-7777-7777-7777-777777777777.png".to_string(),
+        mime_type: None,
+        size: None,
+        status: ReplicaStatus::Error,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
@@ -352,7 +372,6 @@ async fn succeeds_and_copy_fails() {
 async fn succeeds_and_process_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -478,8 +497,8 @@ async fn succeeds_and_process_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.create_replica(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
             EntryUrlPath::from("/77777777-7777-7777-7777-777777777777.png".to_string()),
@@ -500,10 +519,19 @@ async fn succeeds_and_process_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: None,
+        original_url: "file:///77777777-7777-7777-7777-777777777777.png".to_string(),
+        mime_type: None,
+        size: None,
+        status: ReplicaStatus::Error,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
@@ -511,7 +539,6 @@ async fn succeeds_and_process_fails() {
 async fn succeeds_and_update_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -625,8 +652,8 @@ async fn succeeds_and_update_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.create_replica(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
             EntryUrlPath::from("/77777777-7777-7777-7777-777777777777.png".to_string()),
@@ -647,10 +674,8 @@ async fn succeeds_and_update_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
-
-    handle.await.unwrap();
+    let actual = task.await.unwrap_err();
+    assert_matches!(actual.kind(), ErrorKind::Other);
 }
 
 #[tokio::test]
@@ -658,7 +683,6 @@ async fn succeeds_and_update_fails() {
 async fn fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -724,7 +748,7 @@ async fn fails() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
@@ -732,10 +756,9 @@ async fn fails() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Fail,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -743,7 +766,6 @@ async fn fails() {
 async fn fails_and_delete_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -809,7 +831,7 @@ async fn fails_and_delete_fails() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
@@ -817,10 +839,9 @@ async fn fails_and_delete_fails() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Fail,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -829,7 +850,6 @@ async fn fails_with_no_url() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -864,7 +884,7 @@ async fn fails_with_no_url() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
@@ -872,10 +892,9 @@ async fn fails_with_no_url() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Fail,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectPathInvalid);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -883,7 +902,6 @@ async fn fails_with_no_url() {
 async fn fails_with_replica_already_exists() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -936,7 +954,7 @@ async fn fails_with_replica_already_exists() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
@@ -944,10 +962,9 @@ async fn fails_with_replica_already_exists() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Fail,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ReplicaOriginalUrlDuplicate { original_url, .. } if original_url == "file:///77777777-7777-7777-7777-777777777777.png");
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -955,7 +972,6 @@ async fn fails_with_replica_already_exists() {
 async fn fails_with_replica_already_exists_and_fetch_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -991,7 +1007,7 @@ async fn fails_with_replica_already_exists_and_fetch_fails() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::Content(
@@ -999,8 +1015,7 @@ async fn fails_with_replica_already_exists_and_fetch_fails() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Fail,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectAlreadyExists { url, entry } if url == "file:///77777777-7777-7777-7777-777777777777.png" && entry.is_none());
-    assert!(task_tracker.is_empty());
 }

--- a/api/crates/domain/src/tests/service/media/create_replica_from_url.rs
+++ b/api/crates/domain/src/tests/service/media/create_replica_from_url.rs
@@ -4,7 +4,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -31,7 +30,6 @@ use super::mocks::domain::{
 async fn succeeds() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -138,8 +136,8 @@ async fn succeeds() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.create_replica(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
     ).await.unwrap();
@@ -156,17 +154,30 @@ async fn succeeds() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: Some(Thumbnail {
+            id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+            size: Size::new(240, 240),
+            created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+        }),
+        original_url: "file:///77777777-7777-7777-7777-777777777777.png".to_string(),
+        mime_type: Some("image/png".to_string()),
+        size: Some(Size::new(720, 720)),
+        status: ReplicaStatus::Ready,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
 async fn succeeds_and_process_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -265,8 +276,8 @@ async fn succeeds_and_process_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.create_replica(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
     ).await.unwrap();
@@ -283,17 +294,25 @@ async fn succeeds_and_process_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: None,
+        original_url: "file:///77777777-7777-7777-7777-777777777777.png".to_string(),
+        mime_type: None,
+        size: None,
+        status: ReplicaStatus::Error,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
 async fn succeeds_and_update_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -380,8 +399,8 @@ async fn succeeds_and_update_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.create_replica(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
     ).await.unwrap();
@@ -398,17 +417,14 @@ async fn succeeds_and_update_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
-
-    handle.await.unwrap();
+    let actual = task.await.unwrap_err();
+    assert_matches!(actual.kind(), ErrorKind::Other);
 }
 
 #[tokio::test]
 async fn fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -453,14 +469,13 @@ async fn fails() {
         })
         .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -468,7 +483,6 @@ async fn fails_with_no_url() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -493,14 +507,13 @@ async fn fails_with_no_url() {
             )))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectPathInvalid);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -508,7 +521,6 @@ async fn fails_with_no_entry() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -528,12 +540,11 @@ async fn fails_with_no_entry() {
             )))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_replica(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///77777777-7777-7777-7777-777777777777.png".to_string())),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectGetFailed { url } if url == "file:///77777777-7777-7777-7777-777777777777.png");
-    assert!(task_tracker.is_empty());
 }

--- a/api/crates/domain/src/tests/service/media/create_source.rs
+++ b/api/crates/domain/src/tests/service/media/create_source.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -30,7 +29,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -59,7 +57,7 @@ async fn succeeds() {
             }))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_source(
         ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
         ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) },
@@ -87,7 +85,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -101,7 +98,7 @@ async fn fails() {
         })
         .returning(|_, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.create_source(
         ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
         ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) },

--- a/api/crates/domain/src/tests/service/media/delete_medium_by_id.rs
+++ b/api/crates/domain/src/tests/service/media/delete_medium_by_id.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -40,9 +39,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), false).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
@@ -144,9 +142,8 @@ async fn succeeds_with_delete_objects() {
 
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), true).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
@@ -174,9 +171,8 @@ async fn succeeds_with_delete_objects_not_found() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), true).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
@@ -195,9 +191,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), false).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
@@ -225,9 +220,8 @@ async fn fails_with_fetching_medium() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), true).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
@@ -310,9 +304,8 @@ async fn fails_with_deleting_object() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), true).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectDeleteFailed { url } if url == "file:///77777777-7777-7777-7777-777777777777.png");
@@ -396,9 +389,8 @@ async fn fails_with_deleting_replica() {
 
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_medium_by_id(MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")), true).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);

--- a/api/crates/domain/src/tests/service/media/delete_source_by_id.rs
+++ b/api/crates/domain/src/tests/service/media/delete_source_by_id.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -27,7 +26,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -36,7 +34,7 @@ async fn succeeds() {
         .withf(|id| id == &SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")))
         .returning(|_| Box::pin(ok(DeleteResult::Deleted(1))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_source_by_id(SourceId::from(uuid!("11111111-1111-1111-1111-111111111111"))).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
@@ -48,7 +46,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -57,7 +54,7 @@ async fn fails() {
         .withf(|id| id == &SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")))
         .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.delete_source_by_id(SourceId::from(uuid!("11111111-1111-1111-1111-111111111111"))).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);

--- a/api/crates/domain/src/tests/service/media/get_media.rs
+++ b/api/crates/domain/src/tests/service/media/get_media.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -73,9 +72,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media(
         Some(TagDepth::new(1, 1)),
         true,
@@ -137,9 +135,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media(
         Some(TagDepth::new(1, 1)),
         true,

--- a/api/crates/domain/src/tests/service/media/get_media_by_ids.rs
+++ b/api/crates/domain/src/tests/service/media/get_media_by_ids.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -64,9 +63,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media_by_ids(
         [
             MediumId::from(uuid!("88888888-8888-8888-8888-888888888888")),
@@ -120,9 +118,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media_by_ids(
         [
             MediumId::from(uuid!("88888888-8888-8888-8888-888888888888")),

--- a/api/crates/domain/src/tests/service/media/get_media_by_source_ids.rs
+++ b/api/crates/domain/src/tests/service/media/get_media_by_source_ids.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -69,9 +68,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media_by_source_ids(
         [
             SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
@@ -133,9 +131,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media_by_source_ids(
         [
             SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),

--- a/api/crates/domain/src/tests/service/media/get_media_by_tag_ids.rs
+++ b/api/crates/domain/src/tests/service/media/get_media_by_tag_ids.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -75,9 +74,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media_by_tag_ids(
         [
             (
@@ -151,9 +149,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_media_by_tag_ids(
         [
             (

--- a/api/crates/domain/src/tests/service/media/get_object.rs
+++ b/api/crates/domain/src/tests/service/media/get_object.rs
@@ -4,7 +4,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 
 use crate::{
     entity::objects::{Entry, EntryKind, EntryMetadata, EntryUrl},
@@ -28,7 +27,6 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -52,7 +50,7 @@ async fn succeeds() {
             )))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_object(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())).await.unwrap();
 
     assert_eq!(actual, Entry::new(
@@ -74,7 +72,6 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -88,7 +85,7 @@ async fn fails() {
             )))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_object(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectNotFound { url } if url == "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg");

--- a/api/crates/domain/src/tests/service/media/get_objects.rs
+++ b/api/crates/domain/src/tests/service/media/get_objects.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
 use serial_test::serial;
-use tokio_util::task::TaskTracker;
 
 use crate::{
     entity::objects::{Entry, EntryKind, EntryUrl, EntryUrlPath},
@@ -27,7 +26,6 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -74,7 +72,7 @@ async fn succeeds() {
         .expect()
         .return_const("file");
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_objects(EntryUrlPath::from("/path/to/dest".to_string()), None).await.unwrap();
 
     assert_eq!(actual, vec![
@@ -118,7 +116,6 @@ async fn succeeds_with_kind() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -165,7 +162,7 @@ async fn succeeds_with_kind() {
         .expect()
         .return_const("file");
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_objects(EntryUrlPath::from("/path/to/dest".to_string()), Some(EntryKind::Container)).await.unwrap();
 
     assert_eq!(actual, vec![
@@ -191,7 +188,6 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -210,7 +206,7 @@ async fn fails() {
         .expect()
         .return_const("file");
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_objects(EntryUrlPath::from("/path/to/dest".to_string()), None).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectGetFailed { url } if url == "file:///path/to/dest");

--- a/api/crates/domain/src/tests/service/media/get_replica_by_original_url.rs
+++ b/api/crates/domain/src/tests/service/media/get_replica_by_original_url.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -27,7 +26,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_replicas_repository = MockReplicasRepository::new();
     mock_replicas_repository
@@ -53,7 +51,7 @@ async fn succeeds() {
             }))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_replica_by_original_url("file:///77777777-7777-7777-7777-777777777777.png").await.unwrap();
 
     assert_eq!(actual, Replica {
@@ -80,7 +78,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_replicas_repository = MockReplicasRepository::new();
     mock_replicas_repository
@@ -89,7 +86,7 @@ async fn fails() {
         .withf(|original_url| original_url == "file:///77777777-7777-7777-7777-777777777777.png")
         .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_replica_by_original_url("file:///77777777-7777-7777-7777-777777777777.png").await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);

--- a/api/crates/domain/src/tests/service/media/get_replicas_by_ids.rs
+++ b/api/crates/domain/src/tests/service/media/get_replicas_by_ids.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -27,7 +26,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_replicas_repository = MockReplicasRepository::new();
     mock_replicas_repository
@@ -74,7 +72,7 @@ async fn succeeds() {
             ]))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_replicas_by_ids([
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")),
@@ -122,7 +120,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_replicas_repository = MockReplicasRepository::new();
     mock_replicas_repository
@@ -134,7 +131,7 @@ async fn fails() {
         ]))
         .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_replicas_by_ids(vec![
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         ReplicaId::from(uuid!("77777777-7777-7777-7777-777777777777")),

--- a/api/crates/domain/src/tests/service/media/get_source_by_external_metadata.rs
+++ b/api/crates/domain/src/tests/service/media/get_source_by_external_metadata.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -30,7 +29,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -59,7 +57,7 @@ async fn succeeds() {
             })))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_source_by_external_metadata(
          ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
          ExternalMetadata::Pixiv { id: 56736941 },
@@ -87,7 +85,6 @@ async fn not_found() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -101,7 +98,7 @@ async fn not_found() {
         })
         .returning(|_, _| Box::pin(ok(None)));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_source_by_external_metadata(
          ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
          ExternalMetadata::Pixiv { id: 56736941 },
@@ -116,7 +113,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -130,7 +126,7 @@ async fn fails() {
         })
         .returning(|_, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_source_by_external_metadata(
          ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
          ExternalMetadata::Pixiv { id: 56736941 },

--- a/api/crates/domain/src/tests/service/media/get_sources_by_external_metadata_like.rs
+++ b/api/crates/domain/src/tests/service/media/get_sources_by_external_metadata_like.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -30,7 +29,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -56,7 +54,7 @@ async fn succeeds() {
             ]))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_sources_by_external_metadata_like_id("56736941").await.unwrap();
 
     assert_eq!(actual, vec![
@@ -83,7 +81,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -92,7 +89,7 @@ async fn fails() {
         .withf(|id| id == "56736941")
         .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_sources_by_external_metadata_like_id("56736941").await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);

--- a/api/crates/domain/src/tests/service/media/get_sources_by_ids.rs
+++ b/api/crates/domain/src/tests/service/media/get_sources_by_ids.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -30,7 +29,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -73,7 +71,7 @@ async fn succeeds() {
             ]))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_sources_by_ids([
         SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
         SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
@@ -117,7 +115,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -129,7 +126,7 @@ async fn fails() {
         ]))
         .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_sources_by_ids([
         SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
         SourceId::from(uuid!("22222222-2222-2222-2222-222222222222")),

--- a/api/crates/domain/src/tests/service/media/get_thumbnail_by_id.rs
+++ b/api/crates/domain/src/tests/service/media/get_thumbnail_by_id.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -26,7 +25,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_replicas_repository = MockReplicasRepository::new();
     mock_replicas_repository
@@ -35,7 +33,7 @@ async fn succeeds() {
         .withf(|id| id == &ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")))
         .returning(|_| Box::pin(ok(vec![0x01, 0x02, 0x03, 0x04])));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_thumbnail_by_id(ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888"))).await.unwrap();
 
     assert_eq!(actual, vec![0x01, 0x02, 0x03, 0x04]);
@@ -47,7 +45,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_replicas_repository = MockReplicasRepository::new();
     mock_replicas_repository
@@ -56,7 +53,7 @@ async fn fails() {
         .withf(|id| id == &ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")))
         .returning(|_| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.get_thumbnail_by_id(ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888"))).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);

--- a/api/crates/domain/src/tests/service/media/update_medium_by_id.rs
+++ b/api/crates/domain/src/tests/service/media/update_medium_by_id.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -97,9 +96,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_medium_by_id(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         [
@@ -200,9 +198,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_medium_by_id(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         [

--- a/api/crates/domain/src/tests/service/media/update_replica_by_id_from_content.rs
+++ b/api/crates/domain/src/tests/service/media/update_replica_by_id_from_content.rs
@@ -5,7 +5,6 @@ use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
 use serial_test::serial;
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -33,7 +32,6 @@ use super::mocks::domain::{
 async fn succeeds() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -167,8 +165,8 @@ async fn succeeds() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.update_replica_by_id(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
             EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()),
@@ -189,10 +187,24 @@ async fn succeeds() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: Some(Thumbnail {
+            id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+            size: Size::new(240, 240),
+            created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+        }),
+        original_url: "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+        mime_type: Some("image/jpeg".to_string()),
+        size: Some(Size::new(720, 720)),
+        status: ReplicaStatus::Ready,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
@@ -200,7 +212,6 @@ async fn succeeds() {
 async fn succeeds_and_copy_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -318,8 +329,8 @@ async fn succeeds_and_copy_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.update_replica_by_id(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
             EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()),
@@ -340,10 +351,19 @@ async fn succeeds_and_copy_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: None,
+        original_url: "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+        mime_type: None,
+        size: None,
+        status: ReplicaStatus::Error,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
@@ -351,7 +371,6 @@ async fn succeeds_and_copy_fails() {
 async fn succeeds_and_process_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -477,8 +496,8 @@ async fn succeeds_and_process_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.update_replica_by_id(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
             EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()),
@@ -499,10 +518,19 @@ async fn succeeds_and_process_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: None,
+        original_url: "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+        mime_type: None,
+        size: None,
+        status: ReplicaStatus::Error,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
@@ -510,7 +538,6 @@ async fn succeeds_and_process_fails() {
 async fn succeeds_and_update_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -624,8 +651,8 @@ async fn succeeds_and_update_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.update_replica_by_id(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
             EntryUrlPath::from("/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string()),
@@ -646,10 +673,8 @@ async fn succeeds_and_update_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
-
-    handle.await.unwrap();
+    let actual = task.await.unwrap_err();
+    assert_matches!(actual.kind(), ErrorKind::Other);
 }
 
 #[tokio::test]
@@ -657,7 +682,6 @@ async fn succeeds_and_update_fails() {
 async fn fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -723,7 +747,7 @@ async fn fails() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
@@ -731,10 +755,9 @@ async fn fails() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Overwrite,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -742,7 +765,6 @@ async fn fails() {
 async fn fails_and_delete_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -808,7 +830,7 @@ async fn fails_and_delete_fails() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
@@ -816,10 +838,9 @@ async fn fails_and_delete_fails() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Overwrite,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -828,7 +849,6 @@ async fn fails_with_no_url() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -863,7 +883,7 @@ async fn fails_with_no_url() {
         .expect_clone()
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
@@ -871,10 +891,9 @@ async fn fails_with_no_url() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Overwrite,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectPathInvalid);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -882,7 +901,6 @@ async fn fails_with_no_url() {
 async fn fails_with_replica_already_exists() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -936,7 +954,7 @@ async fn fails_with_replica_already_exists() {
         .times(1)
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
@@ -944,10 +962,9 @@ async fn fails_with_replica_already_exists() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Fail,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ReplicaOriginalUrlDuplicate { original_url, .. } if original_url == "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg");
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -955,7 +972,6 @@ async fn fails_with_replica_already_exists() {
 async fn fails_with_replica_already_exists_and_fetch_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_objects_repository = MockObjectsRepository::new();
     mock_objects_repository
@@ -992,7 +1008,7 @@ async fn fails_with_replica_already_exists_and_fetch_fails() {
         .times(1)
         .returning(MockMediumImageProcessor::new);
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::Content(
@@ -1000,8 +1016,7 @@ async fn fails_with_replica_already_exists_and_fetch_fails() {
             Cursor::new(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
             MediumOverwriteBehavior::Fail,
         ),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectAlreadyExists { url, entry } if url == "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg" && entry.is_none());
-    assert!(task_tracker.is_empty());
 }

--- a/api/crates/domain/src/tests/service/media/update_replica_by_id_from_url.rs
+++ b/api/crates/domain/src/tests/service/media/update_replica_by_id_from_url.rs
@@ -4,7 +4,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -30,7 +29,6 @@ use super::mocks::domain::{
 async fn succeeds() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -137,8 +135,8 @@ async fn succeeds() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.update_replica_by_id(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
     ).await.unwrap();
@@ -155,17 +153,30 @@ async fn succeeds() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: Some(Thumbnail {
+            id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+            size: Size::new(240, 240),
+            created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+            updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+        }),
+        original_url: "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+        mime_type: Some("image/jpeg".to_string()),
+        size: Some(Size::new(720, 720)),
+        status: ReplicaStatus::Ready,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
 async fn succeeds_and_process_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -264,8 +275,8 @@ async fn succeeds_and_process_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.update_replica_by_id(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
     ).await.unwrap();
@@ -282,17 +293,25 @@ async fn succeeds_and_process_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
+    let actual = task.await.unwrap();
 
-    handle.await.unwrap();
+    assert_eq!(actual, Replica {
+        id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+        display_order: 1,
+        thumbnail: None,
+        original_url: "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+        mime_type: None,
+        size: None,
+        status: ReplicaStatus::Error,
+        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+    });
 }
 
 #[tokio::test]
 async fn succeeds_and_update_fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -379,8 +398,8 @@ async fn succeeds_and_update_fails() {
             mock_replicas_repository
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
-    let (actual, handle) = service.update_replica_by_id(
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
+    let (actual, task) = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
     ).await.unwrap();
@@ -397,17 +416,14 @@ async fn succeeds_and_update_fails() {
         updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
     });
 
-    task_tracker.close();
-    task_tracker.wait().await;
-
-    handle.await.unwrap();
+    let actual = task.await.unwrap_err();
+    assert_matches!(actual.kind(), ErrorKind::Other);
 }
 
 #[tokio::test]
 async fn fails() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -452,14 +468,13 @@ async fn fails() {
         })
         .returning(|_, _, _, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::Other);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -467,7 +482,6 @@ async fn fails_with_no_url() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -492,14 +506,13 @@ async fn fails_with_no_url() {
             )))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectPathInvalid);
-    assert!(task_tracker.is_empty());
 }
 
 #[tokio::test]
@@ -507,7 +520,6 @@ async fn fails_with_no_entry() {
     let mock_media_repository = MockMediaRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_medium_image_processor = MockMediumImageProcessor::new();
     mock_medium_image_processor
@@ -527,12 +539,11 @@ async fn fails_with_no_entry() {
             )))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker.clone());
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_replica_by_id(
         ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
         MediumSource::<Cursor<&[_]>>::Url(EntryUrl::from("file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string())),
-    ).await.unwrap_err();
+    ).await.map(|(replica, _task)| replica).unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ObjectGetFailed { url } if url == "file:///77777777-7777-7777-7777-777777777777.png");
-    assert!(task_tracker.is_empty());
 }

--- a/api/crates/domain/src/tests/service/media/update_source_by_id.rs
+++ b/api/crates/domain/src/tests/service/media/update_source_by_id.rs
@@ -2,7 +2,6 @@ use anyhow::anyhow;
 use chrono::{TimeZone, Utc};
 use futures::future::{err, ok};
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -30,7 +29,6 @@ async fn succeeds() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -60,7 +58,7 @@ async fn succeeds() {
             }))
         });
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_source_by_id(
         SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
         Some(ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111"))),
@@ -89,7 +87,6 @@ async fn fails() {
     let mock_objects_repository = MockObjectsRepository::new();
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
     let mut mock_sources_repository = MockSourcesRepository::new();
     mock_sources_repository
@@ -104,7 +101,7 @@ async fn fails() {
         })
         .returning(|_, _, _| Box::pin(err(Error::other(anyhow!("error communicating with database")))));
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.update_source_by_id(
         SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
         Some(ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111"))),

--- a/api/crates/domain/src/tests/service/media/watch_medium_by_id.rs
+++ b/api/crates/domain/src/tests/service/media/watch_medium_by_id.rs
@@ -3,7 +3,6 @@ use chrono::{TimeZone, Utc};
 use futures::{future::{err, ok}, stream, StreamExt, TryFutureExt, TryStreamExt};
 use ordermap::OrderMap;
 use pretty_assertions::{assert_eq, assert_matches};
-use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{
@@ -77,9 +76,8 @@ async fn succeeds() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let stream = service.watch_medium_by_id(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         Some(TagDepth::new(1, 1)),
@@ -140,9 +138,8 @@ async fn fails() {
     let mock_replicas_repository = MockReplicasRepository::new();
     let mock_sources_repository = MockSourcesRepository::new();
     let mock_medium_image_processor = MockMediumImageProcessor::new();
-    let task_tracker = TaskTracker::new();
 
-    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor, task_tracker);
+    let service = MediaService::new(mock_media_repository, mock_objects_repository, mock_replicas_repository, mock_sources_repository, mock_medium_image_processor);
     let actual = service.watch_medium_by_id(
         MediumId::from(uuid!("77777777-7777-7777-7777-777777777777")),
         Some(TagDepth::new(1, 1)),

--- a/api/crates/graphql/Cargo.toml
+++ b/api/crates/graphql/Cargo.toml
@@ -57,6 +57,10 @@ version = "1.0.138"
 [dependencies.thiserror]
 version = "2.0.11"
 
+[dependencies.tokio-util]
+version = "0.7.13"
+features = ["rt"]
+
 [dependencies.tower-service]
 version = "0.3.3"
 

--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -12,6 +12,7 @@ use domain::{
     },
 };
 use normalizer::NormalizerInterface;
+use tokio_util::task::TaskTracker;
 use uuid::Uuid;
 
 use crate::{
@@ -210,9 +211,12 @@ where
         upload: Option<ReplicaInput>,
     ) -> Result<Replica> {
         let media_service = ctx.data_unchecked::<MediaService>();
+        let tracker = ctx.data_unchecked::<TaskTracker>();
 
         let medium_source = create_medium_source(ctx, original_url, upload).await?;
-        let (replica, _handle) = media_service.create_replica(medium_id.into(), medium_source).await?;
+        let (replica, task) = media_service.create_replica(medium_id.into(), medium_source).await?;
+        tracker.spawn(task);
+
         Ok(replica.into())
     }
 
@@ -318,9 +322,12 @@ where
         upload: Option<ReplicaInput>,
     ) -> Result<Replica> {
         let media_service = ctx.data_unchecked::<MediaService>();
+        let tracker = ctx.data_unchecked::<TaskTracker>();
 
         let medium_source = create_medium_source(ctx, original_url, upload).await?;
-        let (replica, _handle) = media_service.update_replica_by_id(id.into(), medium_source).await?;
+        let (replica, task) = media_service.update_replica_by_id(id.into(), medium_source).await?;
+        tracker.spawn(task);
+
         Ok(replica.into())
     }
 

--- a/api/crates/graphql/src/tests/mocks/domain/service/media.rs
+++ b/api/crates/graphql/src/tests/mocks/domain/service/media.rs
@@ -16,8 +16,7 @@ use domain::{
     repository::{DeleteResult, Direction, Order},
     service::media::{MediaServiceInterface, MediumSource},
 };
-use futures::stream::BoxStream;
-use tokio::task::JoinHandle;
+use futures::{future::BoxFuture, stream::BoxStream};
 
 mockall::mock! {
     pub(crate) MediaServiceInterface {}
@@ -29,7 +28,7 @@ mockall::mock! {
             T: CloneableIterator<Item = SourceId> + Send,
             U: CloneableIterator<Item = (TagId, TagTypeId)> + Send;
 
-        fn create_replica<R>(&self, medium_id: MediumId, medium_source: MediumSource<R>) -> impl Future<Output = Result<(Replica, JoinHandle<()>)>> + Send
+        fn create_replica<R>(&self, medium_id: MediumId, medium_source: MediumSource<R>) -> impl Future<Output = Result<(Replica, BoxFuture<'static, Result<Replica>>)>> + Send
         where
             R: Read + Seek + Send + 'static;
 
@@ -126,7 +125,7 @@ mockall::mock! {
             W: CloneableIterator<Item = (TagId, TagTypeId)> + Send,
             X: CloneableIterator<Item = ReplicaId> + Send;
 
-        fn update_replica_by_id<R>(&self, id: ReplicaId, medium_source: MediumSource<R>) -> impl Future<Output = Result<(Replica, JoinHandle<()>)>> + Send
+        fn update_replica_by_id<R>(&self, id: ReplicaId, medium_source: MediumSource<R>) -> impl Future<Output = Result<(Replica, BoxFuture<'static, Result<Replica>>)>> + Send
         where
             R: Read + Seek + Send + 'static;
 

--- a/api/crates/graphql/src/tests/mutation/update_replica.rs
+++ b/api/crates/graphql/src/tests/mutation/update_replica.rs
@@ -6,16 +6,16 @@ use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
         objects::{EntryUrl, EntryUrlPath},
-        replicas::{Replica, ReplicaId, ReplicaStatus},
+        replicas::{Replica, ReplicaId, ReplicaStatus, Size, Thumbnail, ThumbnailId},
     },
     service::media::{MediumOverwriteBehavior, MediumSource},
 };
-use futures::future::{ok, ready};
+use futures::{future::ok, FutureExt};
 use indoc::indoc;
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use tempfile::tempfile;
-use tokio::task;
+use tokio_util::task::TaskTracker;
 use uuid::uuid;
 
 use crate::{mutation::Mutation, query::Query};
@@ -35,6 +35,7 @@ async fn succeeds_with_original_url() {
     let external_services_service = MockExternalServicesServiceInterface::new();
     let tags_service = MockTagsServiceInterface::new();
     let normalizer = MockNormalizerInterface::new();
+    let task_tracker = TaskTracker::new();
 
     let mut media_service = MockMediaServiceInterface::new();
     media_service
@@ -57,7 +58,22 @@ async fn succeeds_with_original_url() {
                     created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
                 },
-                task::spawn(ready(())),
+                ok(Replica {
+                    id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+                    display_order: 1,
+                    thumbnail: Some(Thumbnail {
+                        id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+                        size: Size::new(240, 240),
+                        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+                        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+                    }),
+                    original_url: "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+                    mime_type: Some("image/jpeg".to_string()),
+                    size: Some(Size::new(720, 720)),
+                    status: ReplicaStatus::Ready,
+                    created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+                }).boxed(),
             )))
         });
 
@@ -76,6 +92,7 @@ async fn succeeds_with_original_url() {
         .data(tags_service)
         .data(Arc::new(normalizer))
         .data::<Arc<dyn MediaURLFactoryInterface>>(Arc::new(media_url_factory))
+        .data(task_tracker)
         .finish();
 
     let req = indoc! {r#"
@@ -133,6 +150,7 @@ async fn succeeds_with_upload() {
     let external_services_service = MockExternalServicesServiceInterface::new();
     let tags_service = MockTagsServiceInterface::new();
     let normalizer = MockNormalizerInterface::new();
+    let task_tracker = TaskTracker::new();
 
     let mut media_service = MockMediaServiceInterface::new();
     media_service
@@ -164,7 +182,22 @@ async fn succeeds_with_upload() {
                     created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
                     updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
                 },
-                task::spawn(ready(())),
+                ok(Replica {
+                    id: ReplicaId::from(uuid!("66666666-6666-6666-6666-666666666666")),
+                    display_order: 1,
+                    thumbnail: Some(Thumbnail {
+                        id: ThumbnailId::from(uuid!("88888888-8888-8888-8888-888888888888")),
+                        size: Size::new(240, 240),
+                        created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 2, 0).unwrap(),
+                        updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 3, 0).unwrap(),
+                    }),
+                    original_url: "file:///aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.jpg".to_string(),
+                    mime_type: Some("image/jpeg".to_string()),
+                    size: Some(Size::new(720, 720)),
+                    status: ReplicaStatus::Ready,
+                    created_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 0, 0).unwrap(),
+                    updated_at: Utc.with_ymd_and_hms(2022, 6, 2, 0, 1, 0).unwrap(),
+                }).boxed(),
             )))
         });
 
@@ -183,6 +216,7 @@ async fn succeeds_with_upload() {
         .data(tags_service)
         .data(Arc::new(normalizer))
         .data::<Arc<dyn MediaURLFactoryInterface>>(Arc::new(media_url_factory))
+        .data(task_tracker)
         .finish();
 
     let query = indoc! {r#"


### PR DESCRIPTION
This PR changes `domain::service::media::MediaService::{create_replica,update_replica_by_id}` to return `Future` that processes a replica. Previously it returned `tokio::task::JoinHandle`, but now lets the callee handle this `Future`. 

This PR also refactors internal implementation to return `impl FnOnce` rather than `Box<dyn FnOnce>` to avoid `Box`-ing the closure.