### PR TITLE
Correct the feature of tracing-futures

### DIFF
--- a/api/crates/graphql/Cargo.toml
+++ b/api/crates/graphql/Cargo.toml
@@ -69,7 +69,7 @@ version = "0.1.41"
 
 [dependencies.tracing-futures]
 version = "0.2.5"
-features = ["futures"]
+features = ["futures-03"]
 
 [dependencies.uuid]
 version = "1.13.1"

--- a/api/crates/postgres/Cargo.toml
+++ b/api/crates/postgres/Cargo.toml
@@ -70,7 +70,7 @@ version = "0.1.41"
 
 [dependencies.tracing-futures]
 version = "0.2.5"
-features = ["futures"]
+features = ["futures-03"]
 
 [dependencies.uuid]
 version = "1.13.1"


### PR DESCRIPTION
The actual feature that was necessary to enable in `tracing-futures` was [`futures-03`](https://docs.rs/crate/tracing-futures/0.2.5/features#futures-03).