### PR TITLE
Fix the position of tag type icon and a deprecation warning in SearchBar

### DIFF
--- a/ui/next.config.mjs
+++ b/ui/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
   },
   images: {
     minimumCacheTTL: 7 * 86_400,
+    qualities: [100],
   },
   output: 'standalone',
   rewrites: async () => [

--- a/ui/src/components/SearchBar/index.tsx
+++ b/ui/src/components/SearchBar/index.tsx
@@ -4,7 +4,7 @@ import type { FunctionComponent, ComponentPropsWithoutRef, SyntheticEvent } from
 import { useMemo, useState } from 'react'
 import { useCallback } from 'react'
 import clsx from 'clsx'
-import type { AutocompleteRenderGetTagProps } from '@mui/material/Autocomplete'
+import type { AutocompleteRenderValueGetItemProps } from '@mui/material/Autocomplete'
 import Chip from '@mui/material/Chip'
 import Stack from '@mui/material/Stack'
 import LabelIcon from '@mui/icons-material/Label'
@@ -61,7 +61,7 @@ const SearchBar: FunctionComponent<SearchBarProps> = ({
     </li>
   ), [])
 
-  const renderMetadataTags = useCallback((metadata: Metadata[], getTagProps: AutocompleteRenderGetTagProps) => metadata.map((option, index) => {
+  const renderMetadataValue = useCallback((metadata: Metadata[], getTagProps: AutocompleteRenderValueGetItemProps<true>) => metadata.map((option, index) => {
     const { key, ...props } = getTagProps({ index })
     return (
       <Chip key={key} label={<MetadataOption className={styles.chip} metadata={option} />} {...props} />
@@ -133,7 +133,7 @@ const SearchBar: FunctionComponent<SearchBarProps> = ({
         openOnFocus
         placeholder={placeholder}
         renderOption={renderMetadataOption}
-        renderTags={renderMetadataTags}
+        renderValue={renderMetadataValue}
         value={value}
         inputValue={inputValue}
         icon={({ ...props }) => <SearchIcon fontSize="small" {...props} />}

--- a/ui/src/components/SearchBar/styles.module.scss
+++ b/ui/src/components/SearchBar/styles.module.scss
@@ -49,7 +49,6 @@
 
 .tagTypeIcon {
   &:global(.MuiSvgIcon-root) {
-    margin-top: 2px;
     margin-right: 6px;
     color: inherit;
   }


### PR DESCRIPTION
This PR fixes the position of tag type icon in SearchBar as well as replaces the `renderTags` of `<Autocomplete />` with `renderValue` because it has been deprecated since v7.0.2.