### PR TITLE
Reset base URL and URL pattern when an empty value is given to updateExternalService

### DIFF
--- a/api/crates/domain/src/tests/service/external_services/update_external_service_by_id.rs
+++ b/api/crates/domain/src/tests/service/external_services/update_external_service_by_id.rs
@@ -15,6 +15,25 @@ use super::mocks::domain::repository::external_services::MockExternalServicesRep
 async fn succeeds() {
     let mut mock_external_services_repository = MockExternalServicesRepository::new();
     mock_external_services_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids| ids.clone_box().eq([
+            ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        ]))
+        .returning(|_| {
+            Box::pin(ok(vec![
+                ExternalService {
+                    id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                    slug: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
+                    name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
+                    url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+                },
+            ]))
+        });
+
+    mock_external_services_repository
         .expect_update_by_id()
         .times(1)
         .withf(|id, slug, name, base_url, url_pattern| (id, slug, name, base_url, url_pattern) == (
@@ -55,8 +74,89 @@ async fn succeeds() {
 }
 
 #[tokio::test]
+async fn succeeds_with_reset() {
+    let mut mock_external_services_repository = MockExternalServicesRepository::new();
+    mock_external_services_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids| ids.clone_box().eq([
+            ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        ]))
+        .returning(|_| {
+            Box::pin(ok(vec![
+                ExternalService {
+                    id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                    slug: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
+                    name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
+                    url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+                },
+            ]))
+        });
+
+    mock_external_services_repository
+        .expect_update_by_id()
+        .times(1)
+        .withf(|id, slug, name, base_url, url_pattern| (id, slug, name, base_url, url_pattern) == (
+            &ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+            &None,
+            &Some("PIXIV"),
+            &Some(Some("https://www.pixiv.net")),
+            &Some(Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$")),
+        ))
+        .returning(|_, _, _, _, _| {
+            Box::pin(ok(ExternalService {
+                id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                slug: "pixiv".to_string(),
+                kind: ExternalServiceKind::Pixiv,
+                name: "PIXIV".to_string(),
+                base_url: Some("https://www.pixiv.net".to_string()),
+                url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+            }))
+        });
+
+    let service = ExternalServicesService::new(mock_external_services_repository);
+    let actual = service.update_external_service_by_id(
+        ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        None,
+        Some("PIXIV"),
+        Some(None),
+        Some(None),
+    ).await.unwrap();
+
+    assert_eq!(actual, ExternalService {
+        id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        slug: "pixiv".to_string(),
+        kind: ExternalServiceKind::Pixiv,
+        name: "PIXIV".to_string(),
+        base_url: Some("https://www.pixiv.net".to_string()),
+        url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+    })
+}
+
+#[tokio::test]
 async fn fails() {
     let mut mock_external_services_repository = MockExternalServicesRepository::new();
+    mock_external_services_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids| ids.clone_box().eq([
+            ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        ]))
+        .returning(|_| {
+            Box::pin(ok(vec![
+                ExternalService {
+                    id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                    slug: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
+                    name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
+                    url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+                },
+            ]))
+        });
+
     mock_external_services_repository
         .expect_update_by_id()
         .times(1)
@@ -82,8 +182,49 @@ async fn fails() {
 }
 
 #[tokio::test]
+async fn fails_with_not_found() {
+    let mut mock_external_services_repository = MockExternalServicesRepository::new();
+    mock_external_services_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids| ids.clone_box().eq([
+            ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        ]))
+        .returning(|_| Box::pin(ok(Vec::new())));
+
+    let service = ExternalServicesService::new(mock_external_services_repository);
+    let actual = service.update_external_service_by_id(
+        ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        None,
+        Some("PIXIV"),
+        None,
+        None,
+    ).await.unwrap_err();
+
+    assert_matches!(actual.kind(), ErrorKind::ExternalServiceNotFound { id } if id == &ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")));
+}
+
+#[tokio::test]
 async fn fails_with_url_pattern_invalid() {
-    let mock_external_services_repository = MockExternalServicesRepository::new();
+    let mut mock_external_services_repository = MockExternalServicesRepository::new();
+    mock_external_services_repository
+        .expect_fetch_by_ids()
+        .times(1)
+        .withf(|ids| ids.clone_box().eq([
+            ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+        ]))
+        .returning(|_| {
+            Box::pin(ok(vec![
+                ExternalService {
+                    id: ExternalServiceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
+                    slug: "pixiv".to_string(),
+                    kind: ExternalServiceKind::Pixiv,
+                    name: "pixiv".to_string(),
+                    base_url: Some("https://www.pixiv.net".to_string()),
+                    url_pattern: Some(r"^https?://www\.pixiv\.net/(?:artworks/|member_illust\.php\?(?:|.+&)illust_id=)(?<id>\d+)(?:[?&#].*)?$".to_string()),
+                },
+            ]))
+        });
 
     let service = ExternalServicesService::new(mock_external_services_repository);
     let actual = service.update_external_service_by_id(

--- a/api/crates/graphql/src/mutation.rs
+++ b/api/crates/graphql/src/mutation.rs
@@ -123,9 +123,9 @@ where
         slug: Option<String>,
         #[graphql(desc = "The name of the Web service.")]
         name: Option<String>,
-        #[graphql(desc = "The base URL of the Web service. Some services do not have the base URL. Pass an empty value to remove.")]
+        #[graphql(desc = "The base URL of the Web service. Some services do not have the base URL. Pass an empty value to reset.")]
         base_url: Option<String>,
-        #[graphql(desc = "The regex pattern of a URL in the Web service. Pass an empty value to remove.")]
+        #[graphql(desc = "The regex pattern of a URL in the Web service. Pass an empty value to reset.")]
         url_pattern: Option<String>,
     ) -> Result<ExternalService> {
         let external_services_service = ctx.data_unchecked::<ExternalServicesService>();

--- a/schema/hoarder.gql
+++ b/schema/hoarder.gql
@@ -305,11 +305,11 @@ type Mutation {
 		"""
 		name: String,
 		"""
-		The base URL of the Web service. Some services do not have the base URL. Pass an empty value to remove.
+		The base URL of the Web service. Some services do not have the base URL. Pass an empty value to reset.
 		"""
 		baseUrl: String,
 		"""
-		The regex pattern of a URL in the Web service. Pass an empty value to remove.
+		The regex pattern of a URL in the Web service. Pass an empty value to reset.
 		"""
 		urlPattern: String
 	): ExternalService!


### PR DESCRIPTION
This PR allows to reset base URL and URL pattern when an empty value is given to updateExternalService.