### PR TITLE
Revert all migrations after integration testing

### DIFF
--- a/api/crates/postgres/src/migrations/v2.rs
+++ b/api/crates/postgres/src/migrations/v2.rs
@@ -116,7 +116,7 @@ impl Operation<Postgres> for ReplicaUrlOperation {
         }
 
         if let Some(e) = errors.pop() {
-            tracing::error!("{} error(s) found", errors.len());
+            tracing::error!("{} error(s) found", errors.len() + 1);
             return Err(sqlx::Error::Migrate(Box::new(MigrateError::Source(Box::new(e)))))?;
         }
 

--- a/api/crates/postgres/src/migrations/v6.rs
+++ b/api/crates/postgres/src/migrations/v6.rs
@@ -176,7 +176,7 @@ impl Operation<Postgres> for SourceTwitterToX {
                 Expr::cust_with_exprs("jsonb_set($1, $2, $3)", [
                     Expr::col(PostgresSource::ExternalMetadata).into(),
                     "{type}".into(),
-                    Expr::cust_with_expr("to_json($1)", NEW_TYPE),
+                    Expr::cust_with_expr("to_jsonb($1::text)", NEW_TYPE),
                 ]),
             )
             .value(
@@ -184,7 +184,7 @@ impl Operation<Postgres> for SourceTwitterToX {
                 Expr::cust_with_exprs("jsonb_set($1, $2, $3)", [
                     Expr::col(PostgresSource::ExternalMetadataExtra).into(),
                     "{type}".into(),
-                    Expr::cust_with_expr("to_json($1)", NEW_TYPE),
+                    Expr::cust_with_expr("to_jsonb($1::text)", NEW_TYPE),
                 ]),
             )
             .and_where(Expr::col(PostgresSource::ExternalMetadata).cast_json_field("type").eq(OLD_TYPE))


### PR DESCRIPTION
This PR ensures that all migrations are reverted after integration tests.

https://github.com/chitoku-k/hoarder/pull/623/commits/82ca1118f225d451f8c427d847f5c0cfe1708743 is to avoid the following error when the migration `replicas_phase` is reverted:

```
PgDatabaseError {
  severity: Error,
  code: "23502",
  message: "column \"mime_type\" of relation \"replicas\" contains null values",
  detail: None,
  hint: None,
  position: None,
  where: None,
  schema: Some("public"),
  table: Some("replicas"),
  column: Some("mime_type"),
  data_type: None,
  constraint: None,
  file: Some("tablecmds.c"),
  line: Some(6279),
  routine: Some("ATRewriteTable")
}
```

https://github.com/chitoku-k/hoarder/pull/623/commits/3df3d0ed3ac9d1bea505cebfd9601bab9c7de040 is to fix a type mismatch in the migration `external_service_and_sources_twitter_to_x`:

```
PgDatabaseError {
  severity: Error,
  code: "42804",
  message: "could not determine polymorphic type because input has type unknown",
  detail: None,
  hint: None,
  position: None,
  where: None,
  schema: None,
  table: None,
  column: None,
  data_type: None,
  constraint: None,
  file: Some("parse_coerce.c"),
  line: Some(2472),
  routine: Some("enforce_generic_type_consistency")
}
```