### PR TITLE
Render `<Context>` as a provider in place of `<Context.Provider>`

### DIFF
--- a/ui/src/contexts/search/index.tsx
+++ b/ui/src/contexts/search/index.tsx
@@ -77,9 +77,9 @@ export const SearchProvider: FunctionComponent<SearchProviderProps> = ({
   const state = useMemo(() => ({ appendQuery, removeQuery, clearQuery }), [ appendQuery, removeQuery, clearQuery ])
 
   return (
-    <SearchContext.Provider value={state}>
+    <SearchContext value={state}>
       {children}
-    </SearchContext.Provider>
+    </SearchContext>
   )
 }
 


### PR DESCRIPTION
This PR replaces use of `<Context.Provider>` by `<Context>` which has been available since React 19.
https://react.dev/blog/2024/12/05/react-19#context-as-a-provider