### PR TITLE
Improve logging of errors

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -780,6 +780,8 @@ dependencies = [
  "chrono",
  "derive_more",
  "futures",
+ "indenter",
+ "indoc",
  "log",
  "mockall",
  "ordermap",
@@ -1644,6 +1646,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"

--- a/api/crates/domain/Cargo.toml
+++ b/api/crates/domain/Cargo.toml
@@ -21,6 +21,9 @@ version = "0.3.31"
 features = ["std"]
 default-features = false
 
+[dependencies.indenter]
+version = "0.3.3"
+
 [dependencies.log]
 version = "0.4.25"
 
@@ -50,6 +53,9 @@ features = ["serde", "v4"]
 
 [dev-dependencies.anyhow]
 version = "1.0.95"
+
+[dev-dependencies.indoc]
+version = "2.0.5"
 
 [dev-dependencies.mockall]
 version = "0.13.1"

--- a/api/crates/domain/src/tests/error.rs
+++ b/api/crates/domain/src/tests/error.rs
@@ -1,3 +1,7 @@
+use std::fmt::Write;
+
+use anyhow::anyhow;
+use indoc::indoc;
 use pretty_assertions::{assert_eq, assert_matches};
 
 use crate::error::{Error, ErrorKind};
@@ -33,4 +37,94 @@ fn into_inner_succeeds() {
     let error = Error::other("error communicating with database");
     let actual = error.into_inner();
     assert_matches!(actual, (ErrorKind::Other, Some(e)) if e.to_string() == "error communicating with database");
+}
+
+#[test]
+fn debug_fmt_succeeds() {
+    let error = Error::new(ErrorKind::Other, "error communicating with database");
+    let actual = {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", &error).unwrap();
+        s
+    };
+    assert_eq!(actual, "error communicating with database");
+
+    let error = Error::other("error communicating with database");
+    let actual = {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", &error).unwrap();
+        s
+    };
+    assert_eq!(actual, "error communicating with database");
+}
+
+#[test]
+fn debug_fmt_with_details_succeeds() {
+    let error = Error::from(ErrorKind::Other);
+    let actual = {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", &error).unwrap();
+        s
+    };
+    assert_eq!(actual, indoc! {"
+        other error
+        Details:
+              Other"
+    });
+}
+
+#[test]
+fn debug_fmt_with_single_source_succeeds() {
+    let error = Error::new(ErrorKind::Other, anyhow!("error communicating with database").context("error fetching data"));
+    let actual = {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", &error).unwrap();
+        s
+    };
+    assert_eq!(actual, indoc! {"
+        error fetching data
+        Caused by:
+              error communicating with database"
+    });
+
+    let error = Error::other(anyhow!("error communicating with database").context("error fetching data"));
+    let actual = {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", &error).unwrap();
+        s
+    };
+    assert_eq!(actual, indoc! {"
+        error fetching data
+        Caused by:
+              error communicating with database"
+    });
+}
+
+#[test]
+fn debug_fmt_with_multiple_sources_succeeds() {
+    let error = Error::new(ErrorKind::Other, anyhow!("error communicating with database").context("error fetching data").context("query error"));
+    let actual = {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", &error).unwrap();
+        s
+    };
+    assert_eq!(actual, indoc! {"
+        query error
+        Caused by:
+           0: error fetching data
+           1: error communicating with database"
+    });
+
+    let error = Error::other(anyhow!("error communicating with database").context("error fetching data").context("query error"));
+    let actual = {
+        let mut s = String::new();
+        write!(&mut s, "{:?}", &error).unwrap();
+        s
+    };
+    assert_eq!(actual, indoc! {"
+        query error
+        Caused by:
+           0: error fetching data
+           1: error communicating with database"
+    });
 }


### PR DESCRIPTION
This PR manually implements `std::fmt::Debug` for `domain::error::Error` to improve error logging.

Previously it was a simple `#[derive(Debug)]` so the internal representation was logged:

```
[2025-02-04T00:00:00Z ERROR domain::service::media] failed to put an image
Error: Error { kind: ObjectAlreadyExists { url: "file:///%E5%8E%9F%E7%A5%9E/pixiv_97622344.png", entry: Some(Entry { name: "pixiv_97622344.png", url: Some(EntryUrl("file:///%E5%8E%9F%E7%A5%9E/pixiv_97622344.png")), kind: Object, metadata: Some(EntryMetadata { size: 800981, created_at: Some(2022-04-23T14:12:54.841647Z), updated_at: Some(2022-04-23T14:12:54.841647Z), accessed_at: Some(2022-04-29T08:38:17.852821700Z) }) }) }, error: Some(Os { code: 17, kind: AlreadyExists, message: "File exists" }) }
```

Now it prints the error message and optionally its source:

```
[2025-02-04T00:00:00Z ERROR domain::service::media] failed to put an image
Error: the object with the same path already exists
Details:
      ObjectAlreadyExists {
          url: "file:///%E5%8E%9F%E7%A5%9E/pixiv_97622344.png",
          entry: Some(
              Entry {
                  name: "pixiv_97622344.png",
                  url: Some(
                      EntryUrl(
                          "file:///%E5%8E%9F%E7%A5%9E/pixiv_97622344.png",
                      ),
                  ),
                  kind: Object,
                  metadata: Some(
                      EntryMetadata {
                          size: 800981,
                          created_at: Some(
                              2022-04-23T14:12:54.841647Z,
                          ),
                          updated_at: Some(
                              2022-04-23T14:12:54.841647Z,
                          ),
                          accessed_at: Some(
                              2022-04-29T08:38:17.852821700Z,
                          ),
                      },
                  ),
              },
          ),
      }
Caused by:
      File exists (os error 17)
```