### PR TITLE
Introduce tracing for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ $ docker run --rm -it ghcr.io/chitoku-k/hoarder/api migration apply
 #### Global Options
 
 - `--locale` (`LOCALE`): [Unicode locale identifier](https://unicode.org/reports/tr35/tr35.html#Unicode_locale_identifier) for collation order
-- `--log-level` (`LOG_LEVEL`): Log level as in [RUST\_LOG](https://docs.rs/env_logger/latest/env_logger/)
+- `--log-format` (`LOG_FORMAT`): Log format (`compact` or `pretty`)
+- `--log-level` (`LOG_LEVEL`): Log level as in [Directives](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html)
 
 The following environment variables can be used to configure PostgreSQL connection:
 

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -59,15 +59,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -97,12 +98,13 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -122,7 +124,6 @@ dependencies = [
  "futures",
  "hyper",
  "indoc",
- "log",
  "mockall",
  "notify",
  "pretty_assertions",
@@ -131,6 +132,8 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "tower 0.5.2",
+ "tower-http",
+ "tracing",
  "tungstenite",
 ]
 
@@ -184,6 +187,8 @@ dependencies = [
  "static_assertions_next",
  "tempfile",
  "thiserror 1.0.68",
+ "tracing",
+ "tracing-futures",
  "uuid",
 ]
 
@@ -782,7 +787,6 @@ dependencies = [
  "futures",
  "indenter",
  "indoc",
- "log",
  "mockall",
  "ordermap",
  "percent-encoding",
@@ -792,6 +796,7 @@ dependencies = [
  "serial_test",
  "thiserror 2.0.11",
  "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -823,29 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
 ]
 
 [[package]]
@@ -1185,6 +1167,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower-service",
+ "tracing",
+ "tracing-futures",
  "uuid",
 ]
 
@@ -1299,16 +1283,15 @@ dependencies = [
 name = "hoarder"
 version = "0.8.4"
 dependencies = [
+ "anstream",
  "anyhow",
  "application",
  "clap",
  "domain",
- "env_logger",
  "graphql",
  "icu_collator",
  "icu_locid",
  "icu_provider",
- "log",
  "media",
  "normalizer",
  "objects",
@@ -1318,6 +1301,8 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1374,12 +1359,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1713,6 +1692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,6 +1799,15 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "matchit"
@@ -1978,6 +1972,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,13 +2052,14 @@ dependencies = [
  "axum",
  "derive_more",
  "domain",
+ "tracing",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "openssl"
@@ -2109,6 +2114,12 @@ dependencies = [
  "indexmap 2.7.1",
  "serde",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2335,7 +2346,6 @@ dependencies = [
  "domain",
  "futures",
  "include_dir",
- "log",
  "ordermap",
  "pretty_assertions",
  "sea-query",
@@ -2347,6 +2357,8 @@ dependencies = [
  "sqlx_migrator",
  "test-context",
  "tokio",
+ "tracing",
+ "tracing-futures",
  "uuid",
 ]
 
@@ -2479,8 +2491,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2491,8 +2512,14 @@ checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2784,6 +2811,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3111,6 +3147,7 @@ dependencies = [
  "normalize-path",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -3267,6 +3304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "thumbnails"
 version = "0.0.0"
 dependencies = [
@@ -3275,6 +3322,7 @@ dependencies = [
  "derive_more",
  "domain",
  "image",
+ "tracing",
 ]
 
 [[package]]
@@ -3482,6 +3530,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.7.0",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3495,11 +3559,10 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3508,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3519,11 +3582,53 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3627,6 +3732,12 @@ dependencies = [
  "getrandom 0.3.1",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -94,15 +94,15 @@ workspace = true
 [dependencies.thumbnails]
 workspace = true
 
+[dependencies.anstream]
+version = "0.6.18"
+
 [dependencies.anyhow]
 version = "1.0.95"
 
 [dependencies.clap]
 version = "4.5.28"
 features = ["cargo", "derive", "env", "error-context", "string"]
-
-[dependencies.env_logger]
-version = "0.11.6"
 
 [dependencies.icu_collator]
 version = "1.5.0"
@@ -116,9 +116,6 @@ features = ["std"]
 version = "1.5.0"
 features = ["std", "sync"]
 
-[dependencies.log]
-version = "0.4.25"
-
 [dependencies.tikv-jemallocator]
 version = "0.6.0"
 optional = true
@@ -129,3 +126,10 @@ version = "1.43.0"
 [dependencies.tokio-util]
 version = "0.7.13"
 features = ["rt"]
+
+[dependencies.tracing]
+version = "0.1.41"
+
+[dependencies.tracing-subscriber]
+version = "0.3.19"
+features = ["env-filter"]

--- a/api/crates/application/Cargo.toml
+++ b/api/crates/application/Cargo.toml
@@ -22,9 +22,6 @@ version = "0.7.1"
 [dependencies.derive_more]
 version = "2.0.1"
 
-[dependencies.log]
-version = "0.4.25"
-
 [dependencies.notify]
 version = "8.0.0"
 
@@ -37,6 +34,13 @@ version = "2.0.11"
 [dependencies.tokio]
 version = "1.43.0"
 features = ["macros", "net", "process", "rt-multi-thread", "signal"]
+
+[dependencies.tower-http]
+version = "0.6.2"
+features = ["trace"]
+
+[dependencies.tracing]
+version = "0.1.41"
 
 [dev-dependencies.futures]
 version = "0.3.31"

--- a/api/crates/core/di/container.rs
+++ b/api/crates/core/di/container.rs
@@ -13,10 +13,9 @@ use domain::{
         tags::TagsService,
     },
 };
-use graphql::{mutation::Mutation, query::Query, subscription::Subscription, Schema, SchemaBuilder, GraphQLService};
+use graphql::{mutation::Mutation, query::Query, subscription::Subscription, GraphQLService, Schema, SchemaBuilder, Tracing};
 use icu_collator::{Collator, CollatorOptions};
 use icu_provider::DataLocale;
-use log::LevelFilter;
 use media::{FileMediaURLFactory, NoopMediaURLFactory};
 use normalizer::Normalizer;
 use objects::ObjectsService;
@@ -35,6 +34,7 @@ use thumbnails::{
     ThumbnailURLFactory, ThumbnailsService,
 };
 use tokio_util::task::TaskTracker;
+use tracing::log::LevelFilter;
 
 use crate::env::{self, commands::{Commands, SchemaCommand, SchemaCommands}};
 
@@ -215,6 +215,7 @@ impl Application {
                     .data(media_url_factory)
                     .data(thumbnail_url_factory)
                     .data(task_tracker.clone())
+                    .extension(Tracing)
                     .finish();
 
                 let graphql_service = graphql_service(schema);

--- a/api/crates/core/env/trace.rs
+++ b/api/crates/core/env/trace.rs
@@ -1,0 +1,36 @@
+use clap::ValueEnum;
+use tracing::Subscriber;
+use tracing_subscriber::{fmt::{self, time::FormatTime, FormatFields, MakeWriter}, registry::LookupSpan, Layer};
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum Format {
+    Compact,
+    Pretty,
+}
+
+pub(super) trait LayerFormatExt<S>
+where
+    S: Subscriber,
+{
+    fn with_format(self, format: &Format) -> Box<dyn Layer<S> + Send + Sync + 'static>
+    where
+        Self: Sized + Layer<S> + Send + Sync + 'static;
+}
+
+impl<S, N, L, T, W> LayerFormatExt<S> for fmt::Layer<S, N, fmt::format::Format<L, T>, W>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + Send + Sync,
+    T: FormatTime + Send + Sync,
+    W: for<'writer> MakeWriter<'writer> + Send + Sync,
+{
+    fn with_format(self, format: &Format) -> Box<dyn Layer<S> + Send + Sync + 'static>
+    where
+        Self: Sized + Layer<S> + Send + Sync + 'static,
+    {
+        match format {
+            Format::Compact => self.compact().boxed(),
+            Format::Pretty => self.pretty().boxed(),
+        }
+    }
+}

--- a/api/crates/core/main.rs
+++ b/api/crates/core/main.rs
@@ -14,7 +14,7 @@ async fn main() -> ExitCode {
     match Application::start().await {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
-            log::error!("failed to start application\nError: {e:?}");
+            tracing::error!("failed to start application\nError: {e:?}");
             ExitCode::FAILURE
         },
     }

--- a/api/crates/domain/Cargo.toml
+++ b/api/crates/domain/Cargo.toml
@@ -24,9 +24,6 @@ default-features = false
 [dependencies.indenter]
 version = "0.3.3"
 
-[dependencies.log]
-version = "0.4.25"
-
 [dependencies.ordermap]
 version = "0.5.5"
 
@@ -46,6 +43,9 @@ version = "2.0.11"
 [dependencies.tokio]
 version = "1.43.0"
 features = ["macros", "rt-multi-thread"]
+
+[dependencies.tracing]
+version = "0.1.41"
 
 [dependencies.uuid]
 version = "1.13.1"

--- a/api/crates/domain/src/service/external_services.rs
+++ b/api/crates/domain/src/service/external_services.rs
@@ -51,6 +51,7 @@ impl<ExternalServicesRepository> ExternalServicesServiceInterface for ExternalSe
 where
     ExternalServicesRepository: external_services::ExternalServicesRepository,
 {
+    #[tracing::instrument(skip_all)]
     async fn create_external_service(&self, slug: &str, kind: &str, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> Result<ExternalService> {
         if let Some(url_pattern) = url_pattern {
             validate_url_pattern(url_pattern)?;
@@ -59,22 +60,24 @@ where
         match self.external_services_repository.create(slug, kind, name, base_url, url_pattern).await {
             Ok(service) => Ok(service),
             Err(e) => {
-                log::error!("failed to create an external service\nError: {e:?}");
+                tracing::error!("failed to create an external service\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_external_services(&self) -> Result<Vec<ExternalService>> {
         match self.external_services_repository.fetch_all().await {
             Ok(services) => Ok(services),
             Err(e) => {
-                log::error!("failed to get external services\nError: {e:?}");
+                tracing::error!("failed to get external services\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_external_services_by_ids<T>(&self, ids: T) -> Result<Vec<ExternalService>>
     where
         T: CloneableIterator<Item = ExternalServiceId> + Send,
@@ -82,12 +85,13 @@ where
         match self.external_services_repository.fetch_by_ids(ids).await {
             Ok(services) => Ok(services),
             Err(e) => {
-                log::error!("failed to get external services\nError: {e:?}");
+                tracing::error!("failed to get external services\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_external_services_by_url(&self, url: &str) -> Result<Vec<(ExternalService, ExternalMetadata)>> {
         match self.external_services_repository.fetch_all().await {
             Ok(external_services) => {
@@ -101,12 +105,13 @@ where
                 Ok(external_metadata)
             },
             Err(e) => {
-                log::error!("failed to get external services\nError: {e:?}");
+                tracing::error!("failed to get external services\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_external_service_by_id(&self, id: ExternalServiceId, slug: Option<&str>, name: Option<&str>, base_url: Option<Option<&str>>, url_pattern: Option<Option<&str>>) -> Result<ExternalService> {
         if let Some(Some(url_pattern)) = url_pattern {
             validate_url_pattern(url_pattern)?;
@@ -115,17 +120,18 @@ where
         match self.external_services_repository.update_by_id(id, slug, name, base_url, url_pattern).await {
             Ok(service) => Ok(service),
             Err(e) => {
-                log::error!("failed to update the external service\nError: {e:?}");
+                tracing::error!("failed to update the external service\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_external_service_by_id(&self, id: ExternalServiceId) -> Result<DeleteResult> {
         match self.external_services_repository.delete_by_id(id).await {
             Ok(result) => Ok(result),
             Err(e) => {
-                log::error!("failed to delete the external service\nError: {e:?}");
+                tracing::error!("failed to delete the external service\nError: {e:?}");
                 Err(e)
             },
         }

--- a/api/crates/domain/src/service/tags.rs
+++ b/api/crates/domain/src/service/tags.rs
@@ -81,6 +81,7 @@ where
     TagsRepository: tags::TagsRepository,
     TagTypesRepository: tag_types::TagTypesRepository,
 {
+    #[tracing::instrument(skip_all)]
     async fn create_tag<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> Result<Tag>
     where
         T: CloneableIterator<Item = String> + Send,
@@ -88,22 +89,24 @@ where
         match self.tags_repository.create(name, kana, aliases, parent_id, depth).await {
             Ok(tag) => Ok(tag),
             Err(e) => {
-                log::error!("failed to create a tag\nError: {e:?}");
+                tracing::error!("failed to create a tag\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn create_tag_type(&self, slug: &str, name: &str, kana: &str) -> Result<TagType> {
         match self.tag_types_repository.create(slug, name, kana).await {
             Ok(tag_type) => Ok(tag_type),
             Err(e) => {
-                log::error!("failed to create a tag type\nError: {e:?}");
+                tracing::error!("failed to create a tag type\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_tags(
         &self,
         depth: TagDepth,
@@ -116,12 +119,13 @@ where
         match self.tags_repository.fetch_all(depth, root, cursor, order, direction, limit).await {
             Ok(tags) => Ok(tags),
             Err(e) => {
-                log::error!("failed to get the tags\nError: {e:?}");
+                tracing::error!("failed to get the tags\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_tags_by_ids<T>(&self, ids: T, depth: TagDepth) -> Result<Vec<Tag>>
     where
         T: CloneableIterator<Item = TagId> + Send,
@@ -129,32 +133,35 @@ where
         match self.tags_repository.fetch_by_ids(ids, depth).await {
             Ok(tags) => Ok(tags),
             Err(e) => {
-                log::error!("failed to get the tags\nError: {e:?}");
+                tracing::error!("failed to get the tags\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_tags_by_name_or_alias_like(&self, name_or_alias_like: &str, depth: TagDepth) -> Result<Vec<Tag>> {
         match self.tags_repository.fetch_by_name_or_alias_like(name_or_alias_like, depth).await {
             Ok(tags) => Ok(tags),
             Err(e) => {
-                log::error!("failed to get the tags\nError: {e:?}");
+                tracing::error!("failed to get the tags\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_tag_types(&self) -> Result<Vec<TagType>> {
         match self.tag_types_repository.fetch_all().await {
             Ok(tag_types) => Ok(tag_types),
             Err(e) => {
-                log::error!("failed to get the tag types\nError: {e:?}");
+                tracing::error!("failed to get the tag types\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_tag_types_by_ids<T>(&self, ids: T) -> Result<Vec<TagType>>
     where
         T: CloneableIterator<Item = TagTypeId> + Send,
@@ -162,12 +169,13 @@ where
         match self.tag_types_repository.fetch_by_ids(ids).await {
             Ok(tag_types) => Ok(tag_types),
             Err(e) => {
-                log::error!("failed to get the tag types\nError: {e:?}");
+                tracing::error!("failed to get the tag types\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_tag_by_id<T, U>(&self, id: TagId, name: Option<String>, kana: Option<String>, add_aliases: T, remove_aliases: U, depth: TagDepth) -> Result<Tag>
     where
         T: CloneableIterator<Item = String> + Send,
@@ -176,57 +184,62 @@ where
         match self.tags_repository.update_by_id(id, name, kana, add_aliases, remove_aliases, depth).await {
             Ok(tag) => Ok(tag),
             Err(e) => {
-                log::error!("failed to update the tag\nError: {e:?}");
+                tracing::error!("failed to update the tag\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_tag_type_by_id(&self, id: TagTypeId, slug: Option<&str>, name: Option<&str>, kana: Option<&str>) -> Result<TagType> {
         match self.tag_types_repository.update_by_id(id, slug, name, kana).await {
             Ok(tag_type) => Ok(tag_type),
             Err(e) => {
-                log::error!("failed to update the tag type\nError: {e:?}");
+                tracing::error!("failed to update the tag type\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn attach_tag_by_id(&self, id: TagId, parent_id: TagId, depth: TagDepth) -> Result<Tag> {
         match self.tags_repository.attach_by_id(id, parent_id, depth).await {
             Ok(tag) => Ok(tag),
             Err(e) => {
-                log::error!("failed to attach the tag\nError: {e:?}");
+                tracing::error!("failed to attach the tag\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn detach_tag_by_id(&self, id: TagId, depth: TagDepth) -> Result<Tag> {
         match self.tags_repository.detach_by_id(id, depth).await {
             Ok(tag) => Ok(tag),
             Err(e) => {
-                log::error!("failed to detach the tag\nError: {e:?}");
+                tracing::error!("failed to detach the tag\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_tag_by_id(&self, id: TagId, recursive: bool) -> Result<DeleteResult> {
         match self.tags_repository.delete_by_id(id, recursive).await {
             Ok(result) => Ok(result),
             Err(e) => {
-                log::error!("failed to delete the tag\nError: {e:?}");
+                tracing::error!("failed to delete the tag\nError: {e:?}");
                 Err(e)
             },
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_tag_type_by_id(&self, id: TagTypeId) -> Result<DeleteResult> {
         match self.tag_types_repository.delete_by_id(id).await {
             Ok(result) => Ok(result),
             Err(e) => {
-                log::error!("failed to delete the tag type\nError: {e:?}");
+                tracing::error!("failed to delete the tag type\nError: {e:?}");
                 Err(e)
             },
         }

--- a/api/crates/graphql/Cargo.toml
+++ b/api/crates/graphql/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies.async-graphql]
 version = "7.0.15"
-features = ["chrono", "custom-error-conversion", "graphiql", "tempfile", "unblock", "uuid"]
+features = ["chrono", "custom-error-conversion", "graphiql", "tempfile", "tracing", "unblock", "uuid"]
 default-features = false
 
 [dependencies.async-graphql-axum]
@@ -63,6 +63,13 @@ features = ["rt"]
 
 [dependencies.tower-service]
 version = "0.3.3"
+
+[dependencies.tracing]
+version = "0.1.41"
+
+[dependencies.tracing-futures]
+version = "0.2.5"
+features = ["futures"]
 
 [dependencies.uuid]
 version = "1.13.1"

--- a/api/crates/graphql/src/lib.rs
+++ b/api/crates/graphql/src/lib.rs
@@ -12,7 +12,7 @@ use derive_more::Constructor;
 use domain::repository;
 use tower_service::Service;
 
-pub use async_graphql::{Schema, SchemaBuilder};
+pub use async_graphql::{extensions::Tracing, Schema, SchemaBuilder};
 
 pub mod error;
 pub mod mutation;

--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -83,6 +83,7 @@ where
     /// ### Errors
     /// * When the slug already exists, it returns an `EXTERNAL_SERVICE_SLUG_DUPLICATE` error.
     /// * When the urlPattern is invalid, it returns an `EXTERNAL_SERVICE_URL_PATTERN_INVALID` error.
+    #[tracing::instrument(skip_all)]
     async fn create_external_service(
         &self,
         ctx: &Context<'_>,
@@ -112,6 +113,7 @@ where
     /// ### Errors
     /// * When the slug already exists, it returns an `EXTERNAL_SERVICE_SLUG_DUPLICATE` error.
     /// * When the urlPattern is invalid, it returns an `EXTERNAL_SERVICE_URL_PATTERN_INVALID` error.
+    #[tracing::instrument(skip_all)]
     async fn update_external_service(
         &self,
         ctx: &Context<'_>,
@@ -148,6 +150,7 @@ where
     }
 
     /// Deletes an external service.
+    #[tracing::instrument(skip_all)]
     async fn delete_external_service(
         &self,
         ctx: &Context<'_>,
@@ -164,6 +167,7 @@ where
     /// ### Errors
     /// * When any of the sources is not found, it returns a `MEDIUM_SOURCE_NOT_FOUND` error.
     /// * When any of the tags is not found, it returns a `MEDIUM_TAG_NOT_FOUND` error.
+    #[tracing::instrument(skip_all)]
     async fn create_medium(
         &self,
         ctx: &Context<'_>,
@@ -200,6 +204,7 @@ where
     /// * When the object could not be created, it returns an `OBJECT_PUT_FAILED` error.
     /// * When the original URL or the name of the upload is invalid, it returns an `OBJECT_URL_INVALID` error.
     /// * When the original URL is unsupported, it returns an `OBJECT_URL_UNSUPPORTED` error.
+    #[tracing::instrument(skip_all)]
     async fn create_replica(
         &self,
         ctx: &Context<'_>,
@@ -234,6 +239,7 @@ where
     /// * When any source with the same metadata already exists, it returns a `SOURCE_METADATA_DUPLICATE` error.
     /// * When the metadata is invalid, it returns a `SOURCE_METADATA_INVALID` error.
     /// * When the metadata does not match with the external service, it returns a `SOURCE_METADATA_NOT_MATCH` error.
+    #[tracing::instrument(skip_all)]
     async fn create_source(
         &self,
         ctx: &Context<'_>,
@@ -258,6 +264,7 @@ where
     /// * When any of the sources is not found, it returns a `MEDIUM_SOURCE_NOT_FOUND` error.
     /// * When any of the tags is not found, it returns a `MEDIUM_TAG_NOT_FOUND` error.
     /// * When the replicas do not match with the current, it returns a `MEDIUM_REPLICAS_NOT_MATCH` error.
+    #[tracing::instrument(skip_all)]
     async fn update_medium(
         &self,
         ctx: &Context<'_>,
@@ -319,6 +326,7 @@ where
     /// * When the object could not be created, it returns an `OBJECT_PUT_FAILED` error.
     /// * When the original URL or the name of the upload is invalid, it returns an `OBJECT_URL_INVALID` error.
     /// * When the original URL is unsupported, it returns an `OBJECT_URL_UNSUPPORTED` error.
+    #[tracing::instrument(skip_all)]
     async fn update_replica(
         &self,
         ctx: &Context<'_>,
@@ -354,6 +362,7 @@ where
     /// * When any source with the same metadata already exists, it returns a `SOURCE_METADATA_DUPLICATE` error.
     /// * When the metadata is invalid, it returns a `SOURCE_METADATA_INVALID` error.
     /// * When the metadata does not match with the external service, it returns a `SOURCE_METADATA_NOT_MATCH` error.
+    #[tracing::instrument(skip_all)]
     async fn update_source(
         &self,
         ctx: &Context<'_>,
@@ -377,6 +386,7 @@ where
     /// Deletes a medium.
     /// ### Errors
     /// * When the objects in the storage could not be deleted, it returns an `OBJECT_DELETE_FAILED` error.
+    #[tracing::instrument(skip_all)]
     async fn delete_medium(
         &self,
         ctx: &Context<'_>,
@@ -396,6 +406,7 @@ where
     /// Deletes a replica.
     /// ### Errors
     /// * When the object in the storage could not be deleted, it returns an `OBJECT_DELETE_FAILED` error.
+    #[tracing::instrument(skip_all)]
     async fn delete_replica(
         &self,
         ctx: &Context<'_>,
@@ -413,6 +424,7 @@ where
     }
 
     /// Deletes a source.
+    #[tracing::instrument(skip_all)]
     async fn delete_source(
         &self,
         ctx: &Context<'_>,
@@ -428,6 +440,7 @@ where
     /// Creates a tag.
     /// ### Errors
     /// * When the parent tag is not found, it returns a `TAG_NOT_FOUND` error.
+    #[tracing::instrument(skip_all)]
     async fn create_tag(
         &self,
         ctx: &Context<'_>,
@@ -458,6 +471,7 @@ where
     /// Creates a tag type.
     /// ### Errors
     /// * When the slug already exists, it returns a `TAG_TYPE_SLUG_DUPLICATE` error.
+    #[tracing::instrument(skip_all)]
     async fn create_tag_type(
         &self,
         ctx: &Context<'_>,
@@ -480,6 +494,7 @@ where
     }
 
     /// Updates a tag.
+    #[tracing::instrument(skip_all)]
     async fn update_tag(
         &self,
         ctx: &Context<'_>,
@@ -517,6 +532,7 @@ where
     /// Updates a tag type.
     /// ### Errors
     /// * When the slug already exists, it returns a `TAG_TYPE_SLUG_DUPLICATE` error.
+    #[tracing::instrument(skip_all)]
     async fn update_tag_type(
         &self,
         ctx: &Context<'_>,
@@ -545,6 +561,7 @@ where
     /// * When the tag is not found, it returns a `TAG_NOT_FOUND` error.
     /// * When the tag is being attached to its descendant, it returns a `TAG_ATTACHING_TO_DESCENDANT` error.
     /// * When the tag is being attached to itself, it returns a `TAG_ATTACHING_TO_ITSELF` error.
+    #[tracing::instrument(skip_all)]
     async fn attach_tag(
         &self,
         ctx: &Context<'_>,
@@ -564,6 +581,7 @@ where
     /// Detaches a tag from its parent.
     /// ### Errors
     /// * When the tag is not found, it returns a `TAG_NOT_FOUND` error.
+    #[tracing::instrument(skip_all)]
     async fn detach_tag(
         &self,
         ctx: &Context<'_>,
@@ -581,6 +599,7 @@ where
     /// Deletes a tag.
     /// ### Errors
     /// * When the tag has children and `recursive` is disabled, it returns a `TAG_CHILDREN_EXIST` error.
+    #[tracing::instrument(skip_all)]
     async fn delete_tag(
         &self,
         ctx: &Context<'_>,
@@ -596,6 +615,7 @@ where
     }
 
     /// Deletes a tag type.
+    #[tracing::instrument(skip_all)]
     async fn delete_tag_type(
         &self,
         ctx: &Context<'_>,

--- a/api/crates/graphql/src/query.rs
+++ b/api/crates/graphql/src/query.rs
@@ -56,6 +56,7 @@ where
     Normalizer: NormalizerInterface,
 {
     /// Fetches all external services.
+    #[tracing::instrument(skip_all)]
     async fn all_external_services(&self, ctx: &Context<'_>) -> Result<Vec<ExternalService>> {
         let external_services_service = ctx.data_unchecked::<ExternalServicesService>();
 
@@ -64,6 +65,7 @@ where
     }
 
     /// Looks up external services by a list of IDs.
+    #[tracing::instrument(skip_all)]
     async fn external_services(
         &self,
         ctx: &Context<'_>,
@@ -79,6 +81,7 @@ where
     }
 
     /// Fetches media optionally filtered by sources or tags, returning up to 100 results.
+    #[tracing::instrument(skip_all)]
     async fn all_media(
         &self,
         ctx: &Context<'_>,
@@ -167,6 +170,7 @@ where
     }
 
     /// Looks up media by a list of IDs.
+    #[tracing::instrument(skip_all)]
     async fn media(
         &self,
         ctx: &Context<'_>,
@@ -191,6 +195,7 @@ where
     /// Looks up a replica by its original URL.
     /// ### Errors
     /// * When the replica is not found, it returns a `REPLICA_NOT_FOUND_BY_URL` error.
+    #[tracing::instrument(skip_all)]
     async fn replica(
         &self,
         ctx: &Context<'_>,
@@ -204,6 +209,7 @@ where
     }
 
     /// Looks up sources by partial metadata.
+    #[tracing::instrument(skip_all)]
     async fn all_sources_like(
         &self,
         ctx: &Context<'_>,
@@ -240,6 +246,7 @@ where
     }
 
     /// Looks up sources by a list of IDs.
+    #[tracing::instrument(skip_all)]
     async fn sources(
         &self,
         ctx: &Context<'_>,
@@ -255,6 +262,7 @@ where
     }
 
     /// Looks up a source by the ID of an external service and the external metadata.
+    #[tracing::instrument(skip_all)]
     async fn source(
         &self,
         ctx: &Context<'_>,
@@ -275,6 +283,7 @@ where
     /// Fetches all objects in the storage by their prefix and optionally their kind.
     /// ### Errors
     /// * When the prefix is invalid, it returns an `OBJECT_URL_INVALID` error.
+    #[tracing::instrument(skip_all)]
     async fn objects(
         &self,
         ctx: &Context<'_>,
@@ -292,6 +301,7 @@ where
     }
 
     /// Fetches tags.
+    #[tracing::instrument(skip_all)]
     async fn all_tags(
         &self,
         ctx: &Context<'_>,
@@ -363,6 +373,7 @@ where
     }
 
     /// Looks up tags that contains the given name or alias.
+    #[tracing::instrument(skip_all)]
     async fn all_tags_like(
         &self,
         ctx: &Context<'_>,
@@ -380,6 +391,7 @@ where
     }
 
     /// Looks up tags by a list of IDs.
+    #[tracing::instrument(skip_all)]
     async fn tags(
         &self,
         ctx: &Context<'_>,
@@ -396,6 +408,7 @@ where
     }
 
     /// Fetches all tag types.
+    #[tracing::instrument(skip_all)]
     async fn all_tag_types(&self, ctx: &Context<'_>) -> Result<Vec<TagType>> {
         let tags_service = ctx.data_unchecked::<TagsService>();
 
@@ -404,6 +417,7 @@ where
     }
 
     /// Looks up tag types by a list of IDs.
+    #[tracing::instrument(skip_all)]
     async fn tag_types(
         &self,
         ctx: &Context<'_>,

--- a/api/crates/objects/Cargo.toml
+++ b/api/crates/objects/Cargo.toml
@@ -19,3 +19,6 @@ version = "0.8.1"
 [dependencies.derive_more]
 version = "2.0.1"
 features = ["constructor"]
+
+[dependencies.tracing]
+version = "0.1.41"

--- a/api/crates/objects/src/lib.rs
+++ b/api/crates/objects/src/lib.rs
@@ -30,6 +30,7 @@ impl<MediaService> ObjectsServiceInterface for ObjectsService<MediaService>
 where
     MediaService: MediaServiceInterface,
 {
+    #[tracing::instrument(skip_all)]
     async fn redirect(&self, url: String) -> Response {
         let public_url = self.media_service
             .get_object(EntryUrl::from(url))

--- a/api/crates/postgres/Cargo.toml
+++ b/api/crates/postgres/Cargo.toml
@@ -33,9 +33,6 @@ version = "0.3.31"
 features = ["std"]
 default-features = false
 
-[dependencies.log]
-version = "0.4.25"
-
 [dependencies.ordermap]
 version = "0.5.5"
 features = ["serde"]
@@ -67,6 +64,13 @@ default-features = false
 [dependencies.sqlx_migrator]
 version = "0.16.2"
 features = ["postgres"]
+
+[dependencies.tracing]
+version = "0.1.41"
+
+[dependencies.tracing-futures]
+version = "0.2.5"
+features = ["futures"]
 
 [dependencies.uuid]
 version = "1.13.1"

--- a/api/crates/postgres/src/external_services.rs
+++ b/api/crates/postgres/src/external_services.rs
@@ -57,6 +57,7 @@ impl From<PostgresExternalServiceRow> for ExternalService {
 }
 
 impl ExternalServicesRepository for PostgresExternalServicesRepository {
+    #[tracing::instrument(skip_all)]
     async fn create(&self, slug: &str, kind: &str, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> Result<ExternalService> {
         let (sql, values) = Query::insert()
             .into_table(PostgresExternalService::Table)
@@ -95,6 +96,7 @@ impl ExternalServicesRepository for PostgresExternalServicesRepository {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<ExternalService>>
     where
         T: Iterator<Item = ExternalServiceId> + Send,
@@ -123,6 +125,7 @@ impl ExternalServicesRepository for PostgresExternalServicesRepository {
         Ok(external_services)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_all(&self) -> Result<Vec<ExternalService>> {
         let (sql, values) = Query::select()
             .columns([
@@ -147,6 +150,7 @@ impl ExternalServicesRepository for PostgresExternalServicesRepository {
         Ok(external_services)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_by_id(&self, id: ExternalServiceId, slug: Option<&str>, name: Option<&str>, base_url: Option<Option<&str>>, url_pattern: Option<Option<&str>>) -> Result<ExternalService> {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 
@@ -204,6 +208,7 @@ impl ExternalServicesRepository for PostgresExternalServicesRepository {
         Ok(external_service)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_by_id(&self, id: ExternalServiceId) -> Result<DeleteResult> {
         let (sql, values) = Query::delete()
             .from_table(PostgresExternalService::Table)

--- a/api/crates/postgres/src/migrations/v1.rs
+++ b/api/crates/postgres/src/migrations/v1.rs
@@ -44,6 +44,7 @@ struct CreateTableOperation;
 
 #[async_trait]
 impl Operation<Postgres> for CreateTableOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::create()
             .table(PostgresExternalService::Table)
@@ -262,6 +263,7 @@ impl Operation<Postgres> for CreateTableOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::drop()
             .table(PostgresMediumTag::Table)
@@ -331,6 +333,7 @@ struct CreateIndexOperation;
 
 #[async_trait]
 impl Operation<Postgres> for CreateIndexOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Index::create()
             .name("media_created_at_id_idx")
@@ -384,6 +387,7 @@ impl Operation<Postgres> for CreateIndexOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Index::drop()
             .name("media_created_at_id_idx")
@@ -423,6 +427,7 @@ struct InsertRootTagsOperation;
 
 #[async_trait]
 impl Operation<Postgres> for InsertRootTagsOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let (sql, values) = Query::insert()
             .into_table(PostgresTag::Table)
@@ -467,6 +472,7 @@ impl Operation<Postgres> for InsertRootTagsOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let mut tx = connection.begin().await?;
 

--- a/api/crates/postgres/src/migrations/v2.rs
+++ b/api/crates/postgres/src/migrations/v2.rs
@@ -40,6 +40,7 @@ struct PostgresReplicaOriginalUrlRow {
 
 #[async_trait]
 impl Operation<Postgres> for ReplicaUrlOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let mut tx = connection.begin().await?;
 
@@ -75,6 +76,7 @@ impl Operation<Postgres> for ReplicaUrlOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let mut tx = connection.begin().await?;
 
@@ -107,14 +109,14 @@ impl Operation<Postgres> for ReplicaUrlOperation {
                         .await?;
                 },
                 Err(e) => {
-                    log::error!("failed to decode URL\nID: {:?}\nError: {e:?}", replica.id);
+                    tracing::error!("failed to decode URL\nID: {:?}\nError: {e:?}", replica.id);
                     errors.push(e);
                 },
             }
         }
 
         if let Some(e) = errors.pop() {
-            log::error!("{} error(s) found", errors.len());
+            tracing::error!("{} error(s) found", errors.len());
             return Err(sqlx::Error::Migrate(Box::new(MigrateError::Source(Box::new(e)))))?;
         }
 

--- a/api/crates/postgres/src/migrations/v3.rs
+++ b/api/crates/postgres/src/migrations/v3.rs
@@ -34,6 +34,7 @@ enum PostgresExternalServiceTemporary {
 
 #[async_trait]
 impl Operation<Postgres> for ExternalServiceKindOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresExternalService::Table)
@@ -86,6 +87,7 @@ impl Operation<Postgres> for ExternalServiceKindOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresExternalService::Table)

--- a/api/crates/postgres/src/migrations/v4.rs
+++ b/api/crates/postgres/src/migrations/v4.rs
@@ -29,6 +29,7 @@ struct SourceExternalMetadataOperation;
 
 #[async_trait]
 impl Operation<Postgres> for SourceExternalMetadataOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         const OLD_NAME: &str = "creator_id";
         const OLD_PATH: &str = "{creator_id}";
@@ -52,6 +53,7 @@ impl Operation<Postgres> for SourceExternalMetadataOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         const OLD_NAME: &str = "creatorId";
         const OLD_PATH: &str = "{creatorId}";

--- a/api/crates/postgres/src/migrations/v5.rs
+++ b/api/crates/postgres/src/migrations/v5.rs
@@ -37,6 +37,7 @@ enum PostgresSourceTemporary {
 
 #[async_trait]
 impl Operation<Postgres> for SourceExternalMetadataExtraOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresSource::Table)
@@ -111,6 +112,7 @@ impl Operation<Postgres> for SourceExternalMetadataExtraOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Query::update()
             .table(PostgresSource::Table)

--- a/api/crates/postgres/src/migrations/v6.rs
+++ b/api/crates/postgres/src/migrations/v6.rs
@@ -32,6 +32,7 @@ struct ExternalServiceTwitterToX;
 
 #[async_trait]
 impl Operation<Postgres> for ExternalServiceTwitterToX {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         const OLD_SLUG: &str = "twitter";
         const NEW_SLUG: &str = "x";
@@ -80,6 +81,7 @@ impl Operation<Postgres> for ExternalServiceTwitterToX {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         const OLD_SLUG: &str = "x";
         const NEW_SLUG: &str = "twitter";

--- a/api/crates/postgres/src/migrations/v7.rs
+++ b/api/crates/postgres/src/migrations/v7.rs
@@ -29,6 +29,7 @@ struct TagTypeKanaOperation;
 
 #[async_trait]
 impl Operation<Postgres> for TagTypeKanaOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresTagType::Table)
@@ -54,6 +55,7 @@ impl Operation<Postgres> for TagTypeKanaOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresTagType::Table)

--- a/api/crates/postgres/src/migrations/v8.rs
+++ b/api/crates/postgres/src/migrations/v8.rs
@@ -29,6 +29,7 @@ struct ExternalServiceUrlPatternOperation;
 
 #[async_trait]
 impl Operation<Postgres> for ExternalServiceUrlPatternOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresExternalService::Table)
@@ -219,6 +220,7 @@ impl Operation<Postgres> for ExternalServiceUrlPatternOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresExternalService::Table)

--- a/api/crates/postgres/src/migrations/v9.rs
+++ b/api/crates/postgres/src/migrations/v9.rs
@@ -35,6 +35,7 @@ enum PostgresReplicaTemporary {
 
 #[async_trait]
 impl Operation<Postgres> for ReplicasPhaseOperation {
+    #[tracing::instrument(skip_all)]
     async fn up(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = Table::alter()
             .table(PostgresReplica::Table)
@@ -95,6 +96,7 @@ impl Operation<Postgres> for ReplicasPhaseOperation {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all)]
     async fn down(&self, connection: &mut PgConnection) -> Result<(), Error> {
         let sql = r#"
             ALTER TABLE "replicas"

--- a/api/crates/postgres/src/replicas.rs
+++ b/api/crates/postgres/src/replicas.rs
@@ -266,6 +266,7 @@ impl fmt::Display for PostgresReplicaNotification {
 }
 
 impl ReplicasRepository for PostgresReplicasRepository {
+    #[tracing::instrument(skip_all)]
     async fn create(&self, medium_id: MediumId, thumbnail_image: Option<ThumbnailImage>, original_url: &str, original_image: Option<OriginalImage>, status: ReplicaStatus) -> Result<Replica> {
         let mut tx = self.pool.begin().map_err(Error::other).await?;
 
@@ -393,6 +394,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
         Ok(replica)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<Replica>>
     where
         T: Iterator<Item = ReplicaId> + Send,
@@ -436,6 +438,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
         Ok(replicas)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_original_url(&self, original_url: &str) -> Result<Replica> {
         let (sql, values) = Query::select()
             .expr_as(Expr::col((PostgresReplica::Table, PostgresReplica::Id)), PostgresReplicaThumbnail::ReplicaId)
@@ -472,6 +475,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
         Ok(replica)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_thumbnail_by_id(&self, id: ThumbnailId) -> Result<Vec<u8>> {
         let (sql, values) = Query::select()
             .columns([
@@ -490,6 +494,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
         Ok(thumbnail)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_by_id(&self, id: ReplicaId, thumbnail_image: Option<Option<ThumbnailImage>>, original_url: Option<&str>, original_image: Option<Option<OriginalImage>>, status: Option<ReplicaStatus>) -> Result<Replica> {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 
@@ -627,6 +632,7 @@ impl ReplicasRepository for PostgresReplicasRepository {
         Ok(replica)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_by_id(&self, id: ReplicaId) -> Result<DeleteResult> {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 

--- a/api/crates/postgres/src/sources.rs
+++ b/api/crates/postgres/src/sources.rs
@@ -235,6 +235,7 @@ impl TryFrom<PostgresSourceExternalServiceRow> for Source {
 }
 
 impl SourcesRepository for PostgresSourcesRepository {
+    #[tracing::instrument(skip_all)]
     async fn create(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> Result<Source> {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 
@@ -310,6 +311,7 @@ impl SourcesRepository for PostgresSourcesRepository {
         Ok(source)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<Source>>
     where
         T: Iterator<Item = SourceId> + Send,
@@ -348,6 +350,7 @@ impl SourcesRepository for PostgresSourcesRepository {
         Ok(sources)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_external_metadata(&self, external_service_id: ExternalServiceId, external_metadata: ExternalMetadata) -> Result<Option<Source>> {
         let (external_metadata, _) = PostgresExternalServiceMetadataFull::try_from(external_metadata)
             .map_err(|e| Error::new(ErrorKind::SourceMetadataInvalid, e))?
@@ -389,6 +392,7 @@ impl SourcesRepository for PostgresSourcesRepository {
         Ok(source)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_external_metadata_like_id(&self, id: &str) -> Result<Vec<Source>> {
         let (sql, values) = Query::select()
             .expr_as(Expr::col((PostgresSource::Table, PostgresSource::Id)), PostgresSourceExternalService::SourceId)
@@ -424,6 +428,7 @@ impl SourcesRepository for PostgresSourcesRepository {
         Ok(sources)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_by_id(&self, id: SourceId, external_service_id: Option<ExternalServiceId>, external_metadata: Option<ExternalMetadata>) -> Result<Source> {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 
@@ -522,6 +527,7 @@ impl SourcesRepository for PostgresSourcesRepository {
         Ok(source)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_by_id(&self, id: SourceId) -> Result<DeleteResult> {
         let (sql, values) = Query::delete()
             .from_table(PostgresSource::Table)

--- a/api/crates/postgres/src/tag_types.rs
+++ b/api/crates/postgres/src/tag_types.rs
@@ -59,6 +59,7 @@ impl From<PostgresTagTypeRow> for TagType {
 }
 
 impl TagTypesRepository for PostgresTagTypesRepository {
+    #[tracing::instrument(skip_all)]
     async fn create(&self, slug: &str, name: &str, kana: &str) -> Result<TagType> {
         let (sql, values) = Query::insert()
             .into_table(PostgresTagType::Table)
@@ -85,6 +86,7 @@ impl TagTypesRepository for PostgresTagTypesRepository {
         Ok(tag_type)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_ids<T>(&self, ids: T) -> Result<Vec<TagType>>
     where
         T: Iterator<Item = TagTypeId> + Send,
@@ -111,6 +113,7 @@ impl TagTypesRepository for PostgresTagTypesRepository {
         Ok(tag_types)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_all(&self) -> Result<Vec<TagType>> {
         let (sql, values) = Query::select()
             .columns([
@@ -133,6 +136,7 @@ impl TagTypesRepository for PostgresTagTypesRepository {
         Ok(tag_types)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_by_id(&self, id: TagTypeId, slug: Option<&str>, name: Option<&str>, kana: Option<&str>) -> Result<TagType> {
         let mut tx = self.pool.begin().await.map_err(Error::other)?;
 
@@ -185,6 +189,7 @@ impl TagTypesRepository for PostgresTagTypesRepository {
         Ok(tag_type)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_by_id(&self, id: TagTypeId) -> Result<DeleteResult> {
         let (sql, values) = Query::delete()
             .from_table(PostgresTagType::Table)

--- a/api/crates/postgres/src/tags.rs
+++ b/api/crates/postgres/src/tags.rs
@@ -460,6 +460,7 @@ async fn detach_parent(tx: &mut Transaction<'_, Postgres>, id: TagId) -> Result<
 }
 
 impl TagsRepository for PostgresTagsRepository {
+    #[tracing::instrument(skip_all)]
     async fn create<T>(&self, name: &str, kana: &str, aliases: T, parent_id: Option<TagId>, depth: TagDepth) -> Result<Tag>
     where
         T: Iterator<Item = String> + Send,
@@ -528,6 +529,7 @@ impl TagsRepository for PostgresTagsRepository {
         Ok(tag)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_ids<T>(&self, ids: T, depth: TagDepth) -> Result<Vec<Tag>>
     where
         T: Iterator<Item = TagId> + Send,
@@ -538,6 +540,7 @@ impl TagsRepository for PostgresTagsRepository {
         Ok(tags)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_by_name_or_alias_like(&self, name_or_alias_like: &str, depth: TagDepth) -> Result<Vec<Tag>> {
         let mut conn = self.pool.acquire().await.map_err(Error::other)?;
 
@@ -591,6 +594,7 @@ impl TagsRepository for PostgresTagsRepository {
         Ok(tags)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn fetch_all(&self, depth: TagDepth, root: bool, cursor: Option<(String, TagId)>, order: repository::Order, direction: repository::Direction, limit: u64) -> Result<Vec<Tag>> {
         let mut conn = self.pool.acquire().await.map_err(Error::other)?;
 
@@ -668,6 +672,7 @@ impl TagsRepository for PostgresTagsRepository {
         Ok(tags)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn update_by_id<T, U>(&self, id: TagId, name: Option<String>, kana: Option<String>, add_aliases: T, remove_aliases: U, depth: TagDepth) -> Result<Tag>
     where
         T: Iterator<Item = String> + Send,
@@ -728,6 +733,7 @@ impl TagsRepository for PostgresTagsRepository {
         Ok(tag)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn attach_by_id(&self, id: TagId, parent_id: TagId, depth: TagDepth) -> Result<Tag> {
         if id.is_root() || parent_id.is_root() {
             return Err(ErrorKind::TagAttachingRoot)?;
@@ -766,6 +772,7 @@ impl TagsRepository for PostgresTagsRepository {
         Ok(tag)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn detach_by_id(&self, id: TagId, depth: TagDepth) -> Result<Tag> {
         if id.is_root() {
             return Err(ErrorKind::TagDetachingRoot)?;
@@ -783,6 +790,7 @@ impl TagsRepository for PostgresTagsRepository {
         Ok(tag)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete_by_id(&self, id: TagId, recursive: bool) -> Result<DeleteResult> {
         if id.is_root() {
             return Err(ErrorKind::TagDeletingRoot)?;

--- a/api/crates/storage/Cargo.toml
+++ b/api/crates/storage/Cargo.toml
@@ -39,3 +39,6 @@ features = ["fs", "rt-multi-thread"]
 [dependencies.tokio-stream]
 version = "0.1.17"
 features = ["fs"]
+
+[dependencies.tracing]
+version = "0.1.41"

--- a/api/crates/storage/src/filesystem.rs
+++ b/api/crates/storage/src/filesystem.rs
@@ -39,6 +39,7 @@ impl ObjectsRepository for FilesystemObjectsRepository {
         "file"
     }
 
+    #[tracing::instrument(skip_all)]
     async fn put(&self, url: EntryUrl, overwrite: ObjectOverwriteBehavior) -> Result<(Entry, ObjectStatus, Self::Write)> {
         let url = FilesystemEntryUrl::try_from(url)?;
         let fullpath = self.fullpath(url.as_path());
@@ -108,6 +109,7 @@ impl ObjectsRepository for FilesystemObjectsRepository {
         Ok((entry.into_entry(), status, file.into_std().await))
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get(&self, url: EntryUrl) -> Result<(Entry, Self::Read)> {
         let url = FilesystemEntryUrl::try_from(url)?;
         let fullpath = self.fullpath(url.as_path());
@@ -123,6 +125,7 @@ impl ObjectsRepository for FilesystemObjectsRepository {
         }
     }
 
+    #[tracing::instrument(skip_all)]
     fn copy<R>(&self, read: &mut R, write: &mut Self::Write) -> Result<u64>
     where
         R: Read,
@@ -133,6 +136,7 @@ impl ObjectsRepository for FilesystemObjectsRepository {
         Ok(written)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn list(&self, prefix: EntryUrl) -> Result<Vec<Entry>> {
         let url = FilesystemEntryUrl::try_from(prefix)?;
         let fullpath = self.fullpath(url.as_path());
@@ -167,6 +171,7 @@ impl ObjectsRepository for FilesystemObjectsRepository {
         Ok(entries)
     }
 
+    #[tracing::instrument(skip_all)]
     async fn delete(&self, url: EntryUrl) -> Result<DeleteResult> {
         let url = FilesystemEntryUrl::try_from(url)?;
         let fullpath = self.fullpath(url.as_path());

--- a/api/crates/thumbnails/Cargo.toml
+++ b/api/crates/thumbnails/Cargo.toml
@@ -24,3 +24,6 @@ features = ["constructor"]
 version = "0.25.5"
 features = ["bmp", "gif", "jpeg", "png", "webp"]
 default-features = false
+
+[dependencies.tracing]
+version = "0.1.41"

--- a/api/crates/thumbnails/src/lib.rs
+++ b/api/crates/thumbnails/src/lib.rs
@@ -37,6 +37,7 @@ impl<MediaService> ThumbnailsServiceInterface for ThumbnailsService<MediaService
 where
     MediaService: MediaServiceInterface,
 {
+    #[tracing::instrument(skip_all)]
     async fn show(&self, id: ThumbnailId) -> Response {
         match self.media_service.get_thumbnail_by_id(id).await {
             Ok(thumbnail) => {

--- a/api/crates/thumbnails/src/processor.rs
+++ b/api/crates/thumbnails/src/processor.rs
@@ -18,6 +18,7 @@ pub struct InMemoryImageProcessor {
 }
 
 impl MediumImageProcessor for InMemoryImageProcessor {
+    #[tracing::instrument(skip_all)]
     fn generate_thumbnail<R>(&self, read: R) -> Result<(OriginalImage, ThumbnailImage)>
     where
         R: BufRead + Seek,

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,8 +8,9 @@ services:
     ports:
       - '8080:8080'
     environment:
-      LOG_LEVEL: debug,hyper=info
-      RUST_LOG_STYLE: always
+      LOG_FORMAT: pretty
+      LOG_LEVEL: debug,handlebars=info,hyper=info,tungstenite=info
+      CLICOLOR_FORCE: '1'
       PORT: '8080'
       LOCALE: ja-JP
       PGHOST: database


### PR DESCRIPTION
This PR adopts tracing support throughout the entire API. A new option `--log-format=(compact|pretty)` can be used to control how logs are printed to stdout.