### PR TITLE
Migate from Debian “bookworm” to “trixie”

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1
-FROM rust:1.89.0-bookworm AS base
+FROM rust:1.89.0-trixie AS base
 WORKDIR /usr/src
 RUN --mount=type=cache,id=api:/var/cache/apt,target=/var/cache/apt \
     --mount=type=cache,id=api:/var/lib/apt/lists,target=/var/lib/apt/lists \
@@ -39,6 +39,8 @@ COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libjemalloc.so.* /lib/$DEB_
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libm.so.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libssl.so.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libstdc++.so.* /lib/$DEB_BUILD_MULTIARCH/
+COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libz.so.* /lib/$DEB_BUILD_MULTIARCH/
+COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libzstd.so.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /usr/local/bin/hoarder /hoarder
 COPY --link --from=release /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --link --from=release /usr/share/zoneinfo /usr/share/zoneinfo

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1
-FROM node:24.5.0-bookworm AS base
+FROM node:24.5.0-trixie AS base
 WORKDIR /usr/src
 COPY package.json yarn.lock .yarnrc.yml /usr/src/
 
@@ -40,6 +40,8 @@ COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libpthread.so* /lib/$DEB_BU
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libresolv.so* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libssl.so* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libstdc++.so.* /lib/$DEB_BUILD_MULTIARCH/
+COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libz.so.* /lib/$DEB_BUILD_MULTIARCH/
+COPY --link --from=release /lib/$DEB_BUILD_MULTIARCH/libzstd.so.* /lib/$DEB_BUILD_MULTIARCH/
 COPY --link --from=release /usr/local/bin/node /node
 COPY --link --from=release /etc/group /etc/group
 COPY --link --from=release /etc/passwd /etc/passwd


### PR DESCRIPTION
This PR migrates API and UI from Debian “bookworm” to “trixie.” 

The runtime dependencies are added since [openssl](https://packages.debian.org/source/trixie/openssl) has added [libzstd1](https://packages.debian.org/ja/trixie/libzstd1) since 3.2.0-1 and [zlib1g](https://packages.debian.org/ja/trixie/zlib1g) since 3.2.1-2.
* https://packages.debian.org/bookworm/libssl3
* https://packages.debian.org/trixie/libssl3t64