### PR TITLE
Prefer try-catch in async functions to calling `.then()`

### DIFF
--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -8,18 +8,22 @@ import MediumList from '@/components/MediumList'
 import SearchQueryList from '@/components/SearchQueryList'
 import type { Source, Tag, TagType } from '@/types'
 
-const searchParamsToArray = <T extends Record<string, string | string[]>>(
+const searchParamsToArray = async <T extends Record<string, string | string[]>>(
   searchParams: Promise<T>,
-): Promise<Record<string, string[]>> => searchParams.then(
-  params => Object.entries(params).reduce<Record<string, string[]>>(
-    (obj, [ k, v ]) => ({
-      ...obj,
-      [k]: Array.isArray(v) ? v : [ v ],
-    }),
-    {},
-  ),
-  () => ({}),
-)
+): Promise<Record<string, string[]>> => {
+  const params = await searchParams
+  try {
+    return Object.entries(params).reduce<Record<string, string[]>>(
+      (obj, [ k, v ]) => ({
+        ...obj,
+        [k]: Array.isArray(v) ? v : [ v ],
+      }),
+      {},
+    )
+  } catch {
+    return {}
+  }
+}
 
 const displayURL = (url: string): string => url.replace(/^https?:\/\/(?:www\.)?/, '')
 

--- a/ui/src/components/ExternalServiceDeleteDialogBody/index.tsx
+++ b/ui/src/components/ExternalServiceDeleteDialogBody/index.tsx
@@ -22,16 +22,14 @@ const ExternalServiceDeleteDialogBody: FunctionComponent<ExternalServiceDeleteDi
     close()
   }, [ close ])
 
-  const handleClickDelete = useCallback(() => {
-    deleteExternalService({ id: externalService.id }).then(
-      () => {
-        close()
-        onDelete(externalService)
-      },
-      (e: unknown) => {
-        console.error('Error deleting external service\n', e)
-      },
-    )
+  const handleClickDelete = useCallback(async () => {
+    try {
+      await deleteExternalService({ id: externalService.id })
+      close()
+      onDelete(externalService)
+    } catch (e) {
+      console.error('Error deleting external service\n', e)
+    }
   }, [ deleteExternalService, externalService, close, onDelete ])
 
   return error ? (

--- a/ui/src/components/ExternalServiceListColumnBodyCreate/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyCreate/index.tsx
@@ -120,15 +120,13 @@ const ExternalServiceListColumnBodyCreate: FunctionComponent<ExternalServiceList
     close()
   }, [ close ])
 
-  const handleClickSubmit = useCallback(() => {
-    createExternalService(externalService).then(
-      () => {
-        close()
-      },
-      (e: unknown) => {
-        console.error('Error creating external service\n', e)
-      },
-    )
+  const handleClickSubmit = useCallback(async () => {
+    try {
+      await createExternalService(externalService)
+      close()
+    } catch (e) {
+      console.error('Error creating external service\n', e)
+    }
   }, [ externalService, createExternalService, close ])
 
   const externalServiceSlugDuplicate = graphQLError(error, EXTERNAL_SERVICE_SLUG_DUPLICATE)

--- a/ui/src/components/ExternalServiceListColumnBodyEdit/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyEdit/index.tsx
@@ -108,16 +108,14 @@ const ExternalServiceListColumnBodyEdit: FunctionComponent<ExternalServiceListCo
     close()
   }, [ close ])
 
-  const handleClickSubmit = useCallback(() => {
-    updateExternalService(externalService).then(
-      newExternalService => {
-        close()
-        onEdit(newExternalService)
-      },
-      (e: unknown) => {
-        console.error('Error updating external service\n', e)
-      },
-    )
+  const handleClickSubmit = useCallback(async () => {
+    try {
+      const newExternalService = await updateExternalService(externalService)
+      close()
+      onEdit(newExternalService)
+    } catch (e) {
+      console.error('Error updating external service\n', e)
+    }
   }, [ externalService, updateExternalService, onEdit, close ])
 
   const externalServiceUrlPatternInvalid = graphQLError(error, EXTERNAL_SERVICE_URL_PATTERN_INVALID)

--- a/ui/src/components/MediumCreateView/index.tsx
+++ b/ui/src/components/MediumCreateView/index.tsx
@@ -140,43 +140,39 @@ const MediumCreateView: FunctionComponent = () => {
     const processed = (replicas: (Replica | ReplicaCreate)[]) => replicas.every(isReplica)
     if (!processed(replicas)) {
       setReplicas(replicas)
-      updateMedium({
-        id: current.id,
-        replicaOrders: replicas.filter(isReplica).map(({ id }) => id),
-        createdAt: current.createdAt,
-      }).then(
-        newMedium => {
-          setMedium(newMedium)
-        },
-        (e: unknown) => {
-          console.error('Error updating medium\n', e)
-          setMedium(current)
-          setError(e)
-        },
-      )
+      try {
+        const newMedium = await updateMedium({
+          id: current.id,
+          replicaOrders: replicas.filter(isReplica).map(({ id }) => id),
+          createdAt: current.createdAt,
+        })
+        setMedium(newMedium)
+      } catch (e) {
+        console.error('Error updating medium\n', e)
+        setMedium(current)
+        setError(e)
+      }
       return
     }
 
     setUploading(false)
     setUploadAborting(false)
 
-    await updateMedium({
-      id: current.id,
-      replicaOrders: replicas.map(({ id }) => id),
-      createdAt: current.createdAt,
-    }).then(
-      () => {
-        router.refresh()
-      },
-      (e: unknown) => {
-        console.error('Error updating medium\n', e)
-        setMedium({
-          ...current,
-          replicas,
-        })
-        setError(e)
-      },
-    )
+    try {
+      await updateMedium({
+        id: current.id,
+        replicaOrders: replicas.map(({ id }) => id),
+        createdAt: current.createdAt,
+      })
+      router.refresh()
+    } catch (e) {
+      console.error('Error updating medium\n', e)
+      setMedium({
+        ...current,
+        replicas,
+      })
+      setError(e)
+    }
   }, [ updateMedium, router ])
 
   const save = useCallback(async (current: MediumCreate) => {

--- a/ui/src/components/MediumDeleteDialogBody/index.tsx
+++ b/ui/src/components/MediumDeleteDialogBody/index.tsx
@@ -28,16 +28,14 @@ const MediumDeleteDialogBody: FunctionComponent<MediumDeleteDialogBodyProps> = (
     setDeleteObjects(e.currentTarget.value === 'true')
   }, [])
 
-  const handleClickDelete = useCallback(() => {
-    deleteMedium({ id: medium.id, deleteObjects }).then(
-      () => {
-        close()
-        onDelete(medium)
-      },
-      (e: unknown) => {
-        console.error('Error deleting medium\n', e)
-      },
-    )
+  const handleClickDelete = useCallback(async () => {
+    try {
+      await deleteMedium({ id: medium.id, deleteObjects })
+      close()
+      onDelete(medium)
+    } catch (e) {
+      console.error('Error deleting medium\n', e)
+    }
   }, [ deleteMedium, medium, deleteObjects, close, onDelete ])
 
   const hasReplicas = Boolean(medium.replicas?.length)

--- a/ui/src/components/MediumItemImageEdit/index.tsx
+++ b/ui/src/components/MediumItemImageEdit/index.tsx
@@ -170,8 +170,9 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
 
   const handleSelectFiles = useCallback((entries: Promise<File[]>) => {
     const id = uuid()
-    const newAppendFiles = entries.then(
-      files => {
+    const newAppendFiles = (async () => {
+      try {
+        const files = await entries
         if (files.length > FILE_APPEND_CONFIRM_DIALOG_THRESHOLD) {
           return files
         }
@@ -179,8 +180,7 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
         void handleAppendFiles(files)
         handleCloseAppendFiles(id)
         return []
-      },
-      (e: unknown) => {
+      } catch (e) {
         console.error('Error appending selected files\n', e)
 
         if (!(e instanceof Error) || e.name !== 'AbortError') {
@@ -189,8 +189,8 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
 
         handleCloseAppendFiles(id)
         return []
-      },
-    )
+      }
+    })()
 
     setAppendFiles(appendFiles => new Map([ ...appendFiles.set(id, newAppendFiles) ]))
   }, [ handleAppendFiles, handleCloseAppendFiles ])

--- a/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
@@ -84,23 +84,21 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
           addingSourceIDs.push(source.id)
           continue
         }
-        createSources.push(
-          createSource({
-            externalServiceID: source.externalService.id,
-            externalMetadata: source.externalMetadata as ExternalMetadataInput,
-          }).then(
-            newSource => {
-              addingSourceIDs.push(newSource.id)
-            },
-            (e: unknown) => {
-              const sourceMetadataDuplicate = graphQLError(e, SOURCE_METADATA_DUPLICATE)
-              if (!sourceMetadataDuplicate?.extensions.details.data.id) {
-                throw e
-              }
-              addingSourceIDs.push(sourceMetadataDuplicate.extensions.details.data.id)
-            },
-          ),
-        )
+        createSources.push((async () => {
+          try {
+            const newSource = await createSource({
+              externalServiceID: source.externalService.id,
+              externalMetadata: source.externalMetadata as ExternalMetadataInput,
+            })
+            addingSourceIDs.push(newSource.id)
+          } catch (e) {
+            const sourceMetadataDuplicate = graphQLError(e, SOURCE_METADATA_DUPLICATE)
+            if (!sourceMetadataDuplicate?.extensions.details.data.id) {
+              throw e
+            }
+            addingSourceIDs.push(sourceMetadataDuplicate.extensions.details.data.id)
+          }
+        })())
       }
     }
 

--- a/ui/src/components/MediumItemMetadataTagEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagEdit/index.tsx
@@ -180,7 +180,7 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
     close?.()
   }, [ close ])
 
-  const handleClickSubmit = useCallback(() => {
+  const handleClickSubmit = useCallback(async () => {
     const addTagTagTypeIDs: TagTagTypeInput[] = []
     for (const [ tagTypeId, tags ] of addingTags) {
       addTagTagTypeIDs.push(...tags.map(({ id: tagId }) => ({ tagTypeId, tagId })))
@@ -191,14 +191,12 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
       removeTagTagTypeIDs.push(...tags.map(({ id: tagId }) => ({ tagTypeId, tagId })))
     }
 
-    save(medium.id, addTagTagTypeIDs, removeTagTagTypeIDs).then(
-      () => {
-        close?.()
-      },
-      (e: unknown) => {
-        console.error('Error updating medium\n', e)
-      },
-    )
+    try {
+      await save(medium.id, addTagTagTypeIDs, removeTagTagTypeIDs)
+      close?.()
+    } catch (e) {
+      console.error('Error updating medium\n', e)
+    }
   }, [ save, medium, addingTags, removingTags, close ])
 
   const renderTagTypeOption = useCallback(({ key, ...props }: ComponentPropsWithoutRef<'li'>, option: TagType) => (

--- a/ui/src/components/TagDeleteDialogBody/index.tsx
+++ b/ui/src/components/TagDeleteDialogBody/index.tsx
@@ -47,19 +47,17 @@ const TagDeleteDialogBody: FunctionComponent<TagDeleteDialogBodyProps> = ({
     setRecursive(e.currentTarget.checked)
   }, [])
 
-  const handleClickDelete = useCallback(() => {
-    deleteTag({
-      id: tag.id,
-      recursive,
-    }).then(
-      () => {
-        close()
-        onDelete(tag)
-      },
-      (e: unknown) => {
-        console.error('Error deleting tag\n', e)
-      },
-    )
+  const handleClickDelete = useCallback(async () => {
+    try {
+      await deleteTag({
+        id: tag.id,
+        recursive,
+      })
+      close()
+      onDelete(tag)
+    } catch (e) {
+      console.error('Error deleting tag\n', e)
+    }
   }, [ deleteTag, tag, recursive, onDelete, close ])
 
   const tagChildrenExist = graphQLError(error, TAG_CHILDREN_EXIST)

--- a/ui/src/components/TagListColumnBodyCreate/index.tsx
+++ b/ui/src/components/TagListColumnBodyCreate/index.tsx
@@ -82,22 +82,20 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
     close()
   }, [ close ])
 
-  const handleClickSubmit = useCallback(() => {
+  const handleClickSubmit = useCallback(async () => {
     onCreating?.()
-    createTag({
-      name: tag.name,
-      kana: tag.kana,
-      aliases: tag.aliases,
-      parentID: parent?.id ?? null,
-    }).then(
-      newTag => {
-        close()
-        onCreate?.(newTag)
-      },
-      (e: unknown) => {
-        console.error('Error creating tag\n', e)
-      },
-    )
+    try {
+      const newTag = await createTag({
+        name: tag.name,
+        kana: tag.kana,
+        aliases: tag.aliases,
+        parentID: parent?.id ?? null,
+      })
+      close()
+      onCreate?.(newTag)
+    } catch (e) {
+      console.error('Error creating tag\n', e)
+    }
   }, [ tag, parent, onCreating, onCreate, createTag, close ])
 
   const changed = hasChanges(tag)

--- a/ui/src/components/TagListColumnBodyEdit/index.tsx
+++ b/ui/src/components/TagListColumnBodyEdit/index.tsx
@@ -85,24 +85,22 @@ const TagListColumnBodyEdit: FunctionComponent<TagListColumnBodyEditProps> = ({
     close()
   }, [ close ])
 
-  const handleClickSubmit = useCallback(() => {
+  const handleClickSubmit = useCallback(async () => {
     const addAliases = tag.aliases.filter(alias => !current.aliases.includes(alias))
     const removeAliases = current.aliases.filter(alias => !tag.aliases.includes(alias))
 
-    updateTag({
-      id: tag.id,
-      name: tag.name,
-      kana: tag.kana,
-      addAliases,
-      removeAliases,
-    }).then(
-      () => {
-        close()
-      },
-      (e: unknown) => {
-        console.error('Error updating tag\n', e)
-      },
-    )
+    try {
+      await updateTag({
+        id: tag.id,
+        name: tag.name,
+        kana: tag.kana,
+        addAliases,
+        removeAliases,
+      })
+      close()
+    } catch (e) {
+      console.error('Error updating tag\n', e)
+    }
   }, [ tag, current, updateTag, close ])
 
   const changed = hasChanges(tag, current)

--- a/ui/src/components/TagMoveDialogBody/index.tsx
+++ b/ui/src/components/TagMoveDialogBody/index.tsx
@@ -29,19 +29,16 @@ const TagMoveDialogBody: FunctionComponent<TagMoveDialogBodyProps> = ({
   const [ attachTag, { error: attachError, loading: attachLoading } ] = useAttachTag()
   const [ detachTag, { error: detachError, loading: detachLoading } ] = useDetachTag()
 
-  const handleClickMove = useCallback(() => {
-    (destination
-      ? attachTag({ id: tag.id, parentID: destination.id })
-      : detachTag({ id: tag.id })
-    ).then(
-      tag => {
-        close()
-        onMove(tag)
-      },
-      (e: unknown) => {
-        console.error('Error moving tag\n', e)
-      },
-    )
+  const handleClickMove = useCallback(async () => {
+    try {
+      const newTag = destination
+        ? await attachTag({ id: tag.id, parentID: destination.id })
+        : await detachTag({ id: tag.id })
+      close()
+      onMove(newTag)
+    } catch (e) {
+      console.error('Error moving tag\n', e)
+    }
   }, [ tag, destination, attachTag, detachTag, close, onMove ])
 
   const disabled = useCallback(({ id }: Tag) => id === tag.id, [ tag ])

--- a/ui/src/components/TagTypeDeleteDialogBody/index.tsx
+++ b/ui/src/components/TagTypeDeleteDialogBody/index.tsx
@@ -18,16 +18,14 @@ const TagTypeDeleteDialogBody: FunctionComponent<TagTypeDeleteDialogBodyProps> =
 }) => {
   const [ deleteTagType, { error, loading } ] = useDeleteTagType()
 
-  const handleClickDelete = useCallback(() => {
-    deleteTagType({ id: tagType.id }).then(
-      () => {
-        close()
-        onDelete(tagType)
-      },
-      (e: unknown) => {
-        console.error('Error deleting tag type\n', e)
-      },
-    )
+  const handleClickDelete = useCallback(async () => {
+    try {
+      await deleteTagType({ id: tagType.id })
+      close()
+      onDelete(tagType)
+    } catch (e) {
+      console.error('Error deleting tag type\n', e)
+    }
   }, [ deleteTagType, tagType, close, onDelete ])
 
   return error ? (

--- a/ui/src/components/TagTypeListColumnBodyCreate/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyCreate/index.tsx
@@ -75,19 +75,17 @@ const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreate
     close()
   }, [ close ])
 
-  const handleClickSubmit = useCallback(() => {
-    createTagType({
-      slug: tagType.slug,
-      name: tagType.name,
-      kana: tagType.kana,
-    }).then(
-      () => {
-        close()
-      },
-      (e: unknown) => {
-        console.error('Error creating tag type\n', e)
-      },
-    )
+  const handleClickSubmit = useCallback(async () => {
+    try {
+      await createTagType({
+        slug: tagType.slug,
+        name: tagType.name,
+        kana: tagType.kana,
+      })
+      close()
+    } catch (e) {
+      console.error('Error creating tag type\n', e)
+    }
   }, [ tagType, createTagType, close ])
 
   const tagTypeSlugDuplicate = graphQLError(error, TAG_TYPE_SLUG_DUPLICATE)

--- a/ui/src/components/TagTypeListColumnBodyEdit/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyEdit/index.tsx
@@ -59,21 +59,19 @@ const TagTypeListColumnBodyEdit: FunctionComponent<TagTypeListColumnBodyEditProp
     close()
   }, [ close ])
 
-  const handleClickSubmit = useCallback(() => {
-    updateTagType({
-      id: tagType.id,
-      slug: tagType.slug,
-      name: tagType.name,
-      kana: tagType.kana,
-    }).then(
-      newTagType => {
-        close()
-        onEdit(newTagType)
-      },
-      (e: unknown) => {
-        console.error('Error updating tag type\n', e)
-      },
-    )
+  const handleClickSubmit = useCallback(async () => {
+    try {
+      const newTagType = await updateTagType({
+        id: tagType.id,
+        slug: tagType.slug,
+        name: tagType.name,
+        kana: tagType.kana,
+      })
+      close()
+      onEdit(newTagType)
+    } catch (e) {
+      console.error('Error updating tag type\n', e)
+    }
   }, [ tagType, updateTagType, onEdit, close ])
 
   const tagTypeSlugDuplicate = graphQLError(error, TAG_TYPE_SLUG_DUPLICATE)


### PR DESCRIPTION
This PR refactors implementations that invoke `.then()` callbacks by using `try`-`catch` where appropriate.