### PR TITLE
Remove unused structs from domain

### DIFF
--- a/api/crates/domain/src/entity/media.rs
+++ b/api/crates/domain/src/entity/media.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, Utc};
 use derive_more::{Deref, Display, From};
 use ordermap::OrderMap;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use uuid::Uuid;
 
 use crate::entity::{
@@ -23,10 +22,4 @@ pub struct Medium {
     pub replicas: Vec<Replica>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Error)]
-pub enum MediumError {
-    #[error("medium not found: {0}")]
-    NotFound(MediumId),
 }

--- a/api/crates/domain/src/entity/sources.rs
+++ b/api/crates/domain/src/entity/sources.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Utc};
 use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 use uuid::Uuid;
 
 use crate::{entity::external_services::{ExternalMetadata, ExternalService}, error::{ErrorKind, Result}};
@@ -16,12 +15,6 @@ pub struct Source {
     pub external_metadata: ExternalMetadata,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-}
-
-#[derive(Debug, Error)]
-pub enum SourceError {
-    #[error("source not found: {0}")]
-    NotFound(SourceId),
 }
 
 impl Source {


### PR DESCRIPTION
There have been unused structs that were intended to represent an error in domain.