### PR TITLE
Fix a bug where deletion of a tag type or external service not deleted it from screen

### DIFF
--- a/ui/src/components/ExternalServiceListColumnBodyEdit/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyEdit/index.tsx
@@ -158,7 +158,7 @@ const ExternalServiceListColumnBodyEdit: FunctionComponent<ExternalServiceListCo
           margin="normal"
           label="ベース URL"
           disabled={loading}
-          value={externalService.baseUrl}
+          value={externalService.baseUrl ?? ''}
           onChange={handleChangeBaseUrl}
         />
         {isUrlPatternInvalid ? (
@@ -184,7 +184,7 @@ const ExternalServiceListColumnBodyEdit: FunctionComponent<ExternalServiceListCo
               },
             }}
             disabled={loading}
-            value={externalService.urlPattern}
+            value={externalService.urlPattern ?? ''}
             onChange={handleChangeUrlPattern}
           />
         ) : (
@@ -213,7 +213,7 @@ const ExternalServiceListColumnBodyEdit: FunctionComponent<ExternalServiceListCo
               },
             }}
             disabled={loading}
-            value={externalService.urlPattern}
+            value={externalService.urlPattern ?? ''}
             onChange={handleChangeUrlPattern}
             inputRef={urlPatternRef}
           />

--- a/ui/src/components/ExternalServiceListColumnBodyShow/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyShow/index.tsx
@@ -57,7 +57,7 @@ const ExternalServiceListColumnBodyShow: FunctionComponent<ExternalServiceListCo
         <TextField
           margin="normal"
           label="ベース URL"
-          value={externalService.baseUrl}
+          value={externalService.baseUrl ?? ''}
           onDoubleClick={handleClickEdit}
           slotProps={{
             htmlInput: {
@@ -68,7 +68,7 @@ const ExternalServiceListColumnBodyShow: FunctionComponent<ExternalServiceListCo
         <TextField
           margin="normal"
           label="URL 正規表現"
-          value={externalService.urlPattern}
+          value={externalService.urlPattern ?? ''}
           onDoubleClick={handleClickEdit}
           slotProps={{
             htmlInput: {

--- a/ui/src/components/ExternalServiceListView/index.tsx
+++ b/ui/src/components/ExternalServiceListView/index.tsx
@@ -40,25 +40,27 @@ const ExternalServiceListView: FunctionComponent<ExternalServiceListViewProps> =
 
   const closeCreateExternalService = useCallback(() => {
     setCreating(false)
-    setShowingExternalService(column.active)
+    setShowingExternalService(null)
     setEditingExternalService(null)
     setColumn(column => ({
       ...column,
       creating: false,
       editing: null,
+      active: null,
     }))
-  }, [ column ])
+  }, [])
 
   const closeEditExternalService = useCallback(() => {
     setCreating(false)
-    setShowingExternalService(column.active)
+    setShowingExternalService(null)
     setEditingExternalService(null)
     setColumn(column => ({
       ...column,
       creating: false,
       editing: null,
+      active: null,
     }))
-  }, [ column ])
+  }, [])
 
   const closeShowExternalService = useCallback(() => {
     setCreating(false)

--- a/ui/src/components/TagTypeListView/index.tsx
+++ b/ui/src/components/TagTypeListView/index.tsx
@@ -40,25 +40,27 @@ const TagTypeListView: FunctionComponent<TagTypeListViewProps> = ({
 
   const closeCreateTagType = useCallback(() => {
     setCreating(false)
-    setShowingTagType(column.active)
+    setShowingTagType(null)
     setEditingTagType(null)
     setColumn(column => ({
       ...column,
       creating: false,
       editing: null,
+      active: null,
     }))
-  }, [ column ])
+  }, [])
 
   const closeEditTagType = useCallback(() => {
     setCreating(false)
-    setShowingTagType(column.active)
+    setShowingTagType(null)
     setEditingTagType(null)
     setColumn(column => ({
       ...column,
       creating: false,
       editing: null,
+      active: null,
     }))
-  }, [ column ])
+  }, [])
 
   const closeShowTagType = useCallback(() => {
     setCreating(false)


### PR DESCRIPTION
This PR fixes a bug where deletion of a tag type of external service not deleted it from screen when it was firstly selected, edited, and then deleted.