### PR TITLE
Fix incorrect lifetimes in mock `impl`s

### DIFF
--- a/api/crates/domain/src/tests/mocks/domain/repository/external_services.rs
+++ b/api/crates/domain/src/tests/mocks/domain/repository/external_services.rs
@@ -11,7 +11,7 @@ mockall::mock! {
     pub(crate) ExternalServicesRepository {}
 
     impl ExternalServicesRepository for ExternalServicesRepository {
-        fn create<'a>(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
+        fn create<'a, 'b>(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'b str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
         #[mockall::concretize]
         fn fetch_by_ids<T>(&self, ids: T) -> impl Future<Output = Result<Vec<ExternalService>>> + Send
@@ -20,7 +20,7 @@ mockall::mock! {
 
         fn fetch_all(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;
 
-        fn update_by_id<'a>(&self, id: ExternalServiceId, slug: Option<&'a str>, name: Option<&'a str>, base_url: Option<Option<&'a str>>, url_pattern: Option<Option<&'a str>>) -> impl Future<Output = Result<ExternalService>> + Send;
+        fn update_by_id<'a, 'b, 'c, 'd>(&self, id: ExternalServiceId, slug: Option<&'a str>, name: Option<&'b str>, base_url: Option<Option<&'c str>>, url_pattern: Option<Option<&'d str>>) -> impl Future<Output = Result<ExternalService>> + Send;
 
         fn delete_by_id(&self, id: ExternalServiceId) -> impl Future<Output = Result<DeleteResult>> + Send;
     }

--- a/api/crates/domain/src/tests/mocks/domain/repository/tag_types.rs
+++ b/api/crates/domain/src/tests/mocks/domain/repository/tag_types.rs
@@ -20,7 +20,7 @@ mockall::mock! {
 
         fn fetch_all(&self) -> impl Future<Output = Result<Vec<TagType>>> + Send;
 
-        fn update_by_id<'a>(&self, id: TagTypeId, slug: Option<&'a str>, name: Option<&'a str>, kana: Option<&'a str>) -> impl Future<Output = Result<TagType>> + Send;
+        fn update_by_id<'a, 'b, 'c>(&self, id: TagTypeId, slug: Option<&'a str>, name: Option<&'b str>, kana: Option<&'c str>) -> impl Future<Output = Result<TagType>> + Send;
 
         fn delete_by_id(&self, id: TagTypeId) -> impl Future<Output = Result<DeleteResult>> + Send;
     }

--- a/api/crates/graphql/src/tests/mocks/domain/service/external_services.rs
+++ b/api/crates/graphql/src/tests/mocks/domain/service/external_services.rs
@@ -12,7 +12,7 @@ mockall::mock! {
     pub(crate) ExternalServicesServiceInterface {}
 
     impl ExternalServicesServiceInterface for ExternalServicesServiceInterface {
-        fn create_external_service<'a>(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'a str>) -> impl Future<Output = Result<ExternalService>> + Send;
+        fn create_external_service<'a, 'b>(&self, slug: &str, kind: ExternalServiceKind, name: &str, base_url: Option<&'a str>, url_pattern: Option<&'b str>) -> impl Future<Output = Result<ExternalService>> + Send;
 
         fn get_external_services(&self) -> impl Future<Output = Result<Vec<ExternalService>>> + Send;
 
@@ -23,7 +23,7 @@ mockall::mock! {
 
         fn get_external_services_by_url(&self, url: &str) -> impl Future<Output = Result<Vec<(ExternalService, ExternalMetadata)>>> + Send;
 
-        fn update_external_service_by_id<'a>(&self, id: ExternalServiceId, slug: Option<&'a str>, name: Option<&'a str>, base_url: Option<Option<&'a str>>, url_pattern: Option<Option<&'a str>>) -> impl Future<Output = Result<ExternalService>> + Send;
+        fn update_external_service_by_id<'a, 'b, 'c, 'd>(&self, id: ExternalServiceId, slug: Option<&'a str>, name: Option<&'b str>, base_url: Option<Option<&'c str>>, url_pattern: Option<Option<&'d str>>) -> impl Future<Output = Result<ExternalService>> + Send;
 
         fn delete_external_service_by_id(&self, id: ExternalServiceId) -> impl Future<Output = Result<DeleteResult>> + Send;
     }

--- a/api/crates/graphql/src/tests/mocks/domain/service/tags.rs
+++ b/api/crates/graphql/src/tests/mocks/domain/service/tags.rs
@@ -52,7 +52,7 @@ mockall::mock! {
             T: CloneableIterator<Item = String> + Send,
             U: CloneableIterator<Item = String> + Send;
 
-        fn update_tag_type_by_id<'a>(&self, id: TagTypeId, slug: Option<&'a str>, name: Option<&'a str>, kana: Option<&'a str>) -> impl Future<Output = Result<TagType>> + Send;
+        fn update_tag_type_by_id<'a, 'b, 'c>(&self, id: TagTypeId, slug: Option<&'a str>, name: Option<&'b str>, kana: Option<&'c str>) -> impl Future<Output = Result<TagType>> + Send;
 
         fn attach_tag_by_id(&self, id: TagId, parent_id: TagId, depth: TagDepth) -> impl Future<Output = Result<Tag>> + Send;
 


### PR DESCRIPTION
This PR fixes incorrect lifetimes in mock `impl`s which don’t compile in Rust 1.85.