### PR TITLE
Use `Cow<str>` to return URL from `ExternalMetadata::url()`

### DIFF
--- a/api/crates/domain/src/entity/external_services.rs
+++ b/api/crates/domain/src/entity/external_services.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{borrow::Cow, str::FromStr};
 
 use derive_more::{Deref, Display, From};
 use regex::Regex;
@@ -125,25 +125,25 @@ impl ExternalMetadata {
         }
     }
 
-    pub fn url(&self, base_url: Option<&str>) -> Option<String> {
+    pub fn url(&self, base_url: Option<&str>) -> Option<Cow<str>> {
         let base_url = base_url.map(|b| b.trim_end_matches("/"));
 
         use ExternalMetadata::*;
         let url = match self {
-            Bluesky { id, creator_id } => format!("{}/profile/{creator_id}/post/{id}", base_url.unwrap_or(Self::BASE_URL_BLUESKY)),
-            Fantia { id } => format!("{}/posts/{id}", base_url.unwrap_or(Self::BASE_URL_FANTIA)),
-            Mastodon { id, creator_id } => format!("{}/@{creator_id}/{id}", base_url?),
-            Misskey { id } => format!("{}/notes/{id}", base_url?),
-            Nijie { id } => format!("{}/view.php?id={id}", base_url.unwrap_or(Self::BASE_URL_NIJIE)),
-            Pixiv { id } => format!("{}/artworks/{id}", base_url.unwrap_or(Self::BASE_URL_PIXIV)),
-            PixivFanbox { id, creator_id } => format!("https://{creator_id}.fanbox.cc/posts/{id}"),
-            Pleroma { id } => format!("{}/notice/{id}", base_url?),
-            Seiga { id } => format!("{}/seiga/im{id}", base_url.unwrap_or(Self::BASE_URL_SEIGA)),
-            Skeb { id, creator_id } => format!("{}/@{creator_id}/works/{id}", base_url.unwrap_or(Self::BASE_URL_SKEB)),
-            Threads { id, creator_id } => format!("{}/@{}/post/{id}", base_url.unwrap_or(Self::BASE_URL_THREADS), creator_id.as_deref().unwrap_or_default()),
-            Website { url } => url.clone(),
-            X { id, creator_id } => format!("{}/{}/status/{id}", base_url.unwrap_or(Self::BASE_URL_X), creator_id.as_deref().unwrap_or("i")),
-            Xfolio { id, creator_id } => format!("{}/portfolio/{creator_id}/works/{id}", base_url.unwrap_or(Self::BASE_URL_XFOLIO)),
+            Bluesky { id, creator_id } => format!("{}/profile/{creator_id}/post/{id}", base_url.unwrap_or(Self::BASE_URL_BLUESKY)).into(),
+            Fantia { id } => format!("{}/posts/{id}", base_url.unwrap_or(Self::BASE_URL_FANTIA)).into(),
+            Mastodon { id, creator_id } => format!("{}/@{creator_id}/{id}", base_url?).into(),
+            Misskey { id } => format!("{}/notes/{id}", base_url?).into(),
+            Nijie { id } => format!("{}/view.php?id={id}", base_url.unwrap_or(Self::BASE_URL_NIJIE)).into(),
+            Pixiv { id } => format!("{}/artworks/{id}", base_url.unwrap_or(Self::BASE_URL_PIXIV)).into(),
+            PixivFanbox { id, creator_id } => format!("https://{creator_id}.fanbox.cc/posts/{id}").into(),
+            Pleroma { id } => format!("{}/notice/{id}", base_url?).into(),
+            Seiga { id } => format!("{}/seiga/im{id}", base_url.unwrap_or(Self::BASE_URL_SEIGA)).into(),
+            Skeb { id, creator_id } => format!("{}/@{creator_id}/works/{id}", base_url.unwrap_or(Self::BASE_URL_SKEB)).into(),
+            Threads { id, creator_id } => format!("{}/@{}/post/{id}", base_url.unwrap_or(Self::BASE_URL_THREADS), creator_id.as_deref().unwrap_or_default()).into(),
+            Website { url } => url.into(),
+            X { id, creator_id } => format!("{}/{}/status/{id}", base_url.unwrap_or(Self::BASE_URL_X), creator_id.as_deref().unwrap_or("i")).into(),
+            Xfolio { id, creator_id } => format!("{}/portfolio/{creator_id}/works/{id}", base_url.unwrap_or(Self::BASE_URL_XFOLIO)).into(),
             Custom(..) => return None,
         };
 

--- a/api/crates/domain/src/entity/sources.rs
+++ b/api/crates/domain/src/entity/sources.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use chrono::{DateTime, Utc};
 use derive_more::{Deref, Display, From};
 use serde::{Deserialize, Serialize};
@@ -18,7 +20,7 @@ pub struct Source {
 }
 
 impl Source {
-    pub fn url(&self) -> Option<String> {
+    pub fn url(&self) -> Option<Cow<str>> {
         self.external_metadata.url(self.external_service.base_url.as_deref())
     }
 

--- a/api/crates/domain/src/tests/entity/external_services.rs
+++ b/api/crates/domain/src/tests/entity/external_services.rs
@@ -329,132 +329,162 @@ fn external_metadata_kind_succeeds_with_custom() {
 
 #[test]
 fn external_metadata_url_succeeds_with_bluesky() {
-    let actual = ExternalMetadata::Bluesky { id: "abcdefghi".to_string(), creator_id: "creator_01".to_string() }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Bluesky { id: "abcdefghi".to_string(), creator_id: "creator_01".to_string() };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/profile/creator_01/post/abcdefghi");
 
-    let actual = ExternalMetadata::Bluesky { id: "abcdefghi".to_string(), creator_id: "creator_01".to_string() }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://bsky.app/profile/creator_01/post/abcdefghi");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_fantia() {
-    let actual = ExternalMetadata::Fantia { id: 1305295 }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Fantia { id: 1305295 };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/posts/1305295");
 
-    let actual = ExternalMetadata::Fantia { id: 1305295 }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://fantia.jp/posts/1305295");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_mastodon() {
-    let actual = ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() }.url(Some("https://mastodon.social/")).unwrap();
+    let external_metadata = ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() };
+
+    let actual = external_metadata.url(Some("https://mastodon.social/")).unwrap();
     assert_eq!(actual, "https://mastodon.social/@creator_01/123456789");
 
-    let actual = ExternalMetadata::Mastodon { id: 123456789, creator_id: "creator_01".to_string() }.url(None);
+    let actual = external_metadata.url(None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_misskey() {
-    let actual = ExternalMetadata::Misskey { id: "abcdefghi".to_string() }.url(Some("https://misskey.io/")).unwrap();
+    let external_metadata = ExternalMetadata::Misskey { id: "abcdefghi".to_string() };
+
+    let actual = external_metadata.url(Some("https://misskey.io/")).unwrap();
     assert_eq!(actual, "https://misskey.io/notes/abcdefghi");
 
-    let actual = ExternalMetadata::Misskey { id: "abcdefghi".to_string() }.url(None);
+    let actual = external_metadata.url(None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_nijie() {
-    let actual = ExternalMetadata::Nijie { id: 323512 }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Nijie { id: 323512 };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/view.php?id=323512");
 
-    let actual = ExternalMetadata::Nijie { id: 323512 }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://nijie.info/view.php?id=323512");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_pixiv() {
-    let actual = ExternalMetadata::Pixiv { id: 56736941 }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Pixiv { id: 56736941 };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/artworks/56736941");
 
-    let actual = ExternalMetadata::Pixiv { id: 56736941 }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://www.pixiv.net/artworks/56736941");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_pixiv_fanbox() {
-    let actual = ExternalMetadata::PixivFanbox { id: 178080, creator_id: "fairyeye".to_string() }.url(Some("https://example.com")).unwrap();
+    let external_metadata = ExternalMetadata::PixivFanbox { id: 178080, creator_id: "fairyeye".to_string() };
+
+    let actual = external_metadata.url(Some("https://example.com")).unwrap();
     assert_eq!(actual, "https://fairyeye.fanbox.cc/posts/178080");
 
-    let actual = ExternalMetadata::PixivFanbox { id: 178080, creator_id: "fairyeye".to_string() }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://fairyeye.fanbox.cc/posts/178080");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_pleroma() {
-    let actual = ExternalMetadata::Pleroma { id: "abcdefghi".to_string() }.url(Some("https://udongein.xyz")).unwrap();
+    let external_metadata = ExternalMetadata::Pleroma { id: "abcdefghi".to_string() };
+
+    let actual = external_metadata.url(Some("https://udongein.xyz")).unwrap();
     assert_eq!(actual, "https://udongein.xyz/notice/abcdefghi");
 
-    let actual = ExternalMetadata::Pleroma { id: "abcdefghi".to_string() }.url(None);
+    let actual = external_metadata.url(None);
     assert!(actual.is_none());
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_seiga() {
-    let actual = ExternalMetadata::Seiga { id: 6452903 }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Seiga { id: 6452903 };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/seiga/im6452903");
 
-    let actual = ExternalMetadata::Seiga { id: 6452903 }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://seiga.nicovideo.jp/seiga/im6452903");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_skeb() {
-    let actual = ExternalMetadata::Skeb { id: 18, creator_id: "pieleaf_x2".to_string() }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Skeb { id: 18, creator_id: "pieleaf_x2".to_string() };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/@pieleaf_x2/works/18");
 
-    let actual = ExternalMetadata::Skeb { id: 18, creator_id: "pieleaf_x2".to_string() }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://skeb.jp/@pieleaf_x2/works/18");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_threads() {
-    let actual = ExternalMetadata::Threads { id: "abcdefghi".to_string(), creator_id: Some("creator_01".to_string()) }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Threads { id: "abcdefghi".to_string(), creator_id: Some("creator_01".to_string()) };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/@creator_01/post/abcdefghi");
 
-    let actual = ExternalMetadata::Threads { id: "abcdefghi".to_string(), creator_id: Some("creator_01".to_string()) }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://www.threads.net/@creator_01/post/abcdefghi");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_website() {
-    let actual = ExternalMetadata::Website { url: "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885".to_string() }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Website { url: "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885".to_string() };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885");
 
-    let actual = ExternalMetadata::Website { url: "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885".to_string() }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://www.melonbooks.co.jp/corner/detail.php?corner_id=885");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_x() {
-    let actual = ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/_namori_/status/727620202049900544");
 
-    let actual = ExternalMetadata::X { id: 727620202049900544, creator_id: Some("_namori_".to_string()) }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://x.com/_namori_/status/727620202049900544");
 }
 
 #[test]
 fn external_metadata_url_succeeds_with_xfolio() {
-    let actual = ExternalMetadata::Xfolio { id: 123456789, creator_id: "creator_01".to_string() }.url(Some("https://example.com/")).unwrap();
+    let external_metadata = ExternalMetadata::Xfolio { id: 123456789, creator_id: "creator_01".to_string() };
+
+    let actual = external_metadata.url(Some("https://example.com/")).unwrap();
     assert_eq!(actual, "https://example.com/portfolio/creator_01/works/123456789");
 
-    let actual = ExternalMetadata::Xfolio { id: 123456789, creator_id: "creator_01".to_string() }.url(None).unwrap();
+    let actual = external_metadata.url(None).unwrap();
     assert_eq!(actual, "https://xfolio.jp/portfolio/creator_01/works/123456789");
 }
 
 #[test]
 fn external_metadata_url_with_custom() {
-    let actual = ExternalMetadata::Custom(r#"{"id":42}"#.to_string()).url(None);
+    let external_metadata = ExternalMetadata::Custom(r#"{"id":42}"#.to_string());
+
+    let actual = external_metadata.url(None);
     assert!(actual.is_none());
 }

--- a/api/crates/graphql/src/sources.rs
+++ b/api/crates/graphql/src/sources.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use async_graphql::{InputObject, OneofObject, SimpleObject};
 use chrono::{DateTime, Utc};
 use domain::entity::{external_services, sources};
@@ -166,7 +168,7 @@ impl TryFrom<sources::Source> for Source {
     type Error = Error;
 
     fn try_from(source: sources::Source) -> Result<Self, Self::Error> {
-        let url = source.url();
+        let url = source.url().map(Cow::into_owned);
         let external_metadata = ExternalMetadata::try_from(source.external_metadata)?;
 
         Ok(Self {


### PR DESCRIPTION
This PR refactors `ExternalMetadata::url()` to use `Cow<str>` instead of `String`.