### PR TITLE
Set defaults for `DEB_BUILD_MULTIARCH` and `LD` in ui

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -32,7 +32,6 @@ ARG PORT=80
 ENV PORT=$PORT
 ENV PATH=/
 COPY --link --from=release $LD $LD
-COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/ld-linux-x86-64.so.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libc.so.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libcrypto.so.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libgcc_s.so.* /lib/$DEB_BUILD_MULTIARCH/

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -31,7 +31,6 @@ ENV PORT=$PORT
 ENV NODE_ENV=production
 ENV HOSTNAME=
 COPY --link --from=release $LD $LD
-COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/ld-linux-x86-64.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libc.so* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libcrypto.so* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libdl.so.* /lib/$DEB_BUILD_MULTIARCH/

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -24,8 +24,8 @@ RUN --mount=type=tmpfs,target=/tmp \
 
 FROM scratch AS production
 WORKDIR /app
-ARG DEB_BUILD_MULTIARCH
-ARG LD
+ARG DEB_BUILD_MULTIARCH=x86_64-linux-gnu
+ARG LD=/lib64/ld-linux-x86-64.so.2
 ARG PORT=3000
 ENV PORT=$PORT
 ENV NODE_ENV=production


### PR DESCRIPTION
This is a follow up for #898 to remove an unnecessary file from `api/Dockerfile` and `ui/Dockerfile` as well as add missing default values in `ui/Dockerfile`.