### PR TITLE
Create enum for kind of external services

### DIFF
--- a/api/crates/domain/src/error.rs
+++ b/api/crates/domain/src/error.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Write};
 use indenter::indented;
 
 use crate::entity::{
-    external_services::ExternalServiceId,
+    external_services::{ExternalServiceId, ExternalServiceKind},
     media::MediumId,
     objects::Entry,
     replicas::{ReplicaId, ThumbnailId},
@@ -190,7 +190,7 @@ pub enum ErrorKind {
     SourceMetadataInvalid,
 
     #[error("the source metadata does not match with external service")]
-    SourceMetadataNotMatch { kind: String },
+    SourceMetadataNotMatch { kind: ExternalServiceKind },
 
     #[error("the source was not found")]
     SourceNotFound { id: SourceId },

--- a/api/crates/domain/src/repository/external_services.rs
+++ b/api/crates/domain/src/repository/external_services.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use crate::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     error::Result,
     iter::CloneableIterator,
     repository::DeleteResult
@@ -9,7 +9,7 @@ use crate::{
 
 pub trait ExternalServicesRepository: Send + Sync + 'static {
     /// Creates an external service.
-    fn create(&self, slug: &str, kind: &str, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> impl Future<Output = Result<ExternalService>> + Send;
+    fn create(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
     /// Fetches the external services by their IDs.
     fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send

--- a/api/crates/domain/src/service/external_services.rs
+++ b/api/crates/domain/src/service/external_services.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use crate::{
-    entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     error::{Error, ErrorKind, Result},
     iter::CloneableIterator,
     repository::{external_services, DeleteResult},
@@ -12,7 +12,7 @@ use regex::Regex;
 
 pub trait ExternalServicesServiceInterface: Send + Sync + 'static {
     /// Creates an external service.
-    fn create_external_service(&self, slug: &str, kind: &str, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> impl Future<Output = Result<ExternalService>> + Send;
+    fn create_external_service(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
     /// Gets external services.
     fn get_external_services(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;
@@ -52,7 +52,7 @@ where
     ExternalServicesRepository: external_services::ExternalServicesRepository,
 {
     #[tracing::instrument(skip_all)]
-    async fn create_external_service(&self, slug: &str, kind: &str, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> Result<ExternalService> {
+    async fn create_external_service(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> Result<ExternalService> {
         if let Some(url_pattern) = url_pattern {
             validate_url_pattern(url_pattern)?;
         }

--- a/api/crates/domain/src/tests/entity/external_services.rs
+++ b/api/crates/domain/src/tests/entity/external_services.rs
@@ -1,14 +1,14 @@
 use pretty_assertions::assert_eq;
 use uuid::uuid;
 
-use crate::entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId};
+use crate::entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind};
 
 #[test]
 fn external_service_metadata_by_url_succeeds() {
     let external_service = ExternalService {
         id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
         slug: "x".to_string(),
-        kind: "x".to_string(),
+        kind: ExternalServiceKind::X,
         name: "X".to_string(),
         base_url: Some("https://x.com".to_string()),
         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -23,7 +23,7 @@ fn external_service_metadata_by_url_succeeds_invalid_url_pattern() {
     let external_service = ExternalService {
         id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
         slug: "x".to_string(),
-        kind: "x".to_string(),
+        kind: ExternalServiceKind::X,
         name: "X".to_string(),
         base_url: Some("https://x.com".to_string()),
         url_pattern: Some(r"(".to_string()),
@@ -37,7 +37,7 @@ fn external_service_metadata_by_url_succeeds_no_captures() {
     let external_service = ExternalService {
         id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
         slug: "x".to_string(),
-        kind: "x".to_string(),
+        kind: ExternalServiceKind::X,
         name: "X".to_string(),
         base_url: Some("https://x.com".to_string()),
         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/([^/]+)/status/(\d+)(?:[/?#].*)?$".to_string()),
@@ -51,7 +51,7 @@ fn external_service_metadata_by_url_succeeds_no_match() {
     let external_service = ExternalService {
         id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
         slug: "x".to_string(),
-        kind: "x".to_string(),
+        kind: ExternalServiceKind::X,
         name: "X".to_string(),
         base_url: Some("https://x.com".to_string()),
         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -62,263 +62,263 @@ fn external_service_metadata_by_url_succeeds_no_match() {
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_bluesky() {
-    let actual = ExternalMetadata::from_metadata("bluesky", "https://bsky.app/profile/creator_01/post/abcdefghi", Some("abcdefghi"), Some("creator_01")).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Bluesky, "https://bsky.app/profile/creator_01/post/abcdefghi", Some("abcdefghi"), Some("creator_01")).unwrap();
     assert_eq!(actual, ExternalMetadata::Bluesky { id: "abcdefghi".to_string(), creator_id: "creator_01".to_string() });
 
-    let actual = ExternalMetadata::from_metadata("bluesky", "https://bsky.app/profile/creator_01/post/abcdefghi", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Bluesky, "https://bsky.app/profile/creator_01/post/abcdefghi", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("bluesky", "https://bsky.app/profile/creator_01/post/abcdefghi", None, Some("creator_01"));
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Bluesky, "https://bsky.app/profile/creator_01/post/abcdefghi", None, Some("creator_01"));
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_fantia() {
-    let actual = ExternalMetadata::from_metadata("fantia", "https://fantia.jp/posts/1305295", Some("1305295"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Fantia, "https://fantia.jp/posts/1305295", Some("1305295"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::Fantia { id: 1305295 });
 
-    let actual = ExternalMetadata::from_metadata("fantia", "https://fantia.jp/posts/1305295", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Fantia, "https://fantia.jp/posts/1305295", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("fantia", "https://fantia.jp/posts/1305295", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Fantia, "https://fantia.jp/posts/1305295", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_mastodon() {
-    let actual = ExternalMetadata::from_metadata("mastodon", "https://mastodon.social/@creator_01/123456789", Some("123456789"), Some("creator_01")).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Mastodon, "https://mastodon.social/@creator_01/123456789", Some("123456789"), Some("creator_01")).unwrap();
     assert_eq!(actual, ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() });
 
-    let actual = ExternalMetadata::from_metadata("mastodon", "https://mastodon.social/@creator_01/123456789", Some("123456789"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Mastodon, "https://mastodon.social/@creator_01/123456789", Some("123456789"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("mastodon", "https://mastodon.social/@creator_01/123456789", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Mastodon, "https://mastodon.social/@creator_01/123456789", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("mastodon", "https://mastodon.social/@creator_01/123456789", None, Some("creator_01"));
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Mastodon, "https://mastodon.social/@creator_01/123456789", None, Some("creator_01"));
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_misskey() {
-    let actual = ExternalMetadata::from_metadata("misskey", "https://misskey.io/notes/abcdefghi", Some("abcdefghi"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Misskey, "https://misskey.io/notes/abcdefghi", Some("abcdefghi"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::Misskey { id: "abcdefghi".to_string() });
 
-    let actual = ExternalMetadata::from_metadata("misskey", "https://misskey.io/notes/abcdefghi", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Misskey, "https://misskey.io/notes/abcdefghi", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_nijie() {
-    let actual = ExternalMetadata::from_metadata("nijie", "https://nijie.info/view.php?id=323512", Some("323512"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Nijie, "https://nijie.info/view.php?id=323512", Some("323512"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::Nijie { id: 323512 });
 
-    let actual = ExternalMetadata::from_metadata("nijie", "https://nijie.info/view.php?id=323512", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Nijie, "https://nijie.info/view.php?id=323512", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("nijie", "https://nijie.info/view.php?id=323512", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Nijie, "https://nijie.info/view.php?id=323512", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_pixiv() {
-    let actual = ExternalMetadata::from_metadata("pixiv", "https://www.pixiv.net/artworks/56736941", Some("56736941"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Pixiv, "https://www.pixiv.net/artworks/56736941", Some("56736941"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::Pixiv { id: 56736941 });
 
-    let actual = ExternalMetadata::from_metadata("pixiv", "https://www.pixiv.net/artworks/56736941", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Pixiv, "https://www.pixiv.net/artworks/56736941", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("pixiv", "https://www.pixiv.net/artworks/56736941", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Pixiv, "https://www.pixiv.net/artworks/56736941", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_pixiv_fanbox() {
-    let actual = ExternalMetadata::from_metadata("pixiv_fanbox", "https://fairyeye.fanbox.cc/posts/178080", Some("178080"), Some("fairyeye")).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::PixivFanbox, "https://fairyeye.fanbox.cc/posts/178080", Some("178080"), Some("fairyeye")).unwrap();
     assert_eq!(actual, ExternalMetadata::PixivFanbox { id: 178080, creator_id: "fairyeye".to_string() });
 
-    let actual = ExternalMetadata::from_metadata("pixiv_fanbox", "https://fairyeye.fanbox.cc/posts/178080", Some("178080"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::PixivFanbox, "https://fairyeye.fanbox.cc/posts/178080", Some("178080"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("pixiv_fanbox", "https://fairyeye.fanbox.cc/posts/178080", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::PixivFanbox, "https://fairyeye.fanbox.cc/posts/178080", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("pixiv_fanbox", "https://fairyeye.fanbox.cc/posts/178080", None, Some("fairyeye"));
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::PixivFanbox, "https://fairyeye.fanbox.cc/posts/178080", None, Some("fairyeye"));
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_pleroma() {
-    let actual = ExternalMetadata::from_metadata("pleroma", "https://udongein.xyz/notice/abcdefghi", Some("abcdefghi"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Pleroma, "https://udongein.xyz/notice/abcdefghi", Some("abcdefghi"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::Pleroma { id: "abcdefghi".to_string() });
 
-    let actual = ExternalMetadata::from_metadata("pleroma", "https://udongein.xyz/notice/abcdefghi", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Pleroma, "https://udongein.xyz/notice/abcdefghi", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_seiga() {
-    let actual = ExternalMetadata::from_metadata("seiga", "https://seiga.nicovideo.jp/seiga/6452903", Some("6452903"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Seiga, "https://seiga.nicovideo.jp/seiga/6452903", Some("6452903"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::Seiga { id: 6452903 });
 
-    let actual = ExternalMetadata::from_metadata("seiga", "https://seiga.nicovideo.jp/seiga/6452903", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Seiga, "https://seiga.nicovideo.jp/seiga/6452903", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("seiga", "https://seiga.nicovideo.jp/seiga/6452903", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Seiga, "https://seiga.nicovideo.jp/seiga/6452903", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_skeb() {
-    let actual = ExternalMetadata::from_metadata("skeb", "https://skeb.jp/@pieleaf_x2/works/18", Some("18"), Some("pieleaf_x2")).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Skeb, "https://skeb.jp/@pieleaf_x2/works/18", Some("18"), Some("pieleaf_x2")).unwrap();
     assert_eq!(actual, ExternalMetadata::Skeb { id: 18, creator_id: "pieleaf_x2".to_string() });
 
-    let actual = ExternalMetadata::from_metadata("skeb", "https://skeb.jp/@pieleaf_x2/works/18", Some("18"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Skeb, "https://skeb.jp/@pieleaf_x2/works/18", Some("18"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("skeb", "https://skeb.jp/@pieleaf_x2/works/18", Some("abcdefghi"), Some("pieleaf_x2"));
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Skeb, "https://skeb.jp/@pieleaf_x2/works/18", Some("abcdefghi"), Some("pieleaf_x2"));
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("skeb", "https://skeb.jp/@pieleaf_x2/works/18", None, Some("pieleaf_x2"));
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Skeb, "https://skeb.jp/@pieleaf_x2/works/18", None, Some("pieleaf_x2"));
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_threads() {
-    let actual = ExternalMetadata::from_metadata("threads", "https://www.threads.net/@creator_01/post/abcdefghi", Some("abcdefghi"), Some("creator_01")).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Threads, "https://www.threads.net/@creator_01/post/abcdefghi", Some("abcdefghi"), Some("creator_01")).unwrap();
     assert_eq!(actual, ExternalMetadata::Threads { id: "abcdefghi".to_string(), creator_id: Some("creator_01".to_string()) });
 
-    let actual = ExternalMetadata::from_metadata("threads", "https://www.threads.net/@creator_01/post/abcdefghi", Some("abcdefghi"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Threads, "https://www.threads.net/@creator_01/post/abcdefghi", Some("abcdefghi"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::Threads { id: "abcdefghi".to_string(), creator_id: None });
 
-    let actual = ExternalMetadata::from_metadata("threads", "https://www.threads.net/@creator_01/post/abcdefghi", None, Some("creator_01"));
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Threads, "https://www.threads.net/@creator_01/post/abcdefghi", None, Some("creator_01"));
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_website() {
-    let actual = ExternalMetadata::from_metadata("website", "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885", None, None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Website, "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885", None, None).unwrap();
     assert_eq!(actual, ExternalMetadata::Website { url: "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885".to_string() });
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_x() {
-    let actual = ExternalMetadata::from_metadata("x", "https://x.com/_namori_/status/727620202049900544", Some("727620202049900544"), Some("_namori_")).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::X, "https://x.com/_namori_/status/727620202049900544", Some("727620202049900544"), Some("_namori_")).unwrap();
     assert_eq!(actual, ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) });
 
-    let actual = ExternalMetadata::from_metadata("x", "https://x.com/_namori_/status/727620202049900544", Some("727620202049900544"), None).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::X, "https://x.com/_namori_/status/727620202049900544", Some("727620202049900544"), None).unwrap();
     assert_eq!(actual, ExternalMetadata::X { id: 727620202049900544, creator_id: None });
 
-    let actual = ExternalMetadata::from_metadata("x", "https://x.com/_namori_/status/727620202049900544", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::X, "https://x.com/_namori_/status/727620202049900544", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("x", "https://x.com/_namori_/status/727620202049900544", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::X, "https://x.com/_namori_/status/727620202049900544", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_xfolio() {
-    let actual = ExternalMetadata::from_metadata("xfolio", "https://xfolio.jp/portfolio/creator_01/works/123456789", Some("123456789"), Some("creator_01")).unwrap();
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Xfolio, "https://xfolio.jp/portfolio/creator_01/works/123456789", Some("123456789"), Some("creator_01")).unwrap();
     assert_eq!(actual, ExternalMetadata::Xfolio { id: 123456789, creator_id: "creator_01".to_string() });
 
-    let actual = ExternalMetadata::from_metadata("xfolio", "https://xfolio.jp/portfolio/creator_01/works/123456789", Some("123456789"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Xfolio, "https://xfolio.jp/portfolio/creator_01/works/123456789", Some("123456789"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("xfolio", "https://xfolio.jp/portfolio/creator_01/works/123456789", Some("abcdefghi"), None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Xfolio, "https://xfolio.jp/portfolio/creator_01/works/123456789", Some("abcdefghi"), None);
     assert!(actual.is_none());
 
-    let actual = ExternalMetadata::from_metadata("xfolio", "https://xfolio.jp/portfolio/creator_01/works/123456789", None, Some("creator_01"));
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Xfolio, "https://xfolio.jp/portfolio/creator_01/works/123456789", None, Some("creator_01"));
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_from_metadata_succeeds_with_custom() {
-    let actual = ExternalMetadata::from_metadata("custom", "https://example.com", None, None);
+    let actual = ExternalMetadata::from_metadata(&ExternalServiceKind::Custom("custom".to_string()), "https://example.com", None, None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_bluesky() {
     let actual = ExternalMetadata::Bluesky { id: "abcdefghi".to_string(), creator_id: "creator_01".to_string() }.kind().unwrap();
-    assert_eq!(actual, "bluesky");
+    assert_eq!(actual, ExternalServiceKind::Bluesky);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_fantia() {
     let actual = ExternalMetadata::Fantia { id: 1305295 }.kind().unwrap();
-    assert_eq!(actual, "fantia");
+    assert_eq!(actual, ExternalServiceKind::Fantia);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_mastodon() {
     let actual = ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() }.kind().unwrap();
-    assert_eq!(actual, "mastodon");
+    assert_eq!(actual, ExternalServiceKind::Mastodon);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_misskey() {
     let actual = ExternalMetadata::Misskey { id: "abcdefghi".to_string() }.kind().unwrap();
-    assert_eq!(actual, "misskey");
+    assert_eq!(actual, ExternalServiceKind::Misskey);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_nijie() {
     let actual = ExternalMetadata::Nijie { id: 323512 }.kind().unwrap();
-    assert_eq!(actual, "nijie");
+    assert_eq!(actual, ExternalServiceKind::Nijie);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_pixiv() {
     let actual = ExternalMetadata::Pixiv { id: 56736941 }.kind().unwrap();
-    assert_eq!(actual, "pixiv");
+    assert_eq!(actual, ExternalServiceKind::Pixiv);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_pixiv_fanbox() {
     let actual = ExternalMetadata::PixivFanbox { id: 178080, creator_id: "fairyeye".to_string() }.kind().unwrap();
-    assert_eq!(actual, "pixiv_fanbox");
+    assert_eq!(actual, ExternalServiceKind::PixivFanbox);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_pleroma() {
     let actual = ExternalMetadata::Pleroma { id: "abcdefghi".to_string() }.kind().unwrap();
-    assert_eq!(actual, "pleroma");
+    assert_eq!(actual, ExternalServiceKind::Pleroma);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_seiga() {
     let actual = ExternalMetadata::Seiga { id: 6452903 }.kind().unwrap();
-    assert_eq!(actual, "seiga");
+    assert_eq!(actual, ExternalServiceKind::Seiga);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_skeb() {
     let actual = ExternalMetadata::Skeb { id: 18, creator_id: "pieleaf_x2".to_string() }.kind().unwrap();
-    assert_eq!(actual, "skeb");
+    assert_eq!(actual, ExternalServiceKind::Skeb);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_threads() {
     let actual = ExternalMetadata::Threads { id: "abcdefghi".to_string(), creator_id: Some("creator_01".to_string()) }.kind().unwrap();
-    assert_eq!(actual, "threads");
+    assert_eq!(actual, ExternalServiceKind::Threads);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_website() {
     let actual = ExternalMetadata::Website { url: "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885".to_string() }.kind().unwrap();
-    assert_eq!(actual, "website");
+    assert_eq!(actual, ExternalServiceKind::Website);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_x() {
     let actual = ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) }.kind().unwrap();
-    assert_eq!(actual, "x");
+    assert_eq!(actual, ExternalServiceKind::X);
 }
 
 #[test]
 fn external_metadata_kind_succeeds_with_xfolio() {
     let actual = ExternalMetadata::Xfolio { id: 123456789, creator_id: "creator_01".to_string() }.kind().unwrap();
-    assert_eq!(actual, "xfolio");
+    assert_eq!(actual, ExternalServiceKind::Xfolio);
 }
 
 #[test]

--- a/api/crates/domain/src/tests/entity/sources.rs
+++ b/api/crates/domain/src/tests/entity/sources.rs
@@ -2,7 +2,13 @@ use chrono::{TimeZone, Utc};
 use pretty_assertions::assert_matches;
 use uuid::uuid;
 
-use crate::{entity::{external_services::{ExternalMetadata, ExternalService, ExternalServiceId}, sources::{Source, SourceId}}, error::ErrorKind};
+use crate::{
+    entity::{
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
+        sources::{Source, SourceId},
+    },
+    error::ErrorKind,
+};
 
 #[test]
 fn url_succeeds() {
@@ -11,7 +17,7 @@ fn url_succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -32,7 +38,7 @@ fn validate_succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -53,7 +59,7 @@ fn validate_succeeds_with_custom() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             slug: "custom".to_string(),
-            kind: "custom".to_string(),
+            kind: ExternalServiceKind::Custom("custom".to_string()),
             name: "Custom".to_string(),
             base_url: None,
             url_pattern: None,
@@ -74,7 +80,7 @@ fn validate_fails() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             slug: "website".to_string(),
-            kind: "website".to_string(),
+            kind: ExternalServiceKind::Website,
             name: "Website".to_string(),
             base_url: None,
             url_pattern: None,
@@ -85,5 +91,5 @@ fn validate_fails() {
     };
 
     let actual = source.validate().unwrap_err();
-    assert_matches!(actual.kind(), ErrorKind::SourceMetadataNotMatch { kind } if kind == "website");
+    assert_matches!(actual.kind(), ErrorKind::SourceMetadataNotMatch { kind } if kind == &ExternalServiceKind::Website);
 }

--- a/api/crates/domain/src/tests/mocks/domain/repository/external_services.rs
+++ b/api/crates/domain/src/tests/mocks/domain/repository/external_services.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use crate::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     error::Result,
     iter::CloneableIterator,
     repository::{external_services::ExternalServicesRepository, DeleteResult},
@@ -11,7 +11,7 @@ mockall::mock! {
     pub(crate) ExternalServicesRepository {}
 
     impl ExternalServicesRepository for ExternalServicesRepository {
-        fn create<'a>(&self, slug: &str, kind: &str, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
+        fn create<'a>(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
         #[mockall::concretize]
         fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send

--- a/api/crates/domain/src/tests/service/external_services/create_external_service.rs
+++ b/api/crates/domain/src/tests/service/external_services/create_external_service.rs
@@ -4,7 +4,7 @@ use pretty_assertions::{assert_eq, assert_matches};
 use uuid::uuid;
 
 use crate::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     error::{Error, ErrorKind},
     service::external_services::{ExternalServicesService, ExternalServicesServiceInterface},
 };
@@ -19,7 +19,7 @@ async fn succeeds() {
         .times(1)
         .withf(|slug, kind, name, base_url, url_pattern| (slug, kind, name, base_url, url_pattern) == (
             "x",
-            "x",
+            &ExternalServiceKind::X,
             "X",
             &Some("https://x.com"),
             &None,
@@ -28,7 +28,7 @@ async fn succeeds() {
             Box::pin(ok(ExternalService {
                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: None,
@@ -38,7 +38,7 @@ async fn succeeds() {
     let service = ExternalServicesService::new(mock_external_services_repository);
     let actual = service.create_external_service(
         "x",
-        "x",
+        ExternalServiceKind::X,
         "X",
         Some("https://x.com"),
         None,
@@ -47,7 +47,7 @@ async fn succeeds() {
     assert_eq!(actual, ExternalService {
         id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
         slug: "x".to_string(),
-        kind: "x".to_string(),
+        kind: ExternalServiceKind::X,
         name: "X".to_string(),
         base_url: Some("https://x.com".to_string()),
         url_pattern: None,
@@ -62,7 +62,7 @@ async fn succeeds_with_url_pattern() {
         .times(1)
         .withf(|slug, kind, name, base_url, url_pattern| (slug, kind, name, base_url, url_pattern) == (
             "x",
-            "x",
+            &ExternalServiceKind::X,
             "X",
             &Some("https://x.com"),
             &Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$"),
@@ -71,7 +71,7 @@ async fn succeeds_with_url_pattern() {
             Box::pin(ok(ExternalService {
                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -81,7 +81,7 @@ async fn succeeds_with_url_pattern() {
     let service = ExternalServicesService::new(mock_external_services_repository);
     let actual = service.create_external_service(
         "x",
-        "x",
+        ExternalServiceKind::X,
         "X",
         Some("https://x.com"),
         Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$"),
@@ -90,7 +90,7 @@ async fn succeeds_with_url_pattern() {
     assert_eq!(actual, ExternalService {
         id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
         slug: "x".to_string(),
-        kind: "x".to_string(),
+        kind: ExternalServiceKind::X,
         name: "X".to_string(),
         base_url: Some("https://x.com".to_string()),
         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -105,7 +105,7 @@ async fn fails() {
         .times(1)
         .withf(|slug, kind, name, base_url, url_pattern| (slug, kind, name, base_url, url_pattern) == (
             "x",
-            "x",
+            &ExternalServiceKind::X,
             "X",
             &Some("https://x.com"),
             &Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$"),
@@ -115,7 +115,7 @@ async fn fails() {
     let service = ExternalServicesService::new(mock_external_services_repository);
     let actual = service.create_external_service(
         "x",
-        "x",
+        ExternalServiceKind::X,
         "X",
         Some("https://x.com"),
         Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$"),
@@ -131,7 +131,7 @@ async fn fails_with_url_pattern_invalid() {
     let service = ExternalServicesService::new(mock_external_services_repository);
     let actual = service.create_external_service(
         "x",
-        "x",
+        ExternalServiceKind::X,
         "X",
         Some("https://x.com"),
         Some("("),

--- a/api/crates/domain/src/tests/service/external_services/get_external_services.rs
+++ b/api/crates/domain/src/tests/service/external_services/get_external_services.rs
@@ -4,7 +4,7 @@ use pretty_assertions::{assert_eq, assert_matches};
 use uuid::uuid;
 
 use crate::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     error::{Error, ErrorKind},
     service::external_services::{ExternalServicesService, ExternalServicesServiceInterface},
 };
@@ -22,7 +22,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -30,7 +30,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                     slug: "skeb".to_string(),
-                    kind: "skeb".to_string(),
+                    kind: ExternalServiceKind::Skeb,
                     name: "Skeb".to_string(),
                     base_url: Some("https://skeb.jp".to_string()),
                     url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -38,7 +38,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -53,7 +53,7 @@ async fn succeeds() {
         ExternalService {
             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -61,7 +61,7 @@ async fn succeeds() {
         ExternalService {
             id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
             slug: "skeb".to_string(),
-            kind: "skeb".to_string(),
+            kind: ExternalServiceKind::Skeb,
             name: "Skeb".to_string(),
             base_url: Some("https://skeb.jp".to_string()),
             url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -69,7 +69,7 @@ async fn succeeds() {
         ExternalService {
             id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/external_services/get_external_services_by_ids.rs
+++ b/api/crates/domain/src/tests/service/external_services/get_external_services_by_ids.rs
@@ -4,7 +4,7 @@ use pretty_assertions::{assert_eq, assert_matches};
 use uuid::uuid;
 
 use crate::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     error::{Error, ErrorKind},
     service::external_services::{ExternalServicesService, ExternalServicesServiceInterface},
 };
@@ -26,7 +26,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -34,7 +34,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -52,7 +52,7 @@ async fn succeeds() {
         ExternalService {
             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -60,7 +60,7 @@ async fn succeeds() {
         ExternalService {
             id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/external_services/get_external_services_by_url.rs
+++ b/api/crates/domain/src/tests/service/external_services/get_external_services_by_url.rs
@@ -4,7 +4,7 @@ use pretty_assertions::{assert_eq, assert_matches};
 use uuid::uuid;
 
 use crate::{
-    entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     error::{Error, ErrorKind},
     service::external_services::{ExternalServicesService, ExternalServicesServiceInterface},
 };
@@ -22,7 +22,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -30,7 +30,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                     slug: "skeb".to_string(),
-                    kind: "skeb".to_string(),
+                    kind: ExternalServiceKind::Skeb,
                     name: "Skeb".to_string(),
                     base_url: Some("https://skeb.jp".to_string()),
                     url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -38,7 +38,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -54,7 +54,7 @@ async fn succeeds() {
             ExternalService {
                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/external_services/update_external_service_by_id.rs
+++ b/api/crates/domain/src/tests/service/external_services/update_external_service_by_id.rs
@@ -4,7 +4,7 @@ use pretty_assertions::{assert_eq, assert_matches};
 use uuid::uuid;
 
 use crate::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     error::{Error, ErrorKind},
     service::external_services::{ExternalServicesService, ExternalServicesServiceInterface},
 };
@@ -28,7 +28,7 @@ async fn succeeds() {
             Box::pin(ok(ExternalService {
                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "PIXIV".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -47,7 +47,7 @@ async fn succeeds() {
     assert_eq!(actual, ExternalService {
         id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
         slug: "pixiv".to_string(),
-        kind: "pixiv".to_string(),
+        kind: ExternalServiceKind::Pixiv,
         name: "PIXIV".to_string(),
         base_url: Some("https://www.pixiv.net".to_string()),
         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/media/create_medium.rs
+++ b/api/crates/domain/src/tests/service/media/create_medium.rs
@@ -7,7 +7,7 @@ use uuid::uuid;
 
 use crate::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         media::{Medium, MediumId},
         sources::{Source, SourceId},
         tag_types::{TagType, TagTypeId},
@@ -63,7 +63,7 @@ async fn succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                             slug: "x".to_string(),
-                            kind: "x".to_string(),
+                            kind: ExternalServiceKind::X,
                             name: "X".to_string(),
                             base_url: Some("https://x.com".to_string()),
                             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -77,7 +77,7 @@ async fn succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                             slug: "pixiv".to_string(),
-                            kind: "pixiv".to_string(),
+                            kind: ExternalServiceKind::Pixiv,
                             name: "pixiv".to_string(),
                             base_url: Some("https://www.pixiv.net".to_string()),
                             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -171,7 +171,7 @@ async fn succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -185,7 +185,7 @@ async fn succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/media/create_source.rs
+++ b/api/crates/domain/src/tests/service/media/create_source.rs
@@ -6,7 +6,7 @@ use uuid::uuid;
 
 use crate::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     error::{Error, ErrorKind},
@@ -46,7 +46,7 @@ async fn succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -68,7 +68,7 @@ async fn succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/media/get_source_by_external_metadata.rs
+++ b/api/crates/domain/src/tests/service/media/get_source_by_external_metadata.rs
@@ -6,7 +6,7 @@ use uuid::uuid;
 
 use crate::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     error::{Error, ErrorKind},
@@ -46,7 +46,7 @@ async fn succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -68,7 +68,7 @@ async fn succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/media/get_sources_by_external_metadata_like.rs
+++ b/api/crates/domain/src/tests/service/media/get_sources_by_external_metadata_like.rs
@@ -6,7 +6,7 @@ use uuid::uuid;
 
 use crate::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     error::{Error, ErrorKind},
@@ -42,7 +42,7 @@ async fn succeeds() {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -63,7 +63,7 @@ async fn succeeds() {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/media/get_sources_by_ids.rs
+++ b/api/crates/domain/src/tests/service/media/get_sources_by_ids.rs
@@ -6,7 +6,7 @@ use uuid::uuid;
 
 use crate::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     error::{Error, ErrorKind},
@@ -45,7 +45,7 @@ async fn succeeds() {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -59,7 +59,7 @@ async fn succeeds() {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -83,7 +83,7 @@ async fn succeeds() {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -97,7 +97,7 @@ async fn succeeds() {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/domain/src/tests/service/media/update_source_by_id.rs
+++ b/api/crates/domain/src/tests/service/media/update_source_by_id.rs
@@ -6,7 +6,7 @@ use uuid::uuid;
 
 use crate::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     error::{Error, ErrorKind},
@@ -47,7 +47,7 @@ async fn succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -70,7 +70,7 @@ async fn succeeds() {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/graphql/src/error.rs
+++ b/api/crates/graphql/src/error.rs
@@ -201,7 +201,7 @@ impl From<domain::error::ErrorKind> for ErrorKind {
             },
             SourceMetadataDuplicate { id } => ErrorKind::SourceMetadataDuplicate { id },
             SourceMetadataInvalid => ErrorKind::SourceMetadataInvalid,
-            SourceMetadataNotMatch { kind } => ErrorKind::SourceMetadataNotMatch { kind },
+            SourceMetadataNotMatch { kind } => ErrorKind::SourceMetadataNotMatch { kind: kind.to_string() },
             SourceNotFound { id } => ErrorKind::SourceNotFound { id },
             TagAttachingRoot | TagDeletingRoot | TagDetachingRoot | TagUpdatingRoot => ErrorKind::TagNotFound { id: TagId::default() },
             TagAttachingToDescendant { id } => ErrorKind::TagAttachingToDescendant { id },

--- a/api/crates/graphql/src/external_services.rs
+++ b/api/crates/graphql/src/external_services.rs
@@ -39,7 +39,7 @@ impl From<external_services::ExternalService> for ExternalService {
         Self {
             id: *external_service.id,
             slug: external_service.slug,
-            kind: external_service.kind,
+            kind: external_service.kind.to_string(),
             name: external_service.name,
             base_url: external_service.base_url,
             url_pattern: external_service.url_pattern,

--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -3,7 +3,7 @@ use std::{io::{Read, Seek}, marker::PhantomData, sync::Arc};
 use async_graphql::{Context, Object, SimpleObject};
 use chrono::{DateTime, FixedOffset};
 use domain::{
-    entity::objects::{EntryUrl, EntryUrlPath},
+    entity::{external_services::ExternalServiceKind, objects::{EntryUrl, EntryUrlPath}},
     repository,
     service::{
         external_services::ExternalServicesServiceInterface,
@@ -105,7 +105,7 @@ where
         let kind = normalizer.normalize(kind);
         let name = normalizer.normalize(name);
 
-        let service = external_services_service.create_external_service(&slug, &kind, &name, base_url.as_deref(), url_pattern.as_deref()).await?;
+        let service = external_services_service.create_external_service(&slug, ExternalServiceKind::from(kind), &name, base_url.as_deref(), url_pattern.as_deref()).await?;
         Ok(service.into())
     }
 

--- a/api/crates/graphql/src/tests/mocks/domain/service/external_services.rs
+++ b/api/crates/graphql/src/tests/mocks/domain/service/external_services.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use domain::{
-    entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     error::Result,
     iter::CloneableIterator,
     repository::DeleteResult,
@@ -12,7 +12,7 @@ mockall::mock! {
     pub(crate) ExternalServicesServiceInterface {}
 
     impl ExternalServicesServiceInterface for ExternalServicesServiceInterface {
-        fn create_external_service<'a>(&self, slug: &str, kind: &str, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
+        fn create_external_service<'a>(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
         fn get_external_services(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;
 

--- a/api/crates/graphql/src/tests/mutation/create_external_service.rs
+++ b/api/crates/graphql/src/tests/mutation/create_external_service.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use async_graphql::{Schema, EmptySubscription, value};
-use domain::entity::external_services::{ExternalService, ExternalServiceId};
+use domain::entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind};
 use futures::future::ok;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
@@ -26,7 +26,7 @@ async fn succeeds() {
         .times(1)
         .withf(|slug, kind, name, base_url, url_pattern| (slug, kind, name, base_url, url_pattern) == (
             "x",
-            "x",
+            &ExternalServiceKind::X,
             "X",
             &Some("https://x.com"),
             &Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$"),
@@ -35,7 +35,7 @@ async fn succeeds() {
             Box::pin(ok(ExternalService {
                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/mutation/create_medium.rs
+++ b/api/crates/graphql/src/tests/mutation/create_medium.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeSet, sync::Arc};
 use async_graphql::{Schema, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::{
-    external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     media::{Medium, MediumId},
     sources::{Source, SourceId},
     tag_types::{TagType, TagTypeId},
@@ -66,7 +66,7 @@ async fn succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                             slug: "x".to_string(),
-                            kind: "x".to_string(),
+                            kind: ExternalServiceKind::X,
                             name: "X".to_string(),
                             base_url: Some("https://x.com".to_string()),
                             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -80,7 +80,7 @@ async fn succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                             slug: "pixiv".to_string(),
-                            kind: "pixiv".to_string(),
+                            kind: ExternalServiceKind::Pixiv,
                             name: "pixiv".to_string(),
                             base_url: Some("https://www.pixiv.net".to_string()),
                             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/mutation/create_source.rs
+++ b/api/crates/graphql/src/tests/mutation/create_source.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_graphql::{value, EmptySubscription, Schema};
 use chrono::{TimeZone, Utc};
-use domain::entity::{external_services::{ExternalMetadata, ExternalService, ExternalServiceId}, sources::{Source, SourceId}};
+use domain::entity::{external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind}, sources::{Source, SourceId}};
 use futures::future::ok;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
@@ -39,7 +39,7 @@ async fn succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/mutation/update_external_service.rs
+++ b/api/crates/graphql/src/tests/mutation/update_external_service.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, sync::Arc};
 
 use async_graphql::{Schema, EmptySubscription, value};
-use domain::entity::external_services::{ExternalService, ExternalServiceId};
+use domain::entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind};
 use futures::future::ok;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
@@ -35,7 +35,7 @@ async fn succeeds() {
             Box::pin(ok(ExternalService {
                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 slug: "pixiv".to_string(),
-                kind: "PIXIV".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "PIXIV".to_string(),
                 base_url: Some("https://example.com".to_string()),
                 url_pattern: Some(r"^https://example\.com".to_string()),
@@ -85,7 +85,7 @@ async fn succeeds() {
         "updateExternalService": {
             "id": "11111111-1111-1111-1111-111111111111",
             "slug": "pixiv",
-            "kind": "PIXIV",
+            "kind": "pixiv",
             "name": "PIXIV",
             "baseUrl": "https://example.com",
             "urlPattern": r"^https://example\.com",
@@ -110,7 +110,7 @@ async fn succeeds_empty() {
             Box::pin(ok(ExternalService {
                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: None,
                 url_pattern: None,
@@ -177,7 +177,7 @@ async fn succeeds_none() {
             Box::pin(ok(ExternalService {
                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/mutation/update_medium.rs
+++ b/api/crates/graphql/src/tests/mutation/update_medium.rs
@@ -4,7 +4,7 @@ use application::service::{media::MediaURLFactoryInterface, thumbnails::Thumbnai
 use async_graphql::{Schema, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::{
-    external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     media::{Medium, MediumId},
     replicas::{Replica, ReplicaId, ReplicaStatus, Size, Thumbnail, ThumbnailId},
     sources::{Source, SourceId},
@@ -90,7 +90,7 @@ async fn succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                             slug: "pixiv".to_string(),
-                            kind: "pixiv".to_string(),
+                            kind: ExternalServiceKind::Pixiv,
                             name: "pixiv".to_string(),
                             base_url: Some("https://www.pixiv.net".to_string()),
                             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -104,7 +104,7 @@ async fn succeeds() {
                         external_service: ExternalService {
                             id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                             slug: "pixiv".to_string(),
-                            kind: "pixiv".to_string(),
+                            kind: ExternalServiceKind::Pixiv,
                             name: "pixiv".to_string(),
                             base_url: Some("https://www.pixiv.net".to_string()),
                             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/mutation/update_source.rs
+++ b/api/crates/graphql/src/tests/mutation/update_source.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_graphql::{value, EmptySubscription, Schema};
 use chrono::{TimeZone, Utc};
 use domain::entity::{
-    external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     sources::{Source, SourceId},
 };
 use futures::future::ok;
@@ -43,7 +43,7 @@ async fn succeeds() {
                 external_service: ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/query/all_external_services.rs
+++ b/api/crates/graphql/src/tests/query/all_external_services.rs
@@ -1,5 +1,5 @@
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
-use domain::entity::external_services::{ExternalService, ExternalServiceId};
+use domain::entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind};
 use futures::future::ok;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
@@ -27,7 +27,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -35,7 +35,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                     slug: "skeb".to_string(),
-                    kind: "skeb".to_string(),
+                    kind: ExternalServiceKind::Skeb,
                     name: "Skeb".to_string(),
                     base_url: Some("https://skeb.jp".to_string()),
                     url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -43,7 +43,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/query/all_media_with.rs
+++ b/api/crates/graphql/src/tests/query/all_media_with.rs
@@ -5,7 +5,7 @@ use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         media::{Medium, MediumId},
         replicas::{Replica, ReplicaId, ReplicaStatus, Size, Thumbnail, ThumbnailId},
         sources::{Source, SourceId},
@@ -984,7 +984,7 @@ async fn sources_asc_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                                 slug: "x".to_string(),
-                                kind: "x".to_string(),
+                                kind: ExternalServiceKind::X,
                                 name: "X".to_string(),
                                 base_url: Some("https://x.com".to_string()),
                                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -998,7 +998,7 @@ async fn sources_asc_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                                 slug: "pixiv".to_string(),
-                                kind: "pixiv".to_string(),
+                                kind: ExternalServiceKind::Pixiv,
                                 name: "pixiv".to_string(),
                                 base_url: Some("https://www.pixiv.net".to_string()),
                                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -1021,7 +1021,7 @@ async fn sources_asc_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                                 slug: "pixiv".to_string(),
-                                kind: "pixiv".to_string(),
+                                kind: ExternalServiceKind::Pixiv,
                                 name: "pixiv".to_string(),
                                 base_url: Some("https://www.pixiv.net".to_string()),
                                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/query/all_sources_like.rs
+++ b/api/crates/graphql/src/tests/query/all_sources_like.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::{
-    external_services::{self, ExternalServiceId},
+    external_services::{self, ExternalServiceId, ExternalServiceKind},
     sources::{self, SourceId},
 };
 use futures::future::ok;
@@ -37,7 +37,7 @@ async fn id_succeeds() {
                     external_service: external_services::ExternalService {
                         id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -125,7 +125,7 @@ async fn url_succeeds() {
                     external_services::ExternalService {
                         id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -139,7 +139,7 @@ async fn url_succeeds() {
                     external_services::ExternalService {
                         id: ExternalServiceId::from(uuid!("22222222-2222-2222-2222-222222222222")),
                         slug: "website".to_string(),
-                        kind: "website".to_string(),
+                        kind: ExternalServiceKind::Website,
                         name: "Website".to_string(),
                         base_url: None,
                         url_pattern: None,
@@ -165,7 +165,7 @@ async fn url_succeeds() {
                 external_service: external_services::ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/query/external_services.rs
+++ b/api/crates/graphql/src/tests/query/external_services.rs
@@ -1,5 +1,5 @@
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
-use domain::entity::external_services::{ExternalService, ExternalServiceId};
+use domain::entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind};
 use futures::future::ok;
 use indoc::indoc;
 use pretty_assertions::assert_eq;
@@ -31,7 +31,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                     slug: "pixiv".to_string(),
-                    kind: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
                     name: "pixiv".to_string(),
                     base_url: Some("https://www.pixiv.net".to_string()),
                     url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -39,7 +39,7 @@ async fn succeeds() {
                 ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/query/media_with.rs
+++ b/api/crates/graphql/src/tests/query/media_with.rs
@@ -4,7 +4,7 @@ use application::service::{media::MediaURLFactoryInterface, thumbnails::Thumbnai
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::{
-    external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     media::{Medium, MediumId},
     replicas::{Replica, ReplicaId, ReplicaStatus, Size, Thumbnail, ThumbnailId},
     sources::{Source, SourceId},
@@ -709,7 +709,7 @@ async fn sources_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                                 slug: "x".to_string(),
-                                kind: "x".to_string(),
+                                kind: ExternalServiceKind::X,
                                 name: "X".to_string(),
                                 base_url: Some("https://x.com".to_string()),
                                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -723,7 +723,7 @@ async fn sources_succeeds() {
                             external_service: ExternalService {
                                 id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                                 slug: "pixiv".to_string(),
-                                kind: "pixiv".to_string(),
+                                kind: ExternalServiceKind::Pixiv,
                                 name: "pixiv".to_string(),
                                 base_url: Some("https://www.pixiv.net".to_string()),
                                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/query/source.rs
+++ b/api/crates/graphql/src/tests/query/source.rs
@@ -1,7 +1,7 @@
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::{
-    external_services::{self, ExternalServiceId},
+    external_services::{self, ExternalServiceId, ExternalServiceKind},
     sources::{self, SourceId},
 };
 use futures::future::ok;
@@ -40,7 +40,7 @@ async fn succeeds() {
                 external_service: external_services::ExternalService {
                     id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                     slug: "x".to_string(),
-                    kind: "x".to_string(),
+                    kind: ExternalServiceKind::X,
                     name: "X".to_string(),
                     base_url: Some("https://x.com".to_string()),
                     url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/graphql/src/tests/query/sources.rs
+++ b/api/crates/graphql/src/tests/query/sources.rs
@@ -1,7 +1,7 @@
 use async_graphql::{Schema, EmptyMutation, EmptySubscription, value};
 use chrono::{TimeZone, Utc};
 use domain::entity::{
-    external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+    external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     sources::{Source, SourceId},
 };
 use futures::future::ok;
@@ -38,7 +38,7 @@ async fn succeeds() {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("33333333-3333-3333-3333-333333333333")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -52,7 +52,7 @@ async fn succeeds() {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/postgres/src/external_services.rs
+++ b/api/crates/postgres/src/external_services.rs
@@ -1,6 +1,6 @@
 use derive_more::{Constructor, From, Into};
 use domain::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     error::{Error, ErrorKind, Result},
     repository::{external_services::ExternalServicesRepository, DeleteResult},
 };
@@ -48,7 +48,7 @@ impl From<PostgresExternalServiceRow> for ExternalService {
         Self {
             id: row.id.into(),
             slug: row.slug,
-            kind: row.kind,
+            kind: row.kind.into(),
             name: row.name,
             base_url: row.base_url,
             url_pattern: row.url_pattern,
@@ -58,7 +58,7 @@ impl From<PostgresExternalServiceRow> for ExternalService {
 
 impl ExternalServicesRepository for PostgresExternalServicesRepository {
     #[tracing::instrument(skip_all)]
-    async fn create(&self, slug: &str, kind: &str, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> Result<ExternalService> {
+    async fn create(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&str>, url_pattern: Option<&str>) -> Result<ExternalService> {
         let (sql, values) = Query::insert()
             .into_table(PostgresExternalService::Table)
             .columns([
@@ -70,7 +70,7 @@ impl ExternalServicesRepository for PostgresExternalServicesRepository {
             ])
             .values([
                 slug.into(),
-                kind.into(),
+                kind.to_string().into(),
                 name.into(),
                 base_url.into(),
                 url_pattern.into(),

--- a/api/crates/postgres/src/media.rs
+++ b/api/crates/postgres/src/media.rs
@@ -147,7 +147,7 @@ impl TryFrom<PostgresMediumSourceExternalServiceRow> for (MediumId, Source) {
                 external_service: ExternalService {
                     id: row.external_service_id.into(),
                     slug: row.external_service_slug,
-                    kind: row.external_service_kind,
+                    kind: row.external_service_kind.into(),
                     name: row.external_service_name,
                     base_url: row.external_service_base_url,
                     url_pattern: row.external_service_url_pattern,

--- a/api/crates/postgres/src/sources.rs
+++ b/api/crates/postgres/src/sources.rs
@@ -222,7 +222,7 @@ impl TryFrom<PostgresSourceExternalServiceRow> for Source {
             external_service: ExternalService {
                 id: row.external_service_id.into(),
                 slug: row.external_service_slug,
-                kind: row.external_service_kind,
+                kind: row.external_service_kind.into(),
                 name: row.external_service_name,
                 base_url: row.external_service_base_url,
                 url_pattern: row.external_service_url_pattern,

--- a/api/crates/postgres/tests/integration/external_services/create.rs
+++ b/api/crates/postgres/tests/integration/external_services/create.rs
@@ -1,4 +1,5 @@
 use domain::{
+    entity::external_services::ExternalServiceKind,
     error::ErrorKind,
     repository::external_services::ExternalServicesRepository,
 };
@@ -15,14 +16,14 @@ async fn succeeds(ctx: &DatabaseContext) {
     let repository = PostgresExternalServicesRepository::new(ctx.pool.clone());
     let actual = repository.create(
         "foobar",
-        "foobar",
+        ExternalServiceKind::Custom("foobar".to_string()),
         "FooBar",
         Some("https://foobar.example.com"),
         Some(r"^https?://foobar\.example\.com/(?<id>\d+)(?:[/?#].*)?$"),
     ).await.unwrap();
 
     assert_eq!(actual.slug, "foobar".to_string());
-    assert_eq!(actual.kind, "foobar".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::Custom("foobar".to_string()));
     assert_eq!(actual.name, "FooBar".to_string());
     assert_eq!(actual.base_url, Some("https://foobar.example.com".to_string()));
     assert_eq!(actual.url_pattern, Some(r"^https?://foobar\.example\.com/(?<id>\d+)(?:[/?#].*)?$".to_string()));
@@ -46,7 +47,7 @@ async fn fails(ctx: &DatabaseContext) {
     let repository = PostgresExternalServicesRepository::new(ctx.pool.clone());
     let actual = repository.create(
         "x",
-        "x",
+        ExternalServiceKind::X,
         "X",
         Some("https://x.com"),
         Some(r"^https?://foobar\.example\.com/(?<id>\d+)(?:[/?#].*)?$"),

--- a/api/crates/postgres/tests/integration/external_services/fetch_all.rs
+++ b/api/crates/postgres/tests/integration/external_services/fetch_all.rs
@@ -1,5 +1,5 @@
 use domain::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     repository::external_services::ExternalServicesRepository,
 };
 use postgres::external_services::PostgresExternalServicesRepository;
@@ -19,7 +19,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -27,7 +27,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
             slug: "skeb".to_string(),
-            kind: "skeb".to_string(),
+            kind: ExternalServiceKind::Skeb,
             name: "Skeb".to_string(),
             base_url: Some("https://skeb.jp".to_string()),
             url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -35,7 +35,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
-            kind: "custom".to_string(),
+            kind: ExternalServiceKind::Custom("custom".to_string()),
             name: "Custom".to_string(),
             base_url: None,
             url_pattern: None,
@@ -43,7 +43,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/external_services/fetch_by_ids.rs
+++ b/api/crates/postgres/tests/integration/external_services/fetch_by_ids.rs
@@ -1,5 +1,5 @@
 use domain::{
-    entity::external_services::{ExternalService, ExternalServiceId},
+    entity::external_services::{ExternalService, ExternalServiceId, ExternalServiceKind},
     repository::external_services::ExternalServicesRepository,
 };
 use postgres::external_services::PostgresExternalServicesRepository;
@@ -22,7 +22,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -30,7 +30,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/external_services/update_by_id.rs
+++ b/api/crates/postgres/tests/integration/external_services/update_by_id.rs
@@ -1,5 +1,5 @@
 use domain::{
-    entity::external_services::ExternalServiceId,
+    entity::external_services::{ExternalServiceId, ExternalServiceKind},
     error::ErrorKind,
     repository::external_services::ExternalServicesRepository,
 };
@@ -56,7 +56,7 @@ async fn with_slug_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.id, ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")));
     assert_eq!(actual.slug, "twitter".to_string());
-    assert_eq!(actual.kind, "x".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::X);
     assert_eq!(actual.name, "X".to_string());
     assert_eq!(actual.base_url, Some("https://x.com".to_string()));
     assert_eq!(actual.url_pattern, Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()));
@@ -88,7 +88,7 @@ async fn with_name_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.id, ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")));
     assert_eq!(actual.slug, "x".to_string());
-    assert_eq!(actual.kind, "x".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::X);
     assert_eq!(actual.name, "Twitter".to_string());
     assert_eq!(actual.base_url, Some("https://x.com".to_string()));
     assert_eq!(actual.url_pattern, Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()));
@@ -120,7 +120,7 @@ async fn with_base_url_set_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.id, ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")));
     assert_eq!(actual.slug, "x".to_string());
-    assert_eq!(actual.kind, "x".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::X);
     assert_eq!(actual.name, "X".to_string());
     assert_eq!(actual.base_url, Some("https://twitter.com".to_string()));
     assert_eq!(actual.url_pattern, Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()));
@@ -152,7 +152,7 @@ async fn with_base_url_remove_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.id, ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")));
     assert_eq!(actual.slug, "x".to_string());
-    assert_eq!(actual.kind, "x".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::X);
     assert_eq!(actual.name, "X".to_string());
     assert_eq!(actual.base_url, None);
     assert_eq!(actual.url_pattern, Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()));
@@ -184,7 +184,7 @@ async fn with_url_pattern_set_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.id, ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")));
     assert_eq!(actual.slug, "x".to_string());
-    assert_eq!(actual.kind, "x".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::X);
     assert_eq!(actual.name, "X".to_string());
     assert_eq!(actual.base_url, Some("https://x.com".to_string()));
     assert_eq!(actual.url_pattern, Some(r"^https?://twitter\.com/([^/]+)/status/(\d+)(?:[/?#].*)?$".to_string()));
@@ -216,7 +216,7 @@ async fn with_url_pattern_remove_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.id, ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")));
     assert_eq!(actual.slug, "x".to_string());
-    assert_eq!(actual.kind, "x".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::X);
     assert_eq!(actual.name, "X".to_string());
     assert_eq!(actual.base_url, Some("https://x.com".to_string()));
     assert_eq!(actual.url_pattern, None);
@@ -248,7 +248,7 @@ async fn with_all_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual.id, ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")));
     assert_eq!(actual.slug, "x".to_string());
-    assert_eq!(actual.kind, "x".to_string());
+    assert_eq!(actual.kind, ExternalServiceKind::X);
     assert_eq!(actual.name, "X".to_string());
     assert_eq!(actual.base_url, Some("https://x.com".to_string()));
     assert_eq!(actual.url_pattern, Some(r"^https?://x\.com/([^/]+)/status/(\d+)(?:[/?#].*)?$".to_string()));

--- a/api/crates/postgres/tests/integration/media/create.rs
+++ b/api/crates/postgres/tests/integration/media/create.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use chrono::{DateTime, TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
         tag_types::{TagType, TagTypeId},
         tags::{AliasSet, Tag, TagDepth, TagId},
@@ -95,7 +95,7 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -109,7 +109,7 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -386,7 +386,7 @@ async fn with_sources_tags_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -400,7 +400,7 @@ async fn with_sources_tags_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_all_with_sources.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         media::{Medium, MediumId},
         sources::{Source, SourceId},
     },
@@ -38,7 +38,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -52,7 +52,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -75,7 +75,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -89,7 +89,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -112,7 +112,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -161,7 +161,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -175,7 +175,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -198,7 +198,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -212,7 +212,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -253,7 +253,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -267,7 +267,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -290,7 +290,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -304,7 +304,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -327,7 +327,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -368,7 +368,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -391,7 +391,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -414,7 +414,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -428,7 +428,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -469,7 +469,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -483,7 +483,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -506,7 +506,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -520,7 +520,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -561,7 +561,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -584,7 +584,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -598,7 +598,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -621,7 +621,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -635,7 +635,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/media/fetch_by_ids_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_ids_with_sources.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         media::{Medium, MediumId},
         sources::{Source, SourceId},
     },
@@ -38,7 +38,7 @@ async fn succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -61,7 +61,7 @@ async fn succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -75,7 +75,7 @@ async fn succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         media::{Medium, MediumId},
         sources::{Source, SourceId},
     },
@@ -43,7 +43,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -57,7 +57,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -80,7 +80,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -103,7 +103,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -117,7 +117,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -163,7 +163,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -186,7 +186,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -200,7 +200,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -223,7 +223,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -269,7 +269,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -283,7 +283,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -306,7 +306,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -352,7 +352,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -366,7 +366,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -412,7 +412,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -426,7 +426,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -449,7 +449,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -495,7 +495,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         media::{Medium, MediumId},
         sources::{Source, SourceId},
         tag_types::TagTypeId,
@@ -46,7 +46,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -60,7 +60,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -83,7 +83,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -97,7 +97,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -120,7 +120,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -167,7 +167,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -181,7 +181,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -204,7 +204,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -227,7 +227,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -241,7 +241,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -288,7 +288,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -302,7 +302,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -325,7 +325,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -348,7 +348,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -362,7 +362,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -409,7 +409,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -423,7 +423,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -470,7 +470,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -484,7 +484,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -507,7 +507,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -521,7 +521,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                         slug: "skeb".to_string(),
-                        kind: "skeb".to_string(),
+                        kind: ExternalServiceKind::Skeb,
                         name: "Skeb".to_string(),
                         base_url: Some("https://skeb.jp".to_string()),
                         url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -568,7 +568,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                         slug: "pixiv".to_string(),
-                        kind: "pixiv".to_string(),
+                        kind: ExternalServiceKind::Pixiv,
                         name: "pixiv".to_string(),
                         base_url: Some("https://www.pixiv.net".to_string()),
                         url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -582,7 +582,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
                     external_service: ExternalService {
                         id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                         slug: "x".to_string(),
-                        kind: "x".to_string(),
+                        kind: ExternalServiceKind::X,
                         name: "X".to_string(),
                         base_url: Some("https://x.com".to_string()),
                         url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/media/update_by_id.rs
+++ b/api/crates/postgres/tests/integration/media/update_by_id.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use chrono::{DateTime, TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalMetadata, ExternalService, ExternalServiceId},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         media::MediumId,
         replicas::{Replica, ReplicaId, ReplicaStatus, Size, Thumbnail, ThumbnailId},
         sources::{Source, SourceId},
@@ -466,7 +466,7 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                 slug: "skeb".to_string(),
-                kind: "skeb".to_string(),
+                kind: ExternalServiceKind::Skeb,
                 name: "Skeb".to_string(),
                 base_url: Some("https://skeb.jp".to_string()),
                 url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -480,7 +480,7 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -1024,7 +1024,7 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
                 slug: "skeb".to_string(),
-                kind: "skeb".to_string(),
+                kind: ExternalServiceKind::Skeb,
                 name: "Skeb".to_string(),
                 base_url: Some("https://skeb.jp".to_string()),
                 url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),
@@ -1038,7 +1038,7 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/sources/create.rs
+++ b/api/crates/postgres/tests/integration/sources/create.rs
@@ -1,5 +1,5 @@
 use domain::{
-    entity::external_services::{ExternalService, ExternalServiceId, ExternalMetadata},
+    entity::external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
     repository::sources::SourcesRepository,
 };
 use postgres::sources::PostgresSourcesRepository;
@@ -25,7 +25,7 @@ async fn succeeds_with_default(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -69,7 +69,7 @@ async fn succeeds_with_extra(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),
@@ -114,7 +114,7 @@ async fn succeeds_with_custom_object(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
-            kind: "custom".to_string(),
+            kind: ExternalServiceKind::Custom("custom".to_string()),
             name: "Custom".to_string(),
             base_url: None,
             url_pattern: None,
@@ -155,7 +155,7 @@ async fn succeeds_with_custom_string(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
-            kind: "custom".to_string(),
+            kind: ExternalServiceKind::Custom("custom".to_string()),
             name: "Custom".to_string(),
             base_url: None,
             url_pattern: None,
@@ -194,7 +194,7 @@ async fn succeeds_with_custom_number(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("6c07eb4d-93a1-4efd-afce-e13f8f2c0e14")),
             slug: "whatever".to_string(),
-            kind: "custom".to_string(),
+            kind: ExternalServiceKind::Custom("custom".to_string()),
             name: "Custom".to_string(),
             base_url: None,
             url_pattern: None,

--- a/api/crates/postgres/tests/integration/sources/fetch_by_external_metadata.rs
+++ b/api/crates/postgres/tests/integration/sources/fetch_by_external_metadata.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalService, ExternalServiceId, ExternalMetadata},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     repository::sources::SourcesRepository,
@@ -27,7 +27,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -52,7 +52,7 @@ async fn succeeds_with_extra(ctx: &DatabaseContext) {
         external_service: ExternalService {
             id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
             slug: "x".to_string(),
-            kind: "x".to_string(),
+            kind: ExternalServiceKind::X,
             name: "X".to_string(),
             base_url: Some("https://x.com".to_string()),
             url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/sources/fetch_by_external_metadata_like_id.rs
+++ b/api/crates/postgres/tests/integration/sources/fetch_by_external_metadata_like_id.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalService, ExternalServiceId, ExternalMetadata},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     repository::sources::SourcesRepository,
@@ -25,7 +25,7 @@ async fn succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/sources/fetch_by_ids.rs
+++ b/api/crates/postgres/tests/integration/sources/fetch_by_ids.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalService, ExternalServiceId, ExternalMetadata},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::{Source, SourceId},
     },
     repository::sources::SourcesRepository,
@@ -28,7 +28,7 @@ async fn succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
                 slug: "pixiv".to_string(),
-                kind: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
                 name: "pixiv".to_string(),
                 base_url: Some("https://www.pixiv.net".to_string()),
                 url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -42,7 +42,7 @@ async fn succeeds(ctx: &DatabaseContext) {
             external_service: ExternalService {
                 id: ExternalServiceId::from(uuid!("99a9f0e8-1097-4b7f-94f2-2a7d2cc786ab")),
                 slug: "x".to_string(),
-                kind: "x".to_string(),
+                kind: ExternalServiceKind::X,
                 name: "X".to_string(),
                 base_url: Some("https://x.com".to_string()),
                 url_pattern: Some(r"^https?://(?:twitter\.com|x\.com)/(?<creatorId>[^/]+)/status/(?<id>\d+)(?:[/?#].*)?$".to_string()),

--- a/api/crates/postgres/tests/integration/sources/update_by_id.rs
+++ b/api/crates/postgres/tests/integration/sources/update_by_id.rs
@@ -1,7 +1,7 @@
 use chrono::{TimeZone, Utc};
 use domain::{
     entity::{
-        external_services::{ExternalService, ExternalServiceId, ExternalMetadata},
+        external_services::{ExternalMetadata, ExternalService, ExternalServiceId, ExternalServiceKind},
         sources::SourceId,
     },
     error::ErrorKind,
@@ -32,7 +32,7 @@ async fn with_external_metadata_succeeds(ctx: &DatabaseContext) {
         ExternalService {
             id: ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3")),
             slug: "pixiv".to_string(),
-            kind: "pixiv".to_string(),
+            kind: ExternalServiceKind::Pixiv,
             name: "pixiv".to_string(),
             base_url: Some("https://www.pixiv.net".to_string()),
             url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
@@ -80,7 +80,7 @@ async fn with_external_service_and_external_metadata_succeeds(ctx: &DatabaseCont
         ExternalService {
             id: ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7")),
             slug: "skeb".to_string(),
-            kind: "skeb".to_string(),
+            kind: ExternalServiceKind::Skeb,
             name: "Skeb".to_string(),
             base_url: Some("https://skeb.jp".to_string()),
             url_pattern: Some(r"^https?://skeb\.jp/@(?<creatorId>[^/]+)/works/(?<id>\d+)(?:[?#].*)?$".to_string()),


### PR DESCRIPTION
This PR refactors how an external service holds its kind: `String` to `ExternalServiceKind`.