### PR TITLE
Use `readonly` for React states, parameters, and properties

### DIFF
--- a/ui/codegen.ts
+++ b/ui/codegen.ts
@@ -26,6 +26,9 @@ const config = {
         'typescript-operations',
         'typed-document-node',
       ],
+      config: {
+        immutableTypes: true,
+      },
     },
     'src/graphql/types.generated.ts': {
       plugins: [

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -45,7 +45,7 @@ const RootLayout: FunctionComponent<RootLayoutProps> = ({
 )
 
 export interface RootLayoutProps {
-  children: ReactNode
+  readonly children: ReactNode
 }
 
 export default RootLayout

--- a/ui/src/app/media/[id]/page.tsx
+++ b/ui/src/app/media/[id]/page.tsx
@@ -20,11 +20,11 @@ const Page: FunctionComponent<PageProps> = async ({
 }
 
 export interface Params {
-  id: string
+  readonly id: string
 }
 
 export interface PageProps {
-  params: Promise<Params>
+  readonly params: Promise<Params>
 }
 
 export default Page

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -8,12 +8,12 @@ import MediumList from '@/components/MediumList'
 import SearchQueryList from '@/components/SearchQueryList'
 import type { Source, Tag, TagType } from '@/types'
 
-const searchParamsToArray = async <T extends Record<string, string | string[]>>(
+const searchParamsToArray = async <T extends Record<string, string | readonly string[]>>(
   searchParams: Promise<T>,
-): Promise<Record<string, string[]>> => {
+): Promise<Record<string, readonly string[]>> => {
   const params = await searchParams
   try {
-    return Object.entries(params).reduce<Record<string, string[]>>(
+    return Object.entries(params).reduce<Record<string, readonly string[]>>(
       (obj, [ k, v ]) => ({
         ...obj,
         [k]: Array.isArray(v) ? v : [ v ],
@@ -27,7 +27,13 @@ const searchParamsToArray = async <T extends Record<string, string | string[]>>(
 
 const displayURL = (url: string): string => url.replace(/^https?:\/\/(?:www\.)?/, '')
 
-const fetchSearchQuery = async (sourceIDs: string[], tagIDs: string[]): Promise<{ sources?: Source[], tagTagTypes?: { tag: Tag, type: TagType }[] }> => {
+const fetchSearchQuery = async (sourceIDs: readonly string[], tagIDs: readonly string[]): Promise<{
+  readonly sources?: readonly Source[]
+  readonly tagTagTypes?: readonly {
+    readonly tag: Tag
+    readonly type: TagType
+  }[]
+}> => {
   const tagTagTypeIDs = tagIDs
     .map(tag => tag.split(':'))
     .flatMap(([ tagTypeID, tagID ]) => tagTypeID && tagID
@@ -118,10 +124,10 @@ const Page: FunctionComponent<PageProps> = async ({
   }
 }
 
-export type SearchParams = Record<string, string | string[]>
+export type SearchParams = Record<string, string | readonly string[]>
 
 export interface PageProps {
-  searchParams: Promise<SearchParams>
+  readonly searchParams: Promise<SearchParams>
 }
 
 export default Page

--- a/ui/src/components/ApolloWrapper/index.tsx
+++ b/ui/src/components/ApolloWrapper/index.tsx
@@ -14,7 +14,7 @@ const ApolloWrapper: FunctionComponent<ApolloWrapperProps> = ({
 )
 
 export interface ApolloWrapperProps {
-  children: ReactNode
+  readonly children: ReactNode
 }
 
 export default ApolloWrapper

--- a/ui/src/components/AutocompleteContainerBody/index.tsx
+++ b/ui/src/components/AutocompleteContainerBody/index.tsx
@@ -104,7 +104,7 @@ const AutocompleteContainerBody: FunctionComponent<AutocompleteContainerBodyProp
     </li>
   ), [ Icon ])
 
-  const filterOptions = useCallback((options: string[]): string[] => {
+  const filterOptions = useCallback((options: string[]) => {
     const value = inputValue.substring(inputValue.lastIndexOf('/') + 1)
     if (!value.length) {
       return options
@@ -164,12 +164,12 @@ const AutocompleteContainerBody: FunctionComponent<AutocompleteContainerBodyProp
 }
 
 export interface AutocompleteContainerBodyProps extends Omit<AutocompleteProps<string, false, boolean | undefined, true>, 'onChange' | 'options' | 'renderInput'> {
-  focus?: boolean
-  label?: string
-  placeholder?: string
-  variant?: TextFieldVariants
-  icon?: ComponentType<SvgIconProps>
-  onChange?: (container: string | null) => void
+  readonly focus?: boolean
+  readonly label?: string
+  readonly placeholder?: string
+  readonly variant?: TextFieldVariants
+  readonly icon?: ComponentType<SvgIconProps>
+  readonly onChange?: (container: string | null) => void
 }
 
 export default AutocompleteContainerBody

--- a/ui/src/components/AutocompleteExternalServiceBody/index.tsx
+++ b/ui/src/components/AutocompleteExternalServiceBody/index.tsx
@@ -97,13 +97,13 @@ const AutocompleteExternalServiceBody: FunctionComponent<AutocompleteExternalSer
 }
 
 export interface AutocompleteExternalServiceBodyProps extends Omit<AutocompleteProps<ExternalService, false, boolean | undefined, false>, 'onChange' | 'options' | 'renderInput'> {
-  focus?: boolean
-  loadOnOpen?: boolean
-  label?: string
-  placeholder?: string
-  variant?: TextFieldVariants
-  icon?: ComponentType<SvgIconProps>
-  onChange?: (type: ExternalService | null) => void
+  readonly focus?: boolean
+  readonly loadOnOpen?: boolean
+  readonly label?: string
+  readonly placeholder?: string
+  readonly variant?: TextFieldVariants
+  readonly icon?: ComponentType<SvgIconProps>
+  readonly onChange?: (type: ExternalService | null) => void
 }
 
 export default AutocompleteExternalServiceBody

--- a/ui/src/components/AutocompleteMetadataBody/index.tsx
+++ b/ui/src/components/AutocompleteMetadataBody/index.tsx
@@ -29,11 +29,11 @@ export const isMetadataTagType = (option: Metadata): option is MetadataTagType =
 function* useMetadata(
   sources: MetadataLike['sources'] | null | undefined,
   tags: MetadataLike['tags'] | null | undefined,
-  tagTypes: TagType[] | null | undefined,
+  tagTypes: readonly TagType[] | null | undefined,
   options?: {
-    noSources?: boolean
-    noTags?: boolean
-    noTagTypes?: boolean
+    readonly noSources?: boolean
+    readonly noTags?: boolean
+    readonly noTagTypes?: boolean
   },
 ): Generator<Metadata> {
   const collator = useCollator()
@@ -203,7 +203,7 @@ const AutocompleteMetadataBody: FunctionComponent<AutocompleteMetadataBodyProps>
     }
   }, [ onInputChange, updateInputValue ])
 
-  const handleChange = useCallback((_e: SyntheticEvent, metadata: Metadata[]) => {
+  const handleChange = useCallback((_e: SyntheticEvent, metadata: readonly Metadata[]) => {
     onChangeMetadata?.(metadata)
   }, [ onChangeMetadata ])
 
@@ -288,29 +288,29 @@ const AutocompleteMetadataBody: FunctionComponent<AutocompleteMetadataBodyProps>
 }
 
 interface MetadataSource {
-  source: Source
+  readonly source: Source
 }
 
 interface MetadataTag {
-  tag: Tag
+  readonly tag: Tag
 }
 
 interface MetadataTagType {
-  tagType: TagType
+  readonly tagType: TagType
 }
 
 export type Metadata = MetadataSource | MetadataTag | MetadataTagType
 
 export interface AutocompleteMetadataBodyProps extends Omit<AutocompleteProps<Metadata, true, boolean | undefined, false>, 'onChange' | 'options' | 'renderInput'> {
-  focus?: boolean
-  label?: string
-  placeholder?: string
-  variant?: TextFieldVariants
-  icon?: ComponentType<SvgIconProps>
-  onChange?: (metadata: Metadata[]) => void
-  noSources?: boolean
-  noTags?: boolean
-  noTagTypes?: boolean
+  readonly focus?: boolean
+  readonly label?: string
+  readonly placeholder?: string
+  readonly variant?: TextFieldVariants
+  readonly icon?: ComponentType<SvgIconProps>
+  readonly onChange?: (metadata: readonly Metadata[]) => void
+  readonly noSources?: boolean
+  readonly noTags?: boolean
+  readonly noTagTypes?: boolean
 }
 
 export default AutocompleteMetadataBody

--- a/ui/src/components/AutocompleteSourceBody/index.tsx
+++ b/ui/src/components/AutocompleteSourceBody/index.tsx
@@ -246,19 +246,19 @@ const AutocompleteSourceBody: FunctionComponent<AutocompleteSourceBodyProps> = (
 export type SourceCreate = Pick<Source, 'externalService' | 'externalMetadata'>
 
 export interface AutocompleteSourceBodyProps extends Omit<AutocompleteProps<Source | SourceCreate, false, boolean | undefined, false>, 'onChange' | 'options' | 'renderInput'> {
-  externalService: ExternalService
-  focus?: boolean
-  label?: string
-  placeholder?: string
-  variant?: TextFieldVariants
-  icon?: ComponentType<SvgIconProps>
-  onChange?: (source: Source | SourceCreate | null) => void
+  readonly externalService: ExternalService
+  readonly focus?: boolean
+  readonly label?: string
+  readonly placeholder?: string
+  readonly variant?: TextFieldVariants
+  readonly icon?: ComponentType<SvgIconProps>
+  readonly onChange?: (source: Source | SourceCreate | null) => void
 }
 
 interface Builder<Kind extends keyof ExternalMetadataInput> {
-  kind: Kind
-  patterns: RegExp[]
-  build: (params: Record<string, string>) => Partial<ExternalMetadataInput[Kind]>
+  readonly kind: Kind
+  readonly patterns: readonly RegExp[]
+  readonly build: (params: Record<string, string>) => Partial<ExternalMetadataInput[Kind]>
 }
 
 export default AutocompleteSourceBody

--- a/ui/src/components/AutocompleteTagBody/index.tsx
+++ b/ui/src/components/AutocompleteTagBody/index.tsx
@@ -162,13 +162,13 @@ const AutocompleteTagBody: FunctionComponent<AutocompleteTagBodyProps> = ({
 }
 
 export interface AutocompleteTagBodyProps extends Omit<AutocompleteProps<Tag, false, boolean | undefined, false>, 'onChange' | 'options' | 'renderInput'> {
-  focus?: boolean
-  selector?: boolean
-  label?: string
-  placeholder?: string
-  variant?: TextFieldVariants
-  icon?: ComponentType<SvgIconProps>
-  onChange?: (tag: Tag | null) => void
+  readonly focus?: boolean
+  readonly selector?: boolean
+  readonly label?: string
+  readonly placeholder?: string
+  readonly variant?: TextFieldVariants
+  readonly icon?: ComponentType<SvgIconProps>
+  readonly onChange?: (tag: Tag | null) => void
 }
 
 export default AutocompleteTagBody

--- a/ui/src/components/AutocompleteTagTypeBody/index.tsx
+++ b/ui/src/components/AutocompleteTagTypeBody/index.tsx
@@ -102,13 +102,13 @@ const AutocompleteTagTypeBody: FunctionComponent<AutocompleteTagTypeBodyProps> =
 }
 
 export interface AutocompleteTagTypeBodyProps extends Omit<AutocompleteProps<TagType, false, boolean | undefined, false>, 'onChange' | 'options' | 'renderInput'> {
-  focus?: boolean
-  loadOnOpen?: boolean
-  label?: string
-  placeholder?: string
-  variant?: TextFieldVariants
-  icon?: ComponentType<SvgIconProps>
-  onChange?: (type: TagType | null) => void
+  readonly focus?: boolean
+  readonly loadOnOpen?: boolean
+  readonly label?: string
+  readonly placeholder?: string
+  readonly variant?: TextFieldVariants
+  readonly icon?: ComponentType<SvgIconProps>
+  readonly onChange?: (type: TagType | null) => void
 }
 
 export default AutocompleteTagTypeBody

--- a/ui/src/components/Content/index.tsx
+++ b/ui/src/components/Content/index.tsx
@@ -18,7 +18,7 @@ const Content: FunctionComponent<ContentProps> = ({
 )
 
 export interface ContentProps extends GridProps {
-  children: ReactNode
+  readonly children: ReactNode
 }
 
 export default Content

--- a/ui/src/components/DateTime/index.tsx
+++ b/ui/src/components/DateTime/index.tsx
@@ -21,8 +21,8 @@ const DateTime: FunctionComponent<DateTimeProps> = ({
 )
 
 export interface DateTimeProps {
-  date?: Date
-  format: string
+  readonly date?: Date
+  readonly format: string
 }
 
 export default DateTime

--- a/ui/src/components/ExternalServiceDeleteDialogBody/index.tsx
+++ b/ui/src/components/ExternalServiceDeleteDialogBody/index.tsx
@@ -59,9 +59,9 @@ const ExternalServiceDeleteDialogBody: FunctionComponent<ExternalServiceDeleteDi
 }
 
 export interface ExternalServiceDeleteDialogBodyProps {
-  externalService: ExternalService
-  close: () => void
-  onDelete: (externalService: ExternalService) => void
+  readonly externalService: ExternalService
+  readonly close: () => void
+  readonly onDelete: (externalService: ExternalService) => void
 }
 
 export default ExternalServiceDeleteDialogBody

--- a/ui/src/components/ExternalServiceListColumn/index.tsx
+++ b/ui/src/components/ExternalServiceListColumn/index.tsx
@@ -24,8 +24,8 @@ const ExternalServiceListColumn: FunctionComponent<ExternalServiceListColumnProp
 )
 
 export interface ExternalServiceListColumnProps extends GridProps {
-  className?: string
-  children?: ReactNode
+  readonly className?: string
+  readonly children?: ReactNode
 }
 
 export default ExternalServiceListColumn

--- a/ui/src/components/ExternalServiceListColumnBodyCreate/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyCreate/index.tsx
@@ -27,7 +27,7 @@ const ExternalServiceListColumnBodyCreate: FunctionComponent<ExternalServiceList
   }, [])
 
   const urlPatternRef = useRef<HTMLInputElement>(null)
-  const [ urlPatternSelection, setUrlPatternSelection ] = useState<[ number, number ] | [ null, null ]>([ null, null ])
+  const [ urlPatternSelection, setUrlPatternSelection ] = useState<readonly [ number, number ] | readonly [ null, null ]>([ null, null ])
 
   const [ externalService, setExternalService ] = useState<Omit<ExternalService, 'id'>>({
     name: '',
@@ -262,7 +262,7 @@ const ExternalServiceListColumnBodyCreate: FunctionComponent<ExternalServiceList
 }
 
 export interface ExternalServiceListColumnBodyCreateProps {
-  close: () => void
+  readonly close: () => void
 }
 
 export default ExternalServiceListColumnBodyCreate

--- a/ui/src/components/ExternalServiceListColumnBodyEdit/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyEdit/index.tsx
@@ -29,7 +29,7 @@ const ExternalServiceListColumnBodyEdit: FunctionComponent<ExternalServiceListCo
   }, [])
 
   const urlPatternRef = useRef<HTMLInputElement>(null)
-  const [ urlPatternSelection, setUrlPatternSelection ] = useState<[ number, number ] | [ null, null ]>([ null, null ])
+  const [ urlPatternSelection, setUrlPatternSelection ] = useState<readonly [ number, number ] | readonly [ null, null ]>([ null, null ])
 
   const [ externalService, setExternalService ] = useState(current)
 
@@ -241,9 +241,9 @@ const ExternalServiceListColumnBodyEdit: FunctionComponent<ExternalServiceListCo
 }
 
 export interface ExternalServiceListColumnBodyEditProps {
-  externalService: ExternalService
-  close: () => void
-  onEdit: (externalService: ExternalService) => void
+  readonly externalService: ExternalService
+  readonly close: () => void
+  readonly onEdit: (externalService: ExternalService) => void
 }
 
 export default ExternalServiceListColumnBodyEdit

--- a/ui/src/components/ExternalServiceListColumnBodyList/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyList/index.tsx
@@ -199,24 +199,24 @@ const ExternalServiceListColumnBodyList: FunctionComponent<ExternalServiceListCo
 }
 
 export interface ExternalServiceColumn {
-  creating: boolean
-  editing: ExternalService | null
-  active: ExternalService | null
-  hit: ExternalService | null
-  hitInput: string
+  readonly creating: boolean
+  readonly editing: ExternalService | null
+  readonly active: ExternalService | null
+  readonly hit: ExternalService | null
+  readonly hitInput: string
 }
 
 export interface ExternalServiceListColumnBodyListProps extends ExternalServiceColumn {
-  readonly: boolean
-  dense: boolean
-  disabled?: (externalService: ExternalService) => boolean
-  onHit?: (externalService: ExternalService | null) => void
-  onSelect?: (externalService: ExternalService) => void
-  create: () => void
-  show: (externalService: ExternalService) => void
-  edit: (externalService: ExternalService) => void
-  delete: (externalService: ExternalService) => void
-  setColumn: (column: ExternalServiceColumn) => void
+  readonly readonly: boolean
+  readonly dense: boolean
+  readonly disabled?: (externalService: ExternalService) => boolean
+  readonly onHit?: (externalService: ExternalService | null) => void
+  readonly onSelect?: (externalService: ExternalService) => void
+  readonly create: () => void
+  readonly show: (externalService: ExternalService) => void
+  readonly edit: (externalService: ExternalService) => void
+  readonly delete: (externalService: ExternalService) => void
+  readonly setColumn: (column: ExternalServiceColumn) => void
 }
 
 export default ExternalServiceListColumnBodyList

--- a/ui/src/components/ExternalServiceListColumnBodyListItem/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyListItem/index.tsx
@@ -46,14 +46,14 @@ const ExternalServiceListColumnBodyListItem: FunctionComponent<ExternalServiceLi
 )
 
 export interface ExternalServiceListColumnBodyListItemProps {
-  className?: string
-  dense?: boolean
-  disabled?: boolean
-  selected?: boolean
-  primary?: ReactNode
-  secondary?: ReactNode
-  children?: ReactNode
-  onClick?: MouseEventHandler<HTMLElement>
+  readonly className?: string
+  readonly dense?: boolean
+  readonly disabled?: boolean
+  readonly selected?: boolean
+  readonly primary?: ReactNode
+  readonly secondary?: ReactNode
+  readonly children?: ReactNode
+  readonly onClick?: MouseEventHandler<HTMLElement>
 }
 
 export default ExternalServiceListColumnBodyListItem

--- a/ui/src/components/ExternalServiceListColumnBodyShow/index.tsx
+++ b/ui/src/components/ExternalServiceListColumnBodyShow/index.tsx
@@ -89,8 +89,8 @@ const ExternalServiceListColumnBodyShow: FunctionComponent<ExternalServiceListCo
 }
 
 export interface ExternalServiceListColumnBodyShowProps {
-  externalService: ExternalService
-  edit: (externalService: ExternalService) => void
+  readonly externalService: ExternalService
+  readonly edit: (externalService: ExternalService) => void
 }
 
 export default ExternalServiceListColumnBodyShow

--- a/ui/src/components/ExternalServiceListView/index.tsx
+++ b/ui/src/components/ExternalServiceListView/index.tsx
@@ -187,12 +187,12 @@ const ExternalServiceListView: FunctionComponent<ExternalServiceListViewProps> =
 }
 
 export interface ExternalServiceListViewProps {
-  className?: string
-  initial?: ExternalService
-  readonly?: boolean
-  dense?: boolean
-  disabled?: (externalService: ExternalService) => boolean
-  onSelect?: (externalService: ExternalService) => void
+  readonly className?: string
+  readonly initial?: ExternalService
+  readonly readonly?: boolean
+  readonly dense?: boolean
+  readonly disabled?: (externalService: ExternalService) => boolean
+  readonly onSelect?: (externalService: ExternalService) => void
 }
 
 export default ExternalServiceListView

--- a/ui/src/components/FileDrop/index.tsx
+++ b/ui/src/components/FileDrop/index.tsx
@@ -81,14 +81,14 @@ const FileDrop = function <Flatten extends boolean | undefined>({
 }
 
 export interface FileDropProps<Flatten extends boolean | undefined> {
-  className?: string
-  signal?: AbortSignal
-  flatten?: Flatten
-  onSelect?: FileDropOnSelect<Flatten>
-  children?: ReactNode
+  readonly className?: string
+  readonly signal?: AbortSignal
+  readonly flatten?: Flatten
+  readonly onSelect?: FileDropOnSelect<Flatten>
+  readonly children?: ReactNode
 }
 
-export type FileDropEntries<Flatten> = Flatten extends true ? File[] : (File | Folder)[]
+export type FileDropEntries<Flatten> = Flatten extends true ? readonly File[] : readonly (File | Folder)[]
 
 export type FileDropOnSelect<Flatten> = (entries: Promise<FileDropEntries<Flatten>>) => void
 

--- a/ui/src/components/FileOpen/index.tsx
+++ b/ui/src/components/FileOpen/index.tsx
@@ -29,11 +29,11 @@ const FileOpen: FunctionComponent<FileOpenProps> = ({
 }
 
 export interface FileOpenProps {
-  className?: string
-  accept?: string
-  multiple?: boolean
-  onSelect?: (files: Promise<File[]>) => void
-  children?: ReactNode
+  readonly className?: string
+  readonly accept?: string
+  readonly multiple?: boolean
+  readonly onSelect?: (files: Promise<readonly File[]>) => void
+  readonly children?: ReactNode
 }
 
 export default FileOpen

--- a/ui/src/components/FilePaste/index.tsx
+++ b/ui/src/components/FilePaste/index.tsx
@@ -82,9 +82,9 @@ const FilePaste: FunctionComponent<FilePasteProps> = ({
 }
 
 export interface FilePasteProps {
-  className?: string
-  onSelect?: (files: Promise<File[]>) => void
-  children?: ReactNode
+  readonly className?: string
+  readonly onSelect?: (files: Promise<readonly File[]>) => void
+  readonly children?: ReactNode
 }
 
 export default FilePaste

--- a/ui/src/components/Image/index.tsx
+++ b/ui/src/components/Image/index.tsx
@@ -22,11 +22,11 @@ const Image: FunctionComponent<ImageProps> = ({
 )
 
 export interface ImageProps {
-  className?: string
-  style?: CSSProperties
-  width?: number
-  height?: number
-  children?: ReactNode
+  readonly className?: string
+  readonly style?: CSSProperties
+  readonly width?: number
+  readonly height?: number
+  readonly children?: ReactNode
 }
 
 export default Image

--- a/ui/src/components/ImageBodyBlob/index.tsx
+++ b/ui/src/components/ImageBodyBlob/index.tsx
@@ -34,7 +34,7 @@ const ImageBodyBlob: FunctionComponent<ImageBodyBlobProps> = ({
 }
 
 export interface ImageBodyBlobProps extends Omit<ComponentPropsWithoutRef<'img'>, 'src'> {
-  src: Blob
+  readonly src: Blob
 }
 
 export default ImageBodyBlob

--- a/ui/src/components/ImageError/index.tsx
+++ b/ui/src/components/ImageError/index.tsx
@@ -23,11 +23,11 @@ const ImageError: FunctionComponent<ImageErrorProps> = ({
 )
 
 export interface ImageErrorProps {
-  className?: string
-  style?: CSSProperties
-  width?: number
-  height?: number
-  children?: ReactNode
+  readonly className?: string
+  readonly style?: CSSProperties
+  readonly width?: number
+  readonly height?: number
+  readonly children?: ReactNode
 }
 
 export default ImageError

--- a/ui/src/components/ImageLoading/index.tsx
+++ b/ui/src/components/ImageLoading/index.tsx
@@ -18,11 +18,11 @@ const ImageLoading: FunctionComponent<ImageLoadingProps> = ({
 )
 
 export interface ImageLoadingProps {
-  className?: string
-  style?: CSSProperties
-  width?: number
-  height?: number
-  children?: ReactNode
+  readonly className?: string
+  readonly style?: CSSProperties
+  readonly width?: number
+  readonly height?: number
+  readonly children?: ReactNode
 }
 
 export default ImageLoading

--- a/ui/src/components/LocalizationWrapper/index.tsx
+++ b/ui/src/components/LocalizationWrapper/index.tsx
@@ -17,7 +17,7 @@ const LocalizationWrapper: FunctionComponent<LocalizationWrapperProps> = ({
 )
 
 export interface LocalizationWrapperProps {
-  children: ReactNode
+  readonly children: ReactNode
 }
 
 export default LocalizationWrapper

--- a/ui/src/components/MediumCreateView/index.tsx
+++ b/ui/src/components/MediumCreateView/index.tsx
@@ -30,7 +30,7 @@ import type { Medium, Replica } from '@/types'
 
 import styles from './styles.module.scss'
 
-const hasChanges = (medium: Medium | null, replicas: (Replica | ReplicaCreate)[]) => {
+const hasChanges = (medium: Medium | null, replicas: readonly (Replica | ReplicaCreate)[]) => {
   if ((medium?.replicas?.length ?? 0) !== replicas.length) {
     return true
   }
@@ -60,9 +60,9 @@ const MediumCreateView: FunctionComponent = () => {
   const [ editingSources, setEditingSources ] = useState(true)
   const [ editingTags, setEditingTags ] = useState(true)
 
-  const [ resolveSourceIDs, setResolveSourceIDs ] = useState(() => () => Promise.resolve<string[]>([]))
-  const [ tagTagTypeIDs, setTagTagTypeIDs ] = useState<TagTagTypeInput[]>([])
-  const [ replicas, setReplicas ] = useState<(Replica | ReplicaCreate)[]>([])
+  const [ resolveSourceIDs, setResolveSourceIDs ] = useState(() => () => Promise.resolve<readonly string[]>([]))
+  const [ tagTagTypeIDs, setTagTagTypeIDs ] = useState<readonly TagTagTypeInput[]>([])
+  const [ replicas, setReplicas ] = useState<readonly (Replica | ReplicaCreate)[]>([])
 
   const [ uploading, setUploading ] = useState(false)
   const [ uploadAborting, setUploadAborting ] = useState(false)
@@ -90,7 +90,7 @@ const MediumCreateView: FunctionComponent = () => {
     setEditingSummary(true)
   }, [])
 
-  const closeEditSummary = useCallback((newReplicas?: Replica[]) => {
+  const closeEditSummary = useCallback((newReplicas?: readonly Replica[]) => {
     setEditingSummary(false)
     setReplicas(() => newReplicas ?? medium?.replicas ?? [])
   }, [ medium ])
@@ -136,8 +136,8 @@ const MediumCreateView: FunctionComponent = () => {
     }
   }, [])
 
-  const handleComplete = useCallback(async (current: Medium, replicas: (Replica | ReplicaCreate)[]) => {
-    const processed = (replicas: (Replica | ReplicaCreate)[]) => replicas.every(isReplica)
+  const handleComplete = useCallback(async (current: Medium, replicas: readonly (Replica | ReplicaCreate)[]) => {
+    const processed = (replicas: readonly (Replica | ReplicaCreate)[]) => replicas.every(isReplica)
     if (!processed(replicas)) {
       setReplicas(replicas)
       try {
@@ -201,7 +201,7 @@ const MediumCreateView: FunctionComponent = () => {
     }
   }, [ medium, resolveSourceIDs, tagTagTypeIDs, replicas, createMedium, handleComplete ])
 
-  const saveTags = useCallback(async (id: string, addTagTagTypeIDs: TagTagTypeInput[], removeTagTagTypeIDs: TagTagTypeInput[]) => {
+  const saveTags = useCallback(async (id: string, addTagTagTypeIDs: readonly TagTagTypeInput[], removeTagTagTypeIDs: readonly TagTagTypeInput[]) => {
     const medium = await updateMedium({
       id,
       addTagTagTypeIDs,
@@ -211,7 +211,7 @@ const MediumCreateView: FunctionComponent = () => {
     return medium
   }, [ updateMedium ])
 
-  const saveSources = useCallback(async (id: string, addSourceIDs: string[], removeSourceIDs: string[]) => {
+  const saveSources = useCallback(async (id: string, addSourceIDs: readonly string[], removeSourceIDs: readonly string[]) => {
     const medium = await updateMedium({
       id,
       addSourceIDs,
@@ -310,7 +310,7 @@ const MediumCreateView: FunctionComponent = () => {
 }
 
 export interface MediumCreate {
-  createdAt: string | null
+  readonly createdAt: string | null
 }
 
 export default MediumCreateView

--- a/ui/src/components/MediumDeleteDialogBody/index.tsx
+++ b/ui/src/components/MediumDeleteDialogBody/index.tsx
@@ -73,9 +73,9 @@ const MediumDeleteDialogBody: FunctionComponent<MediumDeleteDialogBodyProps> = (
 }
 
 export interface MediumDeleteDialogBodyProps {
-  medium: Medium
-  close: () => void
-  onDelete: (medium: Medium) => void
+  readonly medium: Medium
+  readonly close: () => void
+  readonly onDelete: (medium: Medium) => void
 }
 
 export default MediumDeleteDialogBody

--- a/ui/src/components/MediumItem/index.tsx
+++ b/ui/src/components/MediumItem/index.tsx
@@ -14,7 +14,7 @@ const MediumItem: FunctionComponent<MediumItemProps> = ({
 )
 
 export interface MediumItemProps {
-  id: string
+  readonly id: string
 }
 
 export default MediumItem

--- a/ui/src/components/MediumItemFileAppendDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileAppendDialogBody/index.tsx
@@ -39,9 +39,9 @@ const MediumItemFileAppendDialogBody: FunctionComponent<MediumItemFileAppendDial
 export type Folder = (File | Folder)[]
 
 export interface MediumItemFileAppendDialogBodyProps {
-  entries: Promise<File[]>
-  close: () => void
-  onAppend: (files: File[]) => void
+  readonly entries: Promise<readonly File[]>
+  readonly close: () => void
+  readonly onAppend: (files: readonly File[]) => void
 }
 
 export default MediumItemFileAppendDialogBody

--- a/ui/src/components/MediumItemFileAppendDialogLoading/index.tsx
+++ b/ui/src/components/MediumItemFileAppendDialogLoading/index.tsx
@@ -23,7 +23,7 @@ const MediumItemFileAppendDialogLoading: FunctionComponent<MediumItemFileAppendD
 }
 
 export interface MediumItemFileAppendDialogLoadingProps {
-  cancel?: () => void
+  readonly cancel?: () => void
 }
 
 export default MediumItemFileAppendDialogLoading

--- a/ui/src/components/MediumItemFileErrorDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileErrorDialogBody/index.tsx
@@ -50,9 +50,9 @@ const MediumItemFileErrorDialogBody: FunctionComponent<MediumItemFileErrorDialog
 }
 
 export interface MediumItemFileErrorDialogBodyProps {
-  files?: File[]
-  error?: unknown
-  close: () => void
+  readonly files?: readonly File[]
+  readonly error?: unknown
+  readonly close: () => void
 }
 
 export default MediumItemFileErrorDialogBody

--- a/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileOverwriteDialogBody/index.tsx
@@ -94,20 +94,20 @@ const MediumItemFileOverwriteDialogBody: FunctionComponent<MediumItemFileOverwri
 }
 
 export interface MediumItemFileOverwriteDialogBodyProps {
-  uploading: {
-    name: string
-    size: number
-    lastModified: Date
-    blob: Blob
+  readonly uploading: {
+    readonly name: string
+    readonly size: number
+    readonly lastModified: Date
+    readonly blob: Blob
   }
-  existing: {
-    name: string
-    size: number | null
-    lastModified: Date | null
-    url: string
+  readonly existing: {
+    readonly name: string
+    readonly size: number | null
+    readonly lastModified: Date | null
+    readonly url: string
   } | null
-  overwrite?: () => void
-  close: () => void
+  readonly overwrite?: () => void
+  readonly close: () => void
 }
 
 export default MediumItemFileOverwriteDialogBody

--- a/ui/src/components/MediumItemFileUploadAbortDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadAbortDialogBody/index.tsx
@@ -31,8 +31,8 @@ const MediumItemFileUploadAbortDialogBody: FunctionComponent<MediumItemFileUploa
 }
 
 export interface MediumItemFileUploadAbortDialogBodyProps {
-  abort: () => void
-  close: () => void
+  readonly abort: () => void
+  readonly close: () => void
 }
 
 export default MediumItemFileUploadAbortDialogBody

--- a/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBody/index.tsx
@@ -39,7 +39,7 @@ import type { Medium, Replica } from '@/types'
 import styles from './styles.module.scss'
 
 const isValidName = (name: string) => name.length > 0
-const isUniqueName = (name: string, replicas: (Replica | ReplicaCreate)[]) => replicas.reduce((total, replica) => total + Number(!isReplica(replica) && replica.name === name), 0) === 1
+const isUniqueName = (name: string, replicas: readonly (Replica | ReplicaCreate)[]) => replicas.reduce((total, replica) => total + Number(!isReplica(replica) && replica.name === name), 0) === 1
 
 const extractEntry = (e: ReplicaOriginalUrlDuplicate | ObjectAlreadyExists): ReplicaUploadOverwritingFile | null => {
   const entry = e.extensions.details.data.entry
@@ -75,8 +75,8 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
   const { graphQLError } = useError()
 
   const [ uploading, setUploading ] = useState(false)
-  const [ uploads, setUploads ] = useState(new Map<ReplicaCreateID, ReplicaUpload>())
-  const [ overwriting, setOverwriting ] = useState<ReplicaUploadOverwrite[]>([])
+  const [ uploads, setUploads ] = useState<ReadonlyMap<ReplicaCreateID, ReplicaUpload>>(new Map())
+  const [ overwriting, setOverwriting ] = useState<readonly ReplicaUploadOverwrite[]>([])
   const [ error, setError ] = useState<unknown>(null)
 
   const defaultContainer = useMemo(() => {
@@ -406,40 +406,40 @@ const MediumItemFileUploadDialogBody: FunctionComponent<MediumItemFileUploadDial
 }
 
 export interface MediumItemFileUploadDialogBodyProps {
-  abortSignal?: AbortSignal
-  resolveMedium: () => Promise<Medium>
-  replicas: (Replica | ReplicaCreate)[]
-  setReplicas: (setReplicas: (replicas: (Replica | ReplicaCreate)[]) => (Replica | ReplicaCreate)[]) => void
-  close: () => void
-  onProgress?: (status: UploadStatus) => void
-  onComplete: (medium: Medium, replicas: (Replica | ReplicaCreate)[]) => void
+  readonly abortSignal?: AbortSignal
+  readonly resolveMedium: () => Promise<Medium>
+  readonly replicas: readonly (Replica | ReplicaCreate)[]
+  readonly setReplicas: (setReplicas: (replicas: readonly (Replica | ReplicaCreate)[]) => readonly (Replica | ReplicaCreate)[]) => void
+  readonly close: () => void
+  readonly onProgress?: (status: UploadStatus) => void
+  readonly onComplete: (medium: Medium, replicas: readonly (Replica | ReplicaCreate)[]) => void
 }
 
 type ReplicaCreateID = string
 
 interface ReplicaUpload {
-  status: ReplicaUploadStatus
-  progress?: ReplicaUploadProgress
-  error?: unknown
+  readonly status: ReplicaUploadStatus
+  readonly progress?: ReplicaUploadProgress
+  readonly error?: unknown
 }
 
 interface ReplicaUploadOverwrite {
-  uploading: ReplicaCreate
-  existing: ReplicaUploadOverwritingFile | null
-  onConfirm?: () => void
-  onCancel?: () => void
+  readonly uploading: ReplicaCreate
+  readonly existing: ReplicaUploadOverwritingFile | null
+  readonly onConfirm?: () => void
+  readonly onCancel?: () => void
 }
 
 interface ReplicaUploadOverwritingFile {
-  name: string
-  size: number | null
-  lastModified: Date | null
-  url: string
+  readonly name: string
+  readonly size: number | null
+  readonly lastModified: Date | null
+  readonly url: string
 }
 
 export interface ReplicaUploadProgress {
-  loaded: number
-  total: number
+  readonly loaded: number
+  readonly total: number
 }
 
 export type UploadStatus = 'uploading' | 'done'

--- a/ui/src/components/MediumItemFileUploadDialogBodyItem/index.tsx
+++ b/ui/src/components/MediumItemFileUploadDialogBodyItem/index.tsx
@@ -128,12 +128,12 @@ const MediumItemFileUploadDialogBodyItem: FunctionComponent<MediumItemFileUpload
 }
 
 export interface MediumItemFileUploadDialogBodyItemProps {
-  replica: ReplicaCreate
-  status: ReplicaUploadStatus
-  progress: ReplicaUploadProgress | null
-  error: unknown
-  nameValidationError?: string | null
-  onChangeName?: (name: string) => void
+  readonly replica: ReplicaCreate
+  readonly status: ReplicaUploadStatus
+  readonly progress: ReplicaUploadProgress | null
+  readonly error: unknown
+  readonly nameValidationError?: string | null
+  readonly onChangeName?: (name: string) => void
 }
 
 export default MediumItemFileUploadDialogBodyItem

--- a/ui/src/components/MediumItemImageEdit/index.tsx
+++ b/ui/src/components/MediumItemImageEdit/index.tsx
@@ -44,9 +44,9 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
   const [ abortController, setAbortController ] = useState(new AbortController())
   const [ appending, setAppending ] = useState(0)
   const [ appended, setAppended ] = useState(0)
-  const [ appendFiles, setAppendFiles ] = useState(new Map<string, Promise<File[]>>())
+  const [ appendFiles, setAppendFiles ] = useState<ReadonlyMap<string, Promise<readonly File[]>>>(new Map())
   const [ error, setError ] = useState<unknown>(null)
-  const [ errorFiles, setErrorFiles ] = useState<File[]>([])
+  const [ errorFiles, setErrorFiles ] = useState<readonly File[]>([])
 
   const handleChangeName = useCallback((idx: number, name: string) => {
     setReplicas(replicas => {
@@ -88,7 +88,7 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
     restoreReplica?.(replica)
   }, [ restoreReplica ])
 
-  const handleAppendFiles = useCallback(async (files: File[]) => {
+  const handleAppendFiles = useCallback(async (files: readonly File[]) => {
     const { signal } = abortController
     const rejectOnAbort = new Promise<never>((_resolve, reject) => {
       signal.addEventListener('abort', reject, { once: true })
@@ -168,7 +168,7 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
     })
   }, [])
 
-  const handleSelectFiles = useCallback((entries: Promise<File[]>) => {
+  const handleSelectFiles = useCallback((entries: Promise<readonly File[]>) => {
     const id = uuid()
     const newAppendFiles = (async () => {
       try {
@@ -192,7 +192,7 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
       }
     })()
 
-    setAppendFiles(appendFiles => new Map([ ...appendFiles.set(id, newAppendFiles) ]))
+    setAppendFiles(appendFiles => new Map(appendFiles).set(id, newAppendFiles))
   }, [ handleAppendFiles, handleCloseAppendFiles ])
 
   const handleCancelAppendFiles = useCallback(() => {
@@ -346,39 +346,39 @@ const MediumItemImageEdit: FunctionComponent<MediumItemImageEditProps> = ({
 }
 
 interface ReplicaItem {
-  total: number
-  current: Replica | ReplicaCreate
-  currentIndex: number
-  currentTotal: number
-  removing: boolean
+  readonly total: number
+  readonly current: Replica | ReplicaCreate
+  readonly currentIndex: number
+  readonly currentTotal: number
+  readonly removing: boolean
 }
 
 export interface ReplicaCreate {
-  tempid: string
-  name: string
-  size: number
-  width?: number
-  height?: number
-  lastModified: Date
-  blob: Blob
+  readonly tempid: string
+  readonly name: string
+  readonly size: number
+  readonly width?: number
+  readonly height?: number
+  readonly lastModified: Date
+  readonly blob: Blob
 }
 
 type ReplicaMetadataResult = {
-  status: 'succeeded'
-  value: ReplicaCreate
+  readonly status: 'succeeded'
+  readonly value: ReplicaCreate
 } | {
-  status: 'failed'
-  file: File
+  readonly status: 'failed'
+  readonly file: File
 }
 
 export interface MediumItemImageEditProps {
-  className?: string
-  gap?: number
-  replicas: (Replica | ReplicaCreate)[]
-  setReplicas: (setReplicas: (replicas: (Replica | ReplicaCreate)[]) => (Replica | ReplicaCreate)[]) => void
-  removingReplicas?: Replica[]
-  removeReplica: (replica: Replica | ReplicaCreate) => void
-  restoreReplica?: (replica: Replica) => void
+  readonly className?: string
+  readonly gap?: number
+  readonly replicas: readonly (Replica | ReplicaCreate)[]
+  readonly setReplicas: (setReplicas: (replicas: readonly (Replica | ReplicaCreate)[]) => readonly (Replica | ReplicaCreate)[]) => void
+  readonly removingReplicas?: readonly Replica[]
+  readonly removeReplica: (replica: Replica | ReplicaCreate) => void
+  readonly restoreReplica?: (replica: Replica) => void
 }
 
 export default MediumItemImageEdit

--- a/ui/src/components/MediumItemImageItem/index.tsx
+++ b/ui/src/components/MediumItemImageItem/index.tsx
@@ -64,10 +64,10 @@ const MediumItemImageItem: FunctionComponent<MediumItemImageItemProps> = ({
 }
 
 export interface MediumItemImageItemProps {
-  className?: string
-  replica: Replica | ReplicaCreate
-  fixed?: boolean
-  children?: ReactNode
+  readonly className?: string
+  readonly replica: Replica | ReplicaCreate
+  readonly fixed?: boolean
+  readonly children?: ReactNode
 }
 
 export default memo(MediumItemImageItem)

--- a/ui/src/components/MediumItemImageItemBar/index.tsx
+++ b/ui/src/components/MediumItemImageItemBar/index.tsx
@@ -103,18 +103,18 @@ const MediumItemImageItemBar: FunctionComponent<MediumItemImageItemBarProps> = (
 }
 
 export interface MediumItemImageItemBarProps {
-  index: number
-  total: number
-  currentIndex: number
-  currentTotal: number
-  removing: boolean
-  replica: Replica | ReplicaCreate
-  name?: string
-  onChangeName?: (index: number, name: string) => void
-  onMoveUp: (index: number) => void
-  onMoveDown: (index: number) => void
-  onRemove: (replica: Replica | ReplicaCreate) => void
-  onRestore?: (replica: Replica) => void
+  readonly index: number
+  readonly total: number
+  readonly currentIndex: number
+  readonly currentTotal: number
+  readonly removing: boolean
+  readonly replica: Replica | ReplicaCreate
+  readonly name?: string
+  readonly onChangeName?: (index: number, name: string) => void
+  readonly onMoveUp: (index: number) => void
+  readonly onMoveDown: (index: number) => void
+  readonly onRemove: (replica: Replica | ReplicaCreate) => void
+  readonly onRestore?: (replica: Replica) => void
 }
 
 export default memo(MediumItemImageItemBar)

--- a/ui/src/components/MediumItemImageList/index.tsx
+++ b/ui/src/components/MediumItemImageList/index.tsx
@@ -70,9 +70,9 @@ const MediumItemImageList: FunctionComponent<MediumItemImageListProps> = ({
 }
 
 export interface MediumItemImageListProps {
-  className?: string
-  gap?: number
-  replicas: Replica[]
+  readonly className?: string
+  readonly gap?: number
+  readonly replicas: readonly Replica[]
 }
 
 export default MediumItemImageList

--- a/ui/src/components/MediumItemMetadataHeader/index.tsx
+++ b/ui/src/components/MediumItemMetadataHeader/index.tsx
@@ -19,8 +19,8 @@ const MediumItemMetadataHeader: FunctionComponent<MediumItemMetadataHeaderProps>
 )
 
 export interface MediumItemMetadataHeaderProps {
-  title: string
-  children?: ReactNode
+  readonly title: string
+  readonly children?: ReactNode
 }
 
 export default MediumItemMetadataHeader

--- a/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceCreate/index.tsx
@@ -17,7 +17,7 @@ import type { ExternalService, Source } from '@/types'
 
 import styles from './styles.module.scss'
 
-const hasChanges = (addingExternalServices: ExternalService[], addingSources: Map<ExternalServiceID, (Source | SourceCreate)[]>) => {
+const hasChanges = (addingExternalServices: readonly ExternalService[], addingSources: ReadonlyMap<ExternalServiceID, readonly (Source | SourceCreate)[]>) => {
   if (addingExternalServices.length > 0) {
     return true
   }
@@ -41,8 +41,8 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
   const [ focusedExternalService, setFocusedExternalService ] = useState<ExternalService | null>(null)
   const [ newExternalServiceInput, setNewExternalServiceInput ] = useState('')
 
-  const [ addingExternalServices, setAddingExternalServices ] = useState<ExternalService[]>([])
-  const [ addingSources, setAddingSources ] = useState(new Map<ExternalServiceID, (Source | SourceCreate)[]>())
+  const [ addingExternalServices, setAddingExternalServices ] = useState<readonly ExternalService[]>([])
+  const [ addingSources, setAddingSources ] = useState<ReadonlyMap<ExternalServiceID, readonly (Source | SourceCreate)[]>>(new Map())
 
   const handleChangeNewExternalService = useCallback((type: ExternalService | null) => {
     if (!type) {
@@ -75,7 +75,7 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
     })
   }, [])
 
-  const resolveSourceIDs = useCallback((addingSources: Map<ExternalServiceID, (Source | SourceCreate)[]>) => async () => {
+  const resolveSourceIDs = useCallback((addingSources: ReadonlyMap<ExternalServiceID, readonly (Source | SourceCreate)[]>) => async () => {
     const addingSourceIDs: string[] = []
     const createSources: Promise<void>[] = []
     for (const sources of addingSources.values()) {
@@ -190,8 +190,8 @@ const MediumItemMetadataSourceCreate: FunctionComponent<MediumItemMetadataSource
 }
 
 export interface MediumItemMetadataSourceCreateProps {
-  loading: boolean
-  setResolveSourceIDs: (setResolveSourceIDs: () => () => Promise<string[]>) => void
+  readonly loading: boolean
+  readonly setResolveSourceIDs: (setResolveSourceIDs: () => () => Promise<readonly string[]>) => void
 }
 
 type ExternalServiceID = string

--- a/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceEdit/index.tsx
@@ -20,7 +20,12 @@ import type { ExternalService, Medium, Source } from '@/types'
 
 import styles from './styles.module.scss'
 
-const hasChanges = (addingExternalServices: ExternalService[], removingExternalServices: ExternalService[], addingSources: Map<ExternalServiceID, (Source | SourceCreate)[]>, removingSources: Map<ExternalServiceID, Source[]>) => {
+const hasChanges = (
+  addingExternalServices: readonly ExternalService[],
+  removingExternalServices: readonly ExternalService[],
+  addingSources: ReadonlyMap<ExternalServiceID, readonly (Source | SourceCreate)[]>,
+  removingSources: ReadonlyMap<ExternalServiceID, readonly Source[]>,
+) => {
   if (addingExternalServices.length > 0 || removingExternalServices.length > 0) {
     return true
   }
@@ -53,14 +58,14 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
   const [ focusedExternalService, setFocusedExternalService ] = useState<ExternalService | null>(null)
   const [ newExternalServiceInput, setNewExternalServiceInput ] = useState('')
 
-  const [ addingExternalServices, setAddingExternalServices ] = useState<ExternalService[]>([])
-  const [ removingExternalServices, setRemovingExternalServices ] = useState<ExternalService[]>([])
+  const [ addingExternalServices, setAddingExternalServices ] = useState<readonly ExternalService[]>([])
+  const [ removingExternalServices, setRemovingExternalServices ] = useState<readonly ExternalService[]>([])
 
-  const [ addingSources, setAddingSources ] = useState(new Map<ExternalServiceID, (Source | SourceCreate)[]>())
-  const [ removingSources, setRemovingSources ] = useState(new Map<ExternalServiceID, Source[]>())
+  const [ addingSources, setAddingSources ] = useState<ReadonlyMap<ExternalServiceID, readonly (Source | SourceCreate)[]>>(new Map())
+  const [ removingSources, setRemovingSources ] = useState<ReadonlyMap<ExternalServiceID, readonly Source[]>>(new Map())
 
   const sources = medium.sources ?? []
-  const groups = sources.reduce<SourceGroup[]>((groups, source) => {
+  const groups: readonly ReadonlySourceGroup[] = sources.reduce<SourceGroup[]>((groups, source) => {
     const group = groups.find(s => s.externalService.id === source.externalService.id)
     if (group) {
       group.sources.push(source)
@@ -328,11 +333,16 @@ const MediumItemMetadataSourceEdit: FunctionComponent<MediumItemMetadataSourceEd
 }
 
 export interface MediumItemMetadataSourceEditProps {
-  loading: boolean
-  focus?: boolean
-  medium: Medium
-  save: (id: string, addSourceIDs: string[], removeSourceIDs: string[]) => Promise<Medium>
-  close?: () => void
+  readonly loading: boolean
+  readonly focus?: boolean
+  readonly medium: Medium
+  readonly save: (id: string, addSourceIDs: readonly string[], removeSourceIDs: readonly string[]) => Promise<Medium>
+  readonly close?: () => void
+}
+
+interface ReadonlySourceGroup {
+  readonly externalService: ExternalService
+  readonly sources: readonly Source[]
 }
 
 interface SourceGroup {

--- a/ui/src/components/MediumItemMetadataSourceGroupEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceGroupEdit/index.tsx
@@ -183,18 +183,18 @@ const MediumItemMetadataSourceGroupEdit: FunctionComponent<MediumItemMetadataSou
 }
 
 export interface MediumItemMetadataSourceGroupEditProps {
-  loading: boolean
-  externalService: ExternalService
-  sources: Source[]
-  focus?: boolean
-  removingExternalService: boolean
-  removeExternalService: (externalService: ExternalService) => void
-  restoreExternalService?: (externalService: ExternalService) => void
-  addingSources: (Source | SourceCreate)[]
-  removingSources: Source[]
-  addSource: (externalService: ExternalService, source: Source | SourceCreate) => void
-  removeSource: (externalService: ExternalService, source: Source | SourceCreate) => void
-  restoreSource?: (externalService: ExternalService, source: Source) => void
+  readonly loading: boolean
+  readonly externalService: ExternalService
+  readonly sources: readonly Source[]
+  readonly focus?: boolean
+  readonly removingExternalService: boolean
+  readonly removeExternalService: (externalService: ExternalService) => void
+  readonly restoreExternalService?: (externalService: ExternalService) => void
+  readonly addingSources: readonly (Source | SourceCreate)[]
+  readonly removingSources: readonly Source[]
+  readonly addSource: (externalService: ExternalService, source: Source | SourceCreate) => void
+  readonly removeSource: (externalService: ExternalService, source: Source | SourceCreate) => void
+  readonly restoreSource?: (externalService: ExternalService, source: Source) => void
 }
 
 export default MediumItemMetadataSourceGroupEdit

--- a/ui/src/components/MediumItemMetadataSourceList/index.tsx
+++ b/ui/src/components/MediumItemMetadataSourceList/index.tsx
@@ -21,7 +21,7 @@ const MediumItemMetadataSourceList: FunctionComponent<MediumItemMetadataSourceLi
   }, [ edit ])
 
   const sources = medium.sources ?? []
-  const groups = sources.reduce<SourceGroup[]>((groups, source) => {
+  const groups: readonly ReadonlySourceGroup[] = sources.reduce<SourceGroup[]>((groups, source) => {
     const group = groups.find(s => s.externalService.id === source.externalService.id)
     if (group) {
       group.sources.push(source)
@@ -65,8 +65,13 @@ const MediumItemMetadataSourceList: FunctionComponent<MediumItemMetadataSourceLi
 }
 
 export interface MediumItemMetadataSourceListProps {
-  medium: Medium
-  edit: () => void
+  readonly medium: Medium
+  readonly edit: () => void
+}
+
+interface ReadonlySourceGroup {
+  readonly externalService: ExternalService
+  readonly sources: readonly Source[]
 }
 
 interface SourceGroup {

--- a/ui/src/components/MediumItemMetadataSummaryCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataSummaryCreate/index.tsx
@@ -78,8 +78,8 @@ const MediumItemMetadataSummaryCreate: FunctionComponent<MediumItemMetadataSumma
 }
 
 export interface MediumItemMetadataSummaryCreateProps {
-  loading: boolean
-  save: (medium: MediumCreate) => void
+  readonly loading: boolean
+  readonly save: (medium: MediumCreate) => void
 }
 
 export default MediumItemMetadataSummaryCreate

--- a/ui/src/components/MediumItemMetadataSummaryEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataSummaryEdit/index.tsx
@@ -108,11 +108,11 @@ const MediumItemMetadataSummaryEdit: FunctionComponent<MediumItemMetadataSummary
 }
 
 export interface MediumItemMetadataSummaryEditProps {
-  loading: boolean
-  medium: Medium
-  save: (medium: Medium) => void
-  close?: () => void
-  onDelete: () => void
+  readonly loading: boolean
+  readonly medium: Medium
+  readonly save: (medium: Medium) => void
+  readonly close?: () => void
+  readonly onDelete: () => void
 }
 
 export default MediumItemMetadataSummaryEdit

--- a/ui/src/components/MediumItemMetadataSummaryShow/index.tsx
+++ b/ui/src/components/MediumItemMetadataSummaryShow/index.tsx
@@ -38,8 +38,8 @@ const MediumItemMetadataSummaryShow: FunctionComponent<MediumItemMetadataSummary
 }
 
 export interface MediumItemMetadataSummaryShowProps {
-  medium: Medium
-  edit: () => void
+  readonly medium: Medium
+  readonly edit: () => void
 }
 
 export default MediumItemMetadataSummaryShow

--- a/ui/src/components/MediumItemMetadataTagCreate/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagCreate/index.tsx
@@ -14,7 +14,7 @@ import type { Tag, TagType } from '@/types'
 
 import styles from './styles.module.scss'
 
-const hasChanges = (addingTagTypes: TagType[], addingTags: Map<TagTypeID, Tag[]>) => {
+const hasChanges = (addingTagTypes: readonly TagType[], addingTags: ReadonlyMap<TagTypeID, readonly Tag[]>) => {
   if (addingTagTypes.length > 0) {
     return true
   }
@@ -35,8 +35,8 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
   const [ focusedTagType, setFocusedTagType ] = useState<TagType | null>(null)
   const [ newTagTypeInput, setNewTagTypeInput ] = useState('')
 
-  const [ addingTagTypes, setAddingTagTypes ] = useState<TagType[]>([])
-  const [ addingTags, setAddingTags ] = useState(new Map<TagTypeID, Tag[]>())
+  const [ addingTagTypes, setAddingTagTypes ] = useState<readonly TagType[]>([])
+  const [ addingTags, setAddingTags ] = useState<ReadonlyMap<TagTypeID, readonly Tag[]>>(new Map())
 
   const handleChangeNewTagType = useCallback((type: TagType | null) => {
     if (!type) {
@@ -96,7 +96,7 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
     setTagTagTypeIDs(() => resolveTagTagTypeIDs(newAddingTags))
   }, [ addingTags, setTagTagTypeIDs ])
 
-  const resolveTagTagTypeIDs = (addingTags: Map<TagTypeID, Tag[]>) => {
+  const resolveTagTagTypeIDs = (addingTags: ReadonlyMap<TagTypeID, readonly Tag[]>) => {
     const addTagTagTypeIDs: TagTagTypeInput[] = []
     for (const [ tagTypeId, tags ] of addingTags) {
       addTagTagTypeIDs.push(...tags.map(({ id: tagId }) => ({ tagTypeId, tagId })))
@@ -161,8 +161,8 @@ const MediumItemMetadataTagCreate: FunctionComponent<MediumItemMetadataTagCreate
 }
 
 export interface MediumItemMetadataTagCreateProps {
-  loading: boolean
-  setTagTagTypeIDs: (setTagTagTypeIDs: () => TagTagTypeInput[]) => void
+  readonly loading: boolean
+  readonly setTagTagTypeIDs: (setTagTagTypeIDs: () => readonly TagTagTypeInput[]) => void
 }
 
 type TagTypeID = string

--- a/ui/src/components/MediumItemMetadataTagEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagEdit/index.tsx
@@ -15,7 +15,12 @@ import type { Medium, Tag, TagType } from '@/types'
 
 import styles from './styles.module.scss'
 
-const hasChanges = (addingTagTypes: TagType[], removingTagTypes: TagType[], addingTags: Map<TagTypeID, Tag[]>, removingTags: Map<TagTypeID, Tag[]>) => {
+const hasChanges = (
+  addingTagTypes: readonly TagType[],
+  removingTagTypes: readonly TagType[],
+  addingTags: ReadonlyMap<TagTypeID, readonly Tag[]>,
+  removingTags: ReadonlyMap<TagTypeID, readonly Tag[]>,
+) => {
   if (addingTagTypes.length > 0 || removingTagTypes.length > 0) {
     return true
   }
@@ -45,14 +50,14 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
   const [ focusedTagType, setFocusedTagType ] = useState<TagType | null>(null)
   const [ newTagTypeInput, setNewTagTypeInput ] = useState('')
 
-  const [ addingTagTypes, setAddingTagTypes ] = useState<TagType[]>([])
-  const [ removingTagTypes, setRemovingTagTypes ] = useState<TagType[]>([])
+  const [ addingTagTypes, setAddingTagTypes ] = useState<readonly TagType[]>([])
+  const [ removingTagTypes, setRemovingTagTypes ] = useState<readonly TagType[]>([])
 
-  const [ addingTags, setAddingTags ] = useState(new Map<TagTypeID, Tag[]>())
-  const [ removingTags, setRemovingTags ] = useState(new Map<TagTypeID, Tag[]>())
+  const [ addingTags, setAddingTags ] = useState<ReadonlyMap<TagTypeID, readonly Tag[]>>(new Map())
+  const [ removingTags, setRemovingTags ] = useState<ReadonlyMap<TagTypeID, readonly Tag[]>>(new Map())
 
   const tags = medium.tags ?? []
-  const groups = tags.reduce<TagGroup[]>((groups, { tag, type }) => {
+  const groups: readonly ReadonlyTagGroup[] = tags.reduce<TagGroup[]>((groups, { tag, type }) => {
     const group = groups.find(t => t.type.id === type.id)
     if (group) {
       group.tags.push(tag)
@@ -284,11 +289,16 @@ const MediumItemMetadataTagEdit: FunctionComponent<MediumItemMetadataTagEditProp
 }
 
 export interface MediumItemMetadataTagEditProps {
-  loading: boolean
-  focus?: boolean
-  medium: Medium
-  save: (id: string, addTagTagTypeIDs: TagTagTypeInput[], removeTagTagTypeIDs: TagTagTypeInput[]) => Promise<Medium>
-  close?: () => void
+  readonly loading: boolean
+  readonly focus?: boolean
+  readonly medium: Medium
+  readonly save: (id: string, addTagTagTypeIDs: readonly TagTagTypeInput[], removeTagTagTypeIDs: readonly TagTagTypeInput[]) => Promise<Medium>
+  readonly close?: () => void
+}
+
+interface ReadonlyTagGroup {
+  readonly type: TagType
+  readonly tags: readonly Tag[]
 }
 
 interface TagGroup {

--- a/ui/src/components/MediumItemMetadataTagGroupEdit/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagGroupEdit/index.tsx
@@ -166,18 +166,18 @@ const MediumItemMetadataTagGroupEdit: FunctionComponent<MediumItemMetadataTagGro
 }
 
 export interface MediumItemMetadataTagGroupEditProps {
-  loading: boolean
-  type: TagType
-  tags: Tag[]
-  focus?: boolean
-  removingTagType: boolean
-  removeTagType: (type: TagType) => void
-  restoreTagType?: (type: TagType) => void
-  addingTags: Tag[]
-  removingTags: Tag[]
-  addTag: (type: TagType, tag: Tag) => void
-  removeTag: (type: TagType, tag: Tag) => void
-  restoreTag?: (type: TagType, tag: Tag) => void
+  readonly loading: boolean
+  readonly type: TagType
+  readonly tags: readonly Tag[]
+  readonly focus?: boolean
+  readonly removingTagType: boolean
+  readonly removeTagType: (type: TagType) => void
+  readonly restoreTagType?: (type: TagType) => void
+  readonly addingTags: readonly Tag[]
+  readonly removingTags: readonly Tag[]
+  readonly addTag: (type: TagType, tag: Tag) => void
+  readonly removeTag: (type: TagType, tag: Tag) => void
+  readonly restoreTag?: (type: TagType, tag: Tag) => void
 }
 
 export default MediumItemMetadataTagGroupEdit

--- a/ui/src/components/MediumItemMetadataTagList/index.tsx
+++ b/ui/src/components/MediumItemMetadataTagList/index.tsx
@@ -21,7 +21,7 @@ const MediumItemMetadataTagList: FunctionComponent<MediumItemMetadataTagListProp
   }, [ edit ])
 
   const tags = medium.tags ?? []
-  const groups = tags.reduce<TagGroup[]>((groups, { tag, type }) => {
+  const groups: readonly ReadonlyTagGroup[] = tags.reduce<TagGroup[]>((groups, { tag, type }) => {
     const group = groups.find(t => t.type.id === type.id)
     if (group) {
       group.tags.push(tag)
@@ -65,8 +65,13 @@ const MediumItemMetadataTagList: FunctionComponent<MediumItemMetadataTagListProp
 }
 
 export interface MediumItemMetadataTagListProps {
-  medium: Medium
-  edit: () => void
+  readonly medium: Medium
+  readonly edit: () => void
+}
+
+interface ReadonlyTagGroup {
+  readonly type: TagType
+  readonly tags: readonly Tag[]
 }
 
 interface TagGroup {

--- a/ui/src/components/MediumItemReplicaDeleteDialogBody/index.tsx
+++ b/ui/src/components/MediumItemReplicaDeleteDialogBody/index.tsx
@@ -54,8 +54,8 @@ const MediumItemReplicaDeleteDialogBody: FunctionComponent<MediumItemReplicaDele
 }
 
 export interface MediumItemReplicaDeleteDialogBodyProps {
-  save: (deleteObject: boolean) => void
-  close: () => void
+  readonly save: (deleteObject: boolean) => void
+  readonly close: () => void
 }
 
 export default MediumItemReplicaDeleteDialogBody

--- a/ui/src/components/MediumItemViewBody/index.tsx
+++ b/ui/src/components/MediumItemViewBody/index.tsx
@@ -29,7 +29,7 @@ import type { Medium, Replica } from '@/types'
 
 import styles from './styles.module.scss'
 
-const hasChanges = (medium: Medium, replicas: (Replica | ReplicaCreate)[], removingReplicas: Replica[]) => {
+const hasChanges = (medium: Medium, replicas: readonly (Replica | ReplicaCreate)[], removingReplicas: readonly Replica[]) => {
   if (medium.replicas?.length !== replicas.length || removingReplicas.length > 0) {
     return true
   }
@@ -64,8 +64,8 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
   const [ editingSources, setEditingSources ] = useState(false)
   const [ editingTags, setEditingTags ] = useState(false)
 
-  const [ replicas, setReplicas ] = useState<(Replica | ReplicaCreate)[]>(medium.replicas)
-  const [ removingReplicas, setRemovingReplicas ] = useState<Replica[]>([])
+  const [ replicas, setReplicas ] = useState<readonly (Replica | ReplicaCreate)[]>(medium.replicas)
+  const [ removingReplicas, setRemovingReplicas ] = useState<readonly Replica[]>([])
   const [ deletingObjects, setDeletingObjects ] = useState<MediumDeleteObjects | null>(null)
 
   const [ uploading, setUploading ] = useState(false)
@@ -168,8 +168,8 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
     }
   }, [])
 
-  const handleComplete = useCallback(async (current: Medium, replicas: (Replica | ReplicaCreate)[]) => {
-    const processed = (replicas: (Replica | ReplicaCreate)[]) => replicas.every(isReplica)
+  const handleComplete = useCallback(async (current: Medium, replicas: readonly (Replica | ReplicaCreate)[]) => {
+    const processed = (replicas: readonly (Replica | ReplicaCreate)[]) => replicas.every(isReplica)
     if (!processed(replicas)) {
       setReplicas(replicas)
       updateMedium({
@@ -237,13 +237,13 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
     }
   }, [ replicas, handleComplete ])
 
-  const saveTags = useCallback((id: string, addTagTagTypeIDs: TagTagTypeInput[], removeTagTagTypeIDs: TagTagTypeInput[]) => updateMedium({
+  const saveTags = useCallback((id: string, addTagTagTypeIDs: readonly TagTagTypeInput[], removeTagTagTypeIDs: readonly TagTagTypeInput[]) => updateMedium({
     id,
     addTagTagTypeIDs,
     removeTagTagTypeIDs,
   }), [ updateMedium ])
 
-  const saveSources = useCallback((id: string, addSourceIDs: string[], removeSourceIDs: string[]) => updateMedium({
+  const saveSources = useCallback((id: string, addSourceIDs: readonly string[], removeSourceIDs: readonly string[]) => updateMedium({
     id,
     addSourceIDs,
     removeSourceIDs,
@@ -345,12 +345,12 @@ const MediumItemViewBody: FunctionComponent<MediumItemViewBodyProps> = ({
 }
 
 export interface MediumItemViewBodyProps {
-  id: string
+  readonly id: string
 }
 
 interface MediumDeleteObjects {
-  onConfirm: (result: boolean) => void
-  onCancel: () => void
+  readonly onConfirm: (result: boolean) => void
+  readonly onCancel: () => void
 }
 
 export default MediumItemViewBody

--- a/ui/src/components/MediumList/index.tsx
+++ b/ui/src/components/MediumList/index.tsx
@@ -17,11 +17,11 @@ const MediumList: FunctionComponent<MediumListProps> = ({
 )
 
 export interface MediumListProps {
-  number: number
-  sources?: Source[]
-  tagTagTypes?: {
-    tag: Tag
-    type: TagType
+  readonly number: number
+  readonly sources?: readonly Source[]
+  readonly tagTagTypes?: readonly {
+    readonly tag: Tag
+    readonly type: TagType
   }[]
 }
 

--- a/ui/src/components/MediumListItem/index.tsx
+++ b/ui/src/components/MediumListItem/index.tsx
@@ -23,8 +23,8 @@ export const MediumListItem: FunctionComponent<MediumListItemProps> = ({
 )
 
 export interface MediumListItemProps {
-  medium: Medium
-  size: number
+  readonly medium: Medium
+  readonly size: number
 }
 
 export default MediumListItem

--- a/ui/src/components/MediumListItemCount/index.tsx
+++ b/ui/src/components/MediumListItemCount/index.tsx
@@ -40,7 +40,7 @@ const MediumListItemCount: FunctionComponent<MediumListItemCountProps> = ({
 }
 
 export interface MediumListItemCountProps extends SvgIconProps {
-  count?: number | null
+  readonly count?: number | null
 }
 
 export default MediumListItemCount

--- a/ui/src/components/MediumListItemThumbnail/index.tsx
+++ b/ui/src/components/MediumListItemThumbnail/index.tsx
@@ -29,8 +29,8 @@ const MediumListItemThumbnail: FunctionComponent<MediumListItemThumbnailProps> =
 )
 
 export interface MediumListItemThumbnailProps {
-  replica?: Replica
-  size: number
+  readonly replica?: Replica
+  readonly size: number
 }
 
 export default MediumListItemThumbnail

--- a/ui/src/components/MediumListViewBody/index.tsx
+++ b/ui/src/components/MediumListViewBody/index.tsx
@@ -65,11 +65,11 @@ const MediumListViewBody: FunctionComponent<MediumListViewBodyProps> = ({
 }
 
 export interface MediumListViewBodyProps {
-  number: number
-  sources?: Source[]
-  tagTagTypes?: {
-    tag: Tag
-    type: TagType
+  readonly number: number
+  readonly sources?: readonly Source[]
+  readonly tagTagTypes?: readonly {
+    readonly tag: Tag
+    readonly type: TagType
   }[]
 }
 

--- a/ui/src/components/SearchBar/index.tsx
+++ b/ui/src/components/SearchBar/index.tsx
@@ -61,14 +61,14 @@ const SearchBar: FunctionComponent<SearchBarProps> = ({
     </li>
   ), [])
 
-  const renderMetadataValue = useCallback((metadata: Metadata[], getTagProps: AutocompleteRenderValueGetItemProps<true>) => metadata.map((option, index) => {
+  const renderMetadataValue = useCallback((metadata: readonly Metadata[], getTagProps: AutocompleteRenderValueGetItemProps<true>) => metadata.map((option, index) => {
     const { key, ...props } = getTagProps({ index })
     return (
       <Chip key={key} label={<MetadataOption className={styles.chip} metadata={option} />} {...props} />
     )
   }), [])
 
-  const handleChange = useCallback((metadata: Metadata[]) => {
+  const handleChange = useCallback((metadata: readonly Metadata[]) => {
     setInputValue('')
 
     const option = metadata[metadata.length - 1]
@@ -154,12 +154,12 @@ const SearchBar: FunctionComponent<SearchBarProps> = ({
 }
 
 interface MetadataOptionProps {
-  className?: string
-  metadata: Metadata
+  readonly className?: string
+  readonly metadata: Metadata
 }
 
 export interface SearchBarProps {
-  className?: string
+  readonly className?: string
 }
 
 export default SearchBar

--- a/ui/src/components/SearchQueryList/index.tsx
+++ b/ui/src/components/SearchQueryList/index.tsx
@@ -50,10 +50,10 @@ const SearchQueryList: FunctionComponent<SearchQueryListProps> = ({
 }
 
 export interface SearchQueryListProps {
-  sources?: Source[]
-  tagTagTypes?: {
-    tag: Tag
-    type: TagType
+  readonly sources?: readonly Source[]
+  readonly tagTagTypes?: readonly {
+    readonly tag: Tag
+    readonly type: TagType
   }[]
 }
 

--- a/ui/src/components/SourceURL/builder.ts
+++ b/ui/src/components/SourceURL/builder.ts
@@ -156,6 +156,6 @@ export const buildURL = (externalService: ExternalService, externalMetadata: Rec
 }
 
 interface Builder<Kind extends string, Metadata extends Record<Kind, unknown>> {
-  kind: Kind
-  build: (externalService: ExternalService, params: Partial<Metadata[Kind]>) => string | null
+  readonly kind: Kind
+  readonly build: (externalService: ExternalService, params: Partial<Metadata[Kind]>) => string | null
 }

--- a/ui/src/components/SourceURL/index.tsx
+++ b/ui/src/components/SourceURL/index.tsx
@@ -73,19 +73,19 @@ const SourceURL: FunctionComponent<SourceURLProps> = ({
 }
 
 interface SourceURLPropsBase {
-  className?: string
-  icon?: ComponentType<SvgIconProps>
-  noLink?: boolean
-  noLaunch?: boolean
+  readonly className?: string
+  readonly icon?: ComponentType<SvgIconProps>
+  readonly noLink?: boolean
+  readonly noLaunch?: boolean
 }
 
 interface SourceURLPropsBySource extends SourceURLPropsBase {
-  source: Source
+  readonly source: Source
 }
 
 interface SourceURLPropsByExternalMetadata extends SourceURLPropsBase {
-  externalService: ExternalService
-  externalMetadata: unknown
+  readonly externalService: ExternalService
+  readonly externalMetadata: unknown
 }
 
 export type SourceURLProps = SourceURLPropsBySource | SourceURLPropsByExternalMetadata

--- a/ui/src/components/TagBreadcrumbsListBody/index.tsx
+++ b/ui/src/components/TagBreadcrumbsListBody/index.tsx
@@ -82,18 +82,18 @@ const TagBreadcrumbsListBody: FunctionComponent<TagBreadcrumbsListBodyProps> = (
 }
 
 interface TagBreadcrumbsListBodyPropsBase {
-  className?: string
-  root?: boolean
-  parent?: boolean
-  noWrap?: boolean
+  readonly className?: string
+  readonly root?: boolean
+  readonly parent?: boolean
+  readonly noWrap?: boolean
 }
 
 interface TagBreadcrumbsListBodyPropsByTag extends TagBreadcrumbsListBodyPropsBase {
-  tag: Tag
+  readonly tag: Tag
 }
 
 interface TagBreadcrumbsListBodyPropsByTagID extends TagBreadcrumbsListBodyPropsBase {
-  id: string
+  readonly id: string
 }
 
 export type TagBreadcrumbsListBodyProps = TagBreadcrumbsListBodyPropsBase | TagBreadcrumbsListBodyPropsByTag | TagBreadcrumbsListBodyPropsByTagID

--- a/ui/src/components/TagDeleteDialogBody/index.tsx
+++ b/ui/src/components/TagDeleteDialogBody/index.tsx
@@ -109,9 +109,9 @@ const TagDeleteDialogBody: FunctionComponent<TagDeleteDialogBodyProps> = ({
 }
 
 export interface TagDeleteDialogBodyProps {
-  tag: Tag
-  close: () => void
-  onDelete: (tag: Tag) => void
+  readonly tag: Tag
+  readonly close: () => void
+  readonly onDelete: (tag: Tag) => void
 }
 
 export default TagDeleteDialogBody

--- a/ui/src/components/TagDeleteDialogError/index.tsx
+++ b/ui/src/components/TagDeleteDialogError/index.tsx
@@ -20,7 +20,7 @@ const TagDeleteDialogError: FunctionComponent<TagDeleteDialogErrorProps> = ({
 )
 
 export interface TagDeleteDialogErrorProps {
-  close: () => void
+  readonly close: () => void
 }
 
 export default TagDeleteDialogError

--- a/ui/src/components/TagListColumn/index.tsx
+++ b/ui/src/components/TagListColumn/index.tsx
@@ -54,9 +54,9 @@ const TagListColumn: FunctionComponent<TagListColumnProps> = ({
 }
 
 export interface TagListColumnProps extends GridProps {
-  className?: string
-  focus?: boolean
-  children?: ReactNode
+  readonly className?: string
+  readonly focus?: boolean
+  readonly children?: ReactNode
 }
 
 export default TagListColumn

--- a/ui/src/components/TagListColumnBodyCreate/index.tsx
+++ b/ui/src/components/TagListColumnBodyCreate/index.tsx
@@ -41,7 +41,7 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
   })
 
   const [ kanaChanged, setKanaChanged ] = useState(false)
-  const [ nameHistory, setNameHistory ] = useState<string[]>([])
+  const [ nameHistory, setNameHistory ] = useState<readonly string[]>([])
 
   const handleChangeName = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const name = e.currentTarget.value
@@ -69,7 +69,7 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
     }))
   }, [])
 
-  const handleChangeAliases = useCallback((_e: SyntheticEvent, value: string[]) => {
+  const handleChangeAliases = useCallback((_e: SyntheticEvent, value: readonly string[]) => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const aliases = value.toSorted(collator.compare)
     setTag(tag => ({
@@ -122,7 +122,7 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
         <Autocomplete
           options={[]}
           disabled={loading}
-          value={tag.aliases}
+          value={tag.aliases as string[]}
           multiple
           freeSolo
           autoSelect
@@ -168,10 +168,10 @@ const TagListColumnBodyCreate: FunctionComponent<TagListColumnBodyCreateProps> =
 }
 
 export interface TagListColumnBodyCreateProps {
-  parent: Tag | null
-  close: () => void
-  onCreating?: () => void
-  onCreate?: (tag: Tag) => void
+  readonly parent: Tag | null
+  readonly close: () => void
+  readonly onCreating?: () => void
+  readonly onCreate?: (tag: Tag) => void
 }
 
 type TagCreate = Omit<Tag, 'id' | 'parent' | 'children'>

--- a/ui/src/components/TagListColumnBodyEdit/index.tsx
+++ b/ui/src/components/TagListColumnBodyEdit/index.tsx
@@ -64,7 +64,7 @@ const TagListColumnBodyEdit: FunctionComponent<TagListColumnBodyEditProps> = ({
     }))
   }, [])
 
-  const handleChangeAliases = useCallback((_e: SyntheticEvent, value: string[]) => {
+  const handleChangeAliases = useCallback((_e: SyntheticEvent, value: readonly string[]) => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const aliases = value.toSorted(collator.compare)
     setTag(tag => ({
@@ -127,7 +127,7 @@ const TagListColumnBodyEdit: FunctionComponent<TagListColumnBodyEditProps> = ({
         <Autocomplete
           options={current.aliases.filter(alias => !tag.aliases.includes(alias))}
           disabled={loading}
-          value={tag.aliases}
+          value={tag.aliases as string[]}
           multiple
           freeSolo
           autoSelect
@@ -180,9 +180,9 @@ const TagListColumnBodyEdit: FunctionComponent<TagListColumnBodyEditProps> = ({
 }
 
 export interface TagListColumnBodyEditProps {
-  tag: Tag
-  close: () => void
-  onMove: (tag: Tag) => void
+  readonly tag: Tag
+  readonly close: () => void
+  readonly onMove: (tag: Tag) => void
 }
 
 export default TagListColumnBodyEdit

--- a/ui/src/components/TagListColumnBodyList/index.tsx
+++ b/ui/src/components/TagListColumnBodyList/index.tsx
@@ -146,7 +146,7 @@ const TagListColumnBodyList: FunctionComponent<TagListColumnBodyListProps> = ({
     e.stopPropagation()
   }, [])
 
-  const tagSecondaryNode = useCallback((kana: string, aliases: string[]) => {
+  const tagSecondaryNode = useCallback((kana: string, aliases: readonly string[]) => {
     if (!kana && !aliases.length) {
       return null
     }
@@ -207,7 +207,7 @@ const TagListColumnBodyList: FunctionComponent<TagListColumnBodyListProps> = ({
     handleClickDeleteTag,
   ])
 
-  const renderTagItems = useCallback((tags: Tag[], hasNextPage?: boolean, fetchMore?: () => Promise<void>) => (
+  const renderTagItems = useCallback((tags: readonly Tag[], hasNextPage?: boolean, fetchMore?: () => Promise<void>) => (
     <List ref={ref} className={styles.tags} dense={dense}>
       {tags.map(tag => renderTagItem(tag))}
       {active && tags.every(({ id }) => id !== active.id) ? renderTagItem(active) : null}
@@ -299,30 +299,30 @@ const TagListColumnBodyList: FunctionComponent<TagListColumnBodyListProps> = ({
 }
 
 export interface TagColumn {
-  index: number
-  creating: boolean
-  editing: Tag | null
-  selected: boolean
-  parent: Tag | null
-  active: Tag | null
-  hit: Tag | null
-  hitInput: string
+  readonly index: number
+  readonly creating: boolean
+  readonly editing: Tag | null
+  readonly selected: boolean
+  readonly parent: Tag | null
+  readonly active: Tag | null
+  readonly hit: Tag | null
+  readonly hitInput: string
 }
 
 export type TagColumnSelectable = 'column' | 'tag'
 
 export interface TagListColumnBodyListProps extends TagColumn {
-  readonly: boolean
-  dense: boolean
-  selectable?: TagColumnSelectable
-  disabled?: (tag: Tag) => boolean
-  onHit?: (tag: Tag | null) => void
-  onSelect?: (tag: Tag | null) => void
-  create: (parent: Tag | null, columnIndex: number) => void
-  edit: (tag: Tag, columnIndex: number) => void
-  delete: (tag: Tag, columnIndex: number) => void
-  setColumn: (column: TagColumn) => void
-  appendColumn: (column: TagColumn) => void
+  readonly readonly: boolean
+  readonly dense: boolean
+  readonly selectable?: TagColumnSelectable
+  readonly disabled?: (tag: Tag) => boolean
+  readonly onHit?: (tag: Tag | null) => void
+  readonly onSelect?: (tag: Tag | null) => void
+  readonly create: (parent: Tag | null, columnIndex: number) => void
+  readonly edit: (tag: Tag, columnIndex: number) => void
+  readonly delete: (tag: Tag, columnIndex: number) => void
+  readonly setColumn: (column: TagColumn) => void
+  readonly appendColumn: (column: TagColumn) => void
 }
 
 export default TagListColumnBodyList

--- a/ui/src/components/TagListColumnBodyListChildren/index.tsx
+++ b/ui/src/components/TagListColumnBodyListChildren/index.tsx
@@ -22,8 +22,8 @@ const TagListColumnBodyListChildren: FunctionComponent<TagListColumnBodyListChil
 }
 
 export interface TagListColumnBodyListChildrenProps {
-  id: string
-  component: (tags: Tag[]) => ReactNode
+  readonly id: string
+  readonly component: (tags: readonly Tag[]) => ReactNode
 }
 
 export default TagListColumnBodyListChildren

--- a/ui/src/components/TagListColumnBodyListItem/index.tsx
+++ b/ui/src/components/TagListColumnBodyListItem/index.tsx
@@ -50,14 +50,14 @@ const TagListColumnBodyListItem: FunctionComponent<TagListColumnBodyListItemProp
 )
 
 export interface TagListColumnBodyListItemProps {
-  className?: string
-  dense?: boolean
-  disabled?: boolean
-  selected?: boolean
-  primary?: ReactNode
-  secondary?: ReactNode
-  children?: ReactNode
-  onClick?: MouseEventHandler<HTMLElement>
+  readonly className?: string
+  readonly dense?: boolean
+  readonly disabled?: boolean
+  readonly selected?: boolean
+  readonly primary?: ReactNode
+  readonly secondary?: ReactNode
+  readonly children?: ReactNode
+  readonly onClick?: MouseEventHandler<HTMLElement>
 }
 
 export default TagListColumnBodyListItem

--- a/ui/src/components/TagListColumnBodyListRoot/index.tsx
+++ b/ui/src/components/TagListColumnBodyListRoot/index.tsx
@@ -23,8 +23,8 @@ const TagListColumnBodyListRoot: FunctionComponent<TagListColumnBodyListRootProp
 }
 
 export interface TagListColumnBodyListRootProps {
-  number: number
-  component: (tags: Tag[], hasNextPage: boolean, fetchMore: () => Promise<void>) => ReactNode
+  readonly number: number
+  readonly component: (tags: readonly Tag[], hasNextPage: boolean, fetchMore: () => Promise<void>) => ReactNode
 }
 
 export default TagListColumnBodyListRoot

--- a/ui/src/components/TagListView/index.tsx
+++ b/ui/src/components/TagListView/index.tsx
@@ -28,7 +28,7 @@ const TagListView: FunctionComponent<TagListViewProps> = ({
 )
 
 export interface TagListViewProps extends TagListViewBodyProps {
-  className?: string
+  readonly className?: string
 }
 
 export default TagListView

--- a/ui/src/components/TagListViewBody/index.tsx
+++ b/ui/src/components/TagListViewBody/index.tsx
@@ -65,7 +65,7 @@ const TagListViewBody: FunctionComponent<TagListViewBodyProps> = ({
     [ tag ],
   ) satisfies TagColumn[]
 
-  const [ columns, setColumns ] = useState<TagColumn[]>(initialColumns)
+  const [ columns, setColumns ] = useState<readonly TagColumn[]>(initialColumns)
   const [ creating, setCreating ] = useState(false)
 
   const [ selectedTag, setSelectedTag ] = useState<Tag | null>(null)
@@ -333,12 +333,12 @@ const TagListViewBody: FunctionComponent<TagListViewBodyProps> = ({
 }
 
 export interface TagListViewBodyProps {
-  initial?: Tag
-  readonly?: boolean
-  dense?: boolean
-  disabled?: (tag: Tag) => boolean
-  onSelect?: (tag: Tag | null) => void
-  selectable?: TagColumnSelectable
+  readonly initial?: Tag
+  readonly readonly?: boolean
+  readonly dense?: boolean
+  readonly disabled?: (tag: Tag) => boolean
+  readonly onSelect?: (tag: Tag | null) => void
+  readonly selectable?: TagColumnSelectable
 }
 
 export default TagListViewBody

--- a/ui/src/components/TagMoveDialogBody/index.tsx
+++ b/ui/src/components/TagMoveDialogBody/index.tsx
@@ -115,9 +115,9 @@ const TagMoveDialogBody: FunctionComponent<TagMoveDialogBodyProps> = ({
 }
 
 export interface TagMoveDialogBodyProps {
-  tag: Tag
-  close: () => void
-  onMove: (tag: Tag) => void
+  readonly tag: Tag
+  readonly close: () => void
+  readonly onMove: (tag: Tag) => void
 }
 
 export default TagMoveDialogBody

--- a/ui/src/components/TagMoveDialogError/index.tsx
+++ b/ui/src/components/TagMoveDialogError/index.tsx
@@ -20,7 +20,7 @@ const TagMoveDialogError: FunctionComponent<TagMoveDialogErrorProps> = ({
 )
 
 export interface TagMoveDialogErrorProps {
-  close: () => void
+  readonly close: () => void
 }
 
 export default TagMoveDialogError

--- a/ui/src/components/TagSelectDialogBody/index.tsx
+++ b/ui/src/components/TagSelectDialogBody/index.tsx
@@ -74,8 +74,8 @@ const TagSelectDialogBody: FunctionComponent<TagSelectDialogBodyProps> = ({
 }
 
 export interface TagSelectDialogBodyProps {
-  close: () => void
-  onSelect: (tag: Tag) => void
+  readonly close: () => void
+  readonly onSelect: (tag: Tag) => void
 }
 
 export default TagSelectDialogBody

--- a/ui/src/components/TagSelectDialogError/index.tsx
+++ b/ui/src/components/TagSelectDialogError/index.tsx
@@ -20,7 +20,7 @@ const TagSelectDialogError: FunctionComponent<TagSelectDialogErrorProps> = ({
 )
 
 export interface TagSelectDialogErrorProps {
-  close: () => void
+  readonly close: () => void
 }
 
 export default TagSelectDialogError

--- a/ui/src/components/TagTypeDeleteDialogBody/index.tsx
+++ b/ui/src/components/TagTypeDeleteDialogBody/index.tsx
@@ -55,9 +55,9 @@ const TagTypeDeleteDialogBody: FunctionComponent<TagTypeDeleteDialogBodyProps> =
 }
 
 export interface TagTypeDeleteDialogBodyProps {
-  tagType: TagType
-  close: () => void
-  onDelete: (tagType: TagType) => void
+  readonly tagType: TagType
+  readonly close: () => void
+  readonly onDelete: (tagType: TagType) => void
 }
 
 export default TagTypeDeleteDialogBody

--- a/ui/src/components/TagTypeListColumn/index.tsx
+++ b/ui/src/components/TagTypeListColumn/index.tsx
@@ -24,8 +24,8 @@ const TagTypeListColumn: FunctionComponent<TagTypeListColumnProps> = ({
 )
 
 export interface TagTypeListColumnProps extends GridProps {
-  className?: string
-  children?: ReactNode
+  readonly className?: string
+  readonly children?: ReactNode
 }
 
 export default TagTypeListColumn

--- a/ui/src/components/TagTypeListColumnBodyCreate/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyCreate/index.tsx
@@ -35,7 +35,7 @@ const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreate
   })
 
   const [ kanaChanged, setKanaChanged ] = useState(false)
-  const [ nameHistory, setNameHistory ] = useState<string[]>([])
+  const [ nameHistory, setNameHistory ] = useState<readonly string[]>([])
 
   const handleChangeName = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const name = e.currentTarget.value
@@ -155,7 +155,7 @@ const TagTypeListColumnBodyCreate: FunctionComponent<TagTypeListColumnBodyCreate
 }
 
 export interface TagTypeListColumnBodyCreateProps {
-  close: () => void
+  readonly close: () => void
 }
 
 type TagTypeCreate = Omit<TagType, 'id'>

--- a/ui/src/components/TagTypeListColumnBodyEdit/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyEdit/index.tsx
@@ -141,9 +141,9 @@ const TagTypeListColumnBodyEdit: FunctionComponent<TagTypeListColumnBodyEditProp
 }
 
 export interface TagTypeListColumnBodyEditProps {
-  tagType: TagType
-  close: () => void
-  onEdit: (tagType: TagType) => void
+  readonly tagType: TagType
+  readonly close: () => void
+  readonly onEdit: (tagType: TagType) => void
 }
 
 export default TagTypeListColumnBodyEdit

--- a/ui/src/components/TagTypeListColumnBodyList/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyList/index.tsx
@@ -200,24 +200,24 @@ const TagTypeListColumnBodyList: FunctionComponent<TagTypeListColumnBodyListProp
 }
 
 export interface TagTypeColumn {
-  creating: boolean
-  editing: TagType | null
-  active: TagType | null
-  hit: TagType | null
-  hitInput: string
+  readonly creating: boolean
+  readonly editing: TagType | null
+  readonly active: TagType | null
+  readonly hit: TagType | null
+  readonly hitInput: string
 }
 
 export interface TagTypeListColumnBodyListProps extends TagTypeColumn {
-  readonly: boolean
-  dense: boolean
-  disabled?: (tagType: TagType) => boolean
-  onHit?: (tagType: TagType | null) => void
-  onSelect?: (tagType: TagType) => void
-  create: () => void
-  show: (tagType: TagType) => void
-  edit: (tagType: TagType) => void
-  delete: (tagType: TagType) => void
-  setColumn: (column: TagTypeColumn) => void
+  readonly readonly: boolean
+  readonly dense: boolean
+  readonly disabled?: (tagType: TagType) => boolean
+  readonly onHit?: (tagType: TagType | null) => void
+  readonly onSelect?: (tagType: TagType) => void
+  readonly create: () => void
+  readonly show: (tagType: TagType) => void
+  readonly edit: (tagType: TagType) => void
+  readonly delete: (tagType: TagType) => void
+  readonly setColumn: (column: TagTypeColumn) => void
 }
 
 export default TagTypeListColumnBodyList

--- a/ui/src/components/TagTypeListColumnBodyListItem/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyListItem/index.tsx
@@ -46,14 +46,14 @@ const TagTypeListColumnBodyListItem: FunctionComponent<TagTypeListColumnBodyList
 )
 
 export interface TagTypeListColumnBodyListItemProps {
-  className?: string
-  dense?: boolean
-  disabled?: boolean
-  selected?: boolean
-  primary?: ReactNode
-  secondary?: ReactNode
-  children?: ReactNode
-  onClick?: MouseEventHandler<HTMLElement>
+  readonly className?: string
+  readonly dense?: boolean
+  readonly disabled?: boolean
+  readonly selected?: boolean
+  readonly primary?: ReactNode
+  readonly secondary?: ReactNode
+  readonly children?: ReactNode
+  readonly onClick?: MouseEventHandler<HTMLElement>
 }
 
 export default TagTypeListColumnBodyListItem

--- a/ui/src/components/TagTypeListColumnBodyShow/index.tsx
+++ b/ui/src/components/TagTypeListColumnBodyShow/index.tsx
@@ -57,8 +57,8 @@ const TagTypeListColumnBodyShow: FunctionComponent<TagTypeListColumnBodyShowProp
 }
 
 export interface TagTypeListColumnBodyShowProps {
-  tagType: TagType
-  edit: (tagType: TagType) => void
+  readonly tagType: TagType
+  readonly edit: (tagType: TagType) => void
 }
 
 export default TagTypeListColumnBodyShow

--- a/ui/src/components/TagTypeListView/index.tsx
+++ b/ui/src/components/TagTypeListView/index.tsx
@@ -187,12 +187,12 @@ const TagTypeListView: FunctionComponent<TagTypeListViewProps> = ({
 }
 
 export interface TagTypeListViewProps {
-  className?: string
-  initial?: TagType
-  readonly?: boolean
-  dense?: boolean
-  disabled?: (tagType: TagType) => boolean
-  onSelect?: (tagType: TagType) => void
+  readonly className?: string
+  readonly initial?: TagType
+  readonly readonly?: boolean
+  readonly dense?: boolean
+  readonly disabled?: (tagType: TagType) => boolean
+  readonly onSelect?: (tagType: TagType) => void
 }
 
 export default TagTypeListView

--- a/ui/src/components/ThemeRegistry/index.tsx
+++ b/ui/src/components/ThemeRegistry/index.tsx
@@ -23,7 +23,7 @@ const ThemeRegistry: FunctionComponent<ThemeRegistryProps> = ({
 )
 
 export interface ThemeRegistryProps {
-  children: ReactNode
+  readonly children: ReactNode
 }
 
 export default ThemeRegistry

--- a/ui/src/contexts/search/index.tsx
+++ b/ui/src/contexts/search/index.tsx
@@ -84,19 +84,19 @@ export const SearchProvider: FunctionComponent<SearchProviderProps> = ({
 }
 
 export interface SearchQuery {
-  sourceID?: string
-  tagTagTypeIDs?: {
-    tagID: string
-    typeID: string
+  readonly sourceID?: string
+  readonly tagTagTypeIDs?: readonly {
+    readonly tagID: string
+    readonly typeID: string
   }[]
 }
 
 export interface SearchState {
-  appendQuery: (query: SearchQuery) => void
-  removeQuery: (query: SearchQuery) => void
-  clearQuery: () => void
+  readonly appendQuery: (query: SearchQuery) => void
+  readonly removeQuery: (query: SearchQuery) => void
+  readonly clearQuery: () => void
 }
 
 export interface SearchProviderProps {
-  children: ReactNode
+  readonly children: ReactNode
 }

--- a/ui/src/hooks/useCreateReplica/index.ts
+++ b/ui/src/hooks/useCreateReplica/index.ts
@@ -34,6 +34,6 @@ export function useCreateReplica(): [
 }
 
 export interface CreateReplicaOptions {
-  signal?: AbortSignal
-  onUploadProgress?: (e: ProgressEvent) => void
+  readonly signal?: AbortSignal
+  readonly onUploadProgress?: (e: ProgressEvent) => void
 }

--- a/ui/src/hooks/useError/ExternalServiceNotFound.ts
+++ b/ui/src/hooks/useError/ExternalServiceNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const EXTERNAL_SERVICE_NOT_FOUND = 'EXTERNAL_SERVICE_NOT_FOUND'
 
 export interface ExternalServiceNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof EXTERNAL_SERVICE_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof EXTERNAL_SERVICE_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/ExternalServiceSlugDuplicate.ts
+++ b/ui/src/hooks/useError/ExternalServiceSlugDuplicate.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const EXTERNAL_SERVICE_SLUG_DUPLICATE = 'EXTERNAL_SERVICE_SLUG_DUPLICATE'
 
 export interface ExternalServiceSlugDuplicate extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof EXTERNAL_SERVICE_SLUG_DUPLICATE
-      data: {
-        slug: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof EXTERNAL_SERVICE_SLUG_DUPLICATE
+      readonly data: {
+        readonly slug: string
       }
     }
   }

--- a/ui/src/hooks/useError/ExternalServiceUrlPatternInvalid.ts
+++ b/ui/src/hooks/useError/ExternalServiceUrlPatternInvalid.ts
@@ -3,12 +3,12 @@ import type { GraphQLError } from 'graphql'
 export const EXTERNAL_SERVICE_URL_PATTERN_INVALID = 'EXTERNAL_SERVICE_URL_PATTERN_INVALID'
 
 export interface ExternalServiceUrlPatternInvalid extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof EXTERNAL_SERVICE_URL_PATTERN_INVALID
-      data: {
-        urlPattern: string
-        description: string | null
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof EXTERNAL_SERVICE_URL_PATTERN_INVALID
+      readonly data: {
+        readonly urlPattern: string
+        readonly description: string | null
       }
     }
   }

--- a/ui/src/hooks/useError/MediumNotFound.ts
+++ b/ui/src/hooks/useError/MediumNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_NOT_FOUND = 'MEDIUM_NOT_FOUND'
 
 export interface MediumNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/MediumReplicaDecodeFailed.ts
+++ b/ui/src/hooks/useError/MediumReplicaDecodeFailed.ts
@@ -3,9 +3,9 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_REPLICA_DECODE_FAILED = 'MEDIUM_REPLICA_DECODE_FAILED'
 
 export interface MediumReplicaDecodeFailed extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_REPLICA_DECODE_FAILED
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_REPLICA_DECODE_FAILED
     }
   }
 }

--- a/ui/src/hooks/useError/MediumReplicaEncodeFailed.ts
+++ b/ui/src/hooks/useError/MediumReplicaEncodeFailed.ts
@@ -3,9 +3,9 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_REPLICA_ENCODE_FAILED = 'MEDIUM_REPLICA_ENCODE_FAILED'
 
 export interface MediumReplicaEncodeFailed extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_REPLICA_ENCODE_FAILED
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_REPLICA_ENCODE_FAILED
     }
   }
 }

--- a/ui/src/hooks/useError/MediumReplicaReadFailed.ts
+++ b/ui/src/hooks/useError/MediumReplicaReadFailed.ts
@@ -3,9 +3,9 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_REPLICA_READ_FAILED = 'MEDIUM_REPLICA_READ_FAILED'
 
 export interface MediumReplicaReadFailed extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_REPLICA_READ_FAILED
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_REPLICA_READ_FAILED
     }
   }
 }

--- a/ui/src/hooks/useError/MediumReplicaUnsupported.ts
+++ b/ui/src/hooks/useError/MediumReplicaUnsupported.ts
@@ -3,9 +3,9 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_REPLICA_UNSUPPORTED = 'MEDIUM_REPLICA_UNSUPPORTED'
 
 export interface MediumReplicaUnsupported extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_REPLICA_UNSUPPORTED
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_REPLICA_UNSUPPORTED
     }
   }
 }

--- a/ui/src/hooks/useError/MediumReplicasNotMatch.ts
+++ b/ui/src/hooks/useError/MediumReplicasNotMatch.ts
@@ -3,13 +3,13 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_REPLICAS_NOT_MATCH = 'MEDIUM_REPLICAS_NOT_MATCH'
 
 export interface MediumReplicasNotMatch extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_REPLICAS_NOT_MATCH
-      data: {
-        mediumId: string
-        expectedReplicas: string[]
-        actualReplicas: string[]
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_REPLICAS_NOT_MATCH
+      readonly data: {
+        readonly mediumId: string
+        readonly expectedReplicas: readonly string[]
+        readonly actualReplicas: readonly string[]
       }
     }
   }

--- a/ui/src/hooks/useError/MediumSourceNotFound.ts
+++ b/ui/src/hooks/useError/MediumSourceNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_SOURCE_NOT_FOUND = 'MEDIUM_SOURCE_NOT_FOUND'
 
 export interface MediumSourceNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_SOURCE_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_SOURCE_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/MediumTagNotFound.ts
+++ b/ui/src/hooks/useError/MediumTagNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const MEDIUM_TAG_NOT_FOUND = 'MEDIUM_TAG_NOT_FOUND'
 
 export interface MediumTagNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof MEDIUM_TAG_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof MEDIUM_TAG_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/ObjectAlreadyExists.ts
+++ b/ui/src/hooks/useError/ObjectAlreadyExists.ts
@@ -3,20 +3,20 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_ALREADY_EXISTS = 'OBJECT_ALREADY_EXISTS'
 
 export interface ObjectAlreadyExists extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_ALREADY_EXISTS
-      data: {
-        url: string
-        entry: {
-          name: string
-          url: string
-          kind: string
-          metadata: {
-            size: number
-            createdAt: string | null
-            updatedAt: string | null
-            accessedAt: string | null
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_ALREADY_EXISTS
+      readonly data: {
+        readonly url: string
+        readonly entry: {
+          readonly name: string
+          readonly url: string
+          readonly kind: string
+          readonly metadata: {
+            readonly size: number
+            readonly createdAt: string | null
+            readonly updatedAt: string | null
+            readonly accessedAt: string | null
           } | null
         } | null
       }

--- a/ui/src/hooks/useError/ObjectDeleteFailed.ts
+++ b/ui/src/hooks/useError/ObjectDeleteFailed.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_DELETE_FAILED = 'OBJECT_DELETE_FAILED'
 
 export interface ObjectDeleteFailed extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_DELETE_FAILED
-      data: {
-        url: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_DELETE_FAILED
+      readonly data: {
+        readonly url: string
       }
     }
   }

--- a/ui/src/hooks/useError/ObjectGetFailed.ts
+++ b/ui/src/hooks/useError/ObjectGetFailed.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_GET_FAILED = 'OBJECT_GET_FAILED'
 
 export interface ObjectGetFailed extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_GET_FAILED
-      data: {
-        url: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_GET_FAILED
+      readonly data: {
+        readonly url: string
       }
     }
   }

--- a/ui/src/hooks/useError/ObjectListFailed.ts
+++ b/ui/src/hooks/useError/ObjectListFailed.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_LIST_FAILED = 'OBJECT_LIST_FAILED'
 
 export interface ObjectListFailed extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_LIST_FAILED
-      data: {
-        url: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_LIST_FAILED
+      readonly data: {
+        readonly url: string
       }
     }
   }

--- a/ui/src/hooks/useError/ObjectNotFound.ts
+++ b/ui/src/hooks/useError/ObjectNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_NOT_FOUND = 'OBJECT_NOT_FOUND'
 
 export interface ObjectNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_NOT_FOUND
-      data: {
-        url: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_NOT_FOUND
+      readonly data: {
+        readonly url: string
       }
     }
   }

--- a/ui/src/hooks/useError/ObjectPathInvalid.ts
+++ b/ui/src/hooks/useError/ObjectPathInvalid.ts
@@ -3,9 +3,9 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_PATH_INVALID = 'OBJECT_PATH_INVALID'
 
 export interface ObjectPathInvalid extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_PATH_INVALID
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_PATH_INVALID
     }
   }
 }

--- a/ui/src/hooks/useError/ObjectPutFailed.ts
+++ b/ui/src/hooks/useError/ObjectPutFailed.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_PUT_FAILED = 'OBJECT_PUT_FAILED'
 
 export interface ObjectPutFailed extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_PUT_FAILED
-      data: {
-        url: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_PUT_FAILED
+      readonly data: {
+        readonly url: string
       }
     }
   }

--- a/ui/src/hooks/useError/ObjectUrlInvalid.ts
+++ b/ui/src/hooks/useError/ObjectUrlInvalid.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_URL_INVALID = 'OBJECT_URL_INVALID'
 
 export interface ObjectUrlInvalid extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_URL_INVALID
-      data: {
-        url: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_URL_INVALID
+      readonly data: {
+        readonly url: string
       }
     }
   }

--- a/ui/src/hooks/useError/ObjectUrlUnsupported.ts
+++ b/ui/src/hooks/useError/ObjectUrlUnsupported.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const OBJECT_URL_UNSUPPORTED = 'OBJECT_URL_UNSUPPORTED'
 
 export interface ObjectUrlUnsupported extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof OBJECT_URL_UNSUPPORTED
-      data: {
-        url: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof OBJECT_URL_UNSUPPORTED
+      readonly data: {
+        readonly url: string
       }
     }
   }

--- a/ui/src/hooks/useError/ReplicaNotFound.ts
+++ b/ui/src/hooks/useError/ReplicaNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const REPLICA_NOT_FOUND = 'REPLICA_NOT_FOUND'
 
 export interface ReplicaNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof REPLICA_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof REPLICA_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/ReplicaNotFoundByUrl.ts
+++ b/ui/src/hooks/useError/ReplicaNotFoundByUrl.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const REPLICA_NOT_FOUND_BY_URL = 'REPLICA_NOT_FOUND_BY_URL'
 
 export interface ReplicaNotFoundByUrl extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof REPLICA_NOT_FOUND_BY_URL
-      data: {
-        originalUrl: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof REPLICA_NOT_FOUND_BY_URL
+      readonly data: {
+        readonly originalUrl: string
       }
     }
   }

--- a/ui/src/hooks/useError/ReplicaOriginalUrlDuplicate.ts
+++ b/ui/src/hooks/useError/ReplicaOriginalUrlDuplicate.ts
@@ -3,20 +3,20 @@ import type { GraphQLError } from 'graphql'
 export const REPLICA_ORIGINAL_URL_DUPLICATE = 'REPLICA_ORIGINAL_URL_DUPLICATE'
 
 export interface ReplicaOriginalUrlDuplicate extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof REPLICA_ORIGINAL_URL_DUPLICATE
-      data: {
-        originalUrl: string
-        entry: {
-          name: string
-          url: string
-          kind: string
-          metadata: {
-            size: number
-            createdAt: string | null
-            updatedAt: string | null
-            accessedAt: string | null
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof REPLICA_ORIGINAL_URL_DUPLICATE
+      readonly data: {
+        readonly originalUrl: string
+        readonly entry: {
+          readonly name: string
+          readonly url: string
+          readonly kind: string
+          readonly metadata: {
+            readonly size: number
+            readonly createdAt: string | null
+            readonly updatedAt: string | null
+            readonly accessedAt: string | null
           } | null
         } | null
       }

--- a/ui/src/hooks/useError/SourceMetadataDuplicate.ts
+++ b/ui/src/hooks/useError/SourceMetadataDuplicate.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const SOURCE_METADATA_DUPLICATE = 'SOURCE_METADATA_DUPLICATE'
 
 export interface SourceMetadataDuplicate extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof SOURCE_METADATA_DUPLICATE
-      data: {
-        id: string | null
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof SOURCE_METADATA_DUPLICATE
+      readonly data: {
+        readonly id: string | null
       }
     }
   }

--- a/ui/src/hooks/useError/SourceMetadataInvalid.ts
+++ b/ui/src/hooks/useError/SourceMetadataInvalid.ts
@@ -3,9 +3,9 @@ import type { GraphQLError } from 'graphql'
 export const SOURCE_METADATA_INVALID = 'SOURCE_METADATA_INVALID'
 
 export interface SourceMetadataInvalid extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof SOURCE_METADATA_INVALID
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof SOURCE_METADATA_INVALID
     }
   }
 }

--- a/ui/src/hooks/useError/SourceMetadataNotMatch.ts
+++ b/ui/src/hooks/useError/SourceMetadataNotMatch.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const SOURCE_METADATA_NOT_MATCH = 'SOURCE_METADATA_NOT_MATCH'
 
 export interface SourceMetadataNotMatch extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof SOURCE_METADATA_NOT_MATCH
-      data: {
-        slug: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof SOURCE_METADATA_NOT_MATCH
+      readonly data: {
+        readonly slug: string
       }
     }
   }

--- a/ui/src/hooks/useError/SourceNotFound.ts
+++ b/ui/src/hooks/useError/SourceNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const SOURCE_NOT_FOUND = 'SOURCE_NOT_FOUND'
 
 export interface SourceNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof SOURCE_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof SOURCE_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/TagAttachingToDescendant.ts
+++ b/ui/src/hooks/useError/TagAttachingToDescendant.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const TAG_ATTACHING_TO_DESCENDANT = 'TAG_ATTACHING_TO_DESCENDANT'
 
 export interface TagAttachingToDescendant extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof TAG_ATTACHING_TO_DESCENDANT
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof TAG_ATTACHING_TO_DESCENDANT
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/TagAttachingToItself.ts
+++ b/ui/src/hooks/useError/TagAttachingToItself.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const TAG_ATTACHING_TO_ITSELF = 'TAG_ATTACHING_TO_ITSELF'
 
 export interface TagAttachingToItself extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof TAG_ATTACHING_TO_ITSELF
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof TAG_ATTACHING_TO_ITSELF
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/TagChildrenExist.ts
+++ b/ui/src/hooks/useError/TagChildrenExist.ts
@@ -3,12 +3,12 @@ import type { GraphQLError } from 'graphql'
 export const TAG_CHILDREN_EXIST = 'TAG_CHILDREN_EXIST'
 
 export interface TagChildrenExist extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof TAG_CHILDREN_EXIST
-      data: {
-        id: string
-        children: string[]
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof TAG_CHILDREN_EXIST
+      readonly data: {
+        readonly id: string
+        readonly children: readonly string[]
       }
     }
   }

--- a/ui/src/hooks/useError/TagNotFound.ts
+++ b/ui/src/hooks/useError/TagNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const TAG_NOT_FOUND = 'TAG_NOT_FOUND'
 
 export interface TagNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof TAG_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof TAG_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/TagTypeNotFound.ts
+++ b/ui/src/hooks/useError/TagTypeNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const TAG_TYPE_NOT_FOUND = 'TAG_TYPE_NOT_FOUND'
 
 export interface TagTypeNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof TAG_TYPE_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof TAG_TYPE_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useError/TagTypeSlugDuplicate.ts
+++ b/ui/src/hooks/useError/TagTypeSlugDuplicate.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const TAG_TYPE_SLUG_DUPLICATE = 'TAG_TYPE_SLUG_DUPLICATE'
 
 export interface TagTypeSlugDuplicate extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof TAG_TYPE_SLUG_DUPLICATE
-      data: {
-        slug: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof TAG_TYPE_SLUG_DUPLICATE
+      readonly data: {
+        readonly slug: string
       }
     }
   }

--- a/ui/src/hooks/useError/ThumbnailNotFound.ts
+++ b/ui/src/hooks/useError/ThumbnailNotFound.ts
@@ -3,11 +3,11 @@ import type { GraphQLError } from 'graphql'
 export const THUMBNAIL_NOT_FOUND = 'THUMBNAIL_NOT_FOUND'
 
 export interface ThumbnailNotFound extends GraphQLError {
-  extensions: {
-    details: {
-      code: typeof THUMBNAIL_NOT_FOUND
-      data: {
-        id: string
+  readonly extensions: {
+    readonly details: {
+      readonly code: typeof THUMBNAIL_NOT_FOUND
+      readonly data: {
+        readonly id: string
       }
     }
   }

--- a/ui/src/hooks/useFileSystemEntry/index.ts
+++ b/ui/src/hooks/useFileSystemEntry/index.ts
@@ -6,7 +6,7 @@ const isDirectoryEntry = (entry: FileSystemEntry): entry is FileSystemDirectoryE
 
 const isFileEntry = (entry: FileSystemEntry): entry is FileSystemFileEntry => entry.isFile
 
-function* walk(entries: (File | Folder)[]): Generator<File> {
+function* walk(entries: readonly (File | Folder)[]): Generator<File> {
   for (const entry of entries) {
     if (Array.isArray(entry)) {
       yield* walk(entry)
@@ -24,7 +24,7 @@ export function useFileSystemEntry<Flatten extends boolean | undefined>(options?
     for (;;) {
       signal?.throwIfAborted()
 
-      const value = await new Promise<FileSystemEntry[]>((resolve, reject) => reader.readEntries(resolve, reject))
+      const value = await new Promise<readonly FileSystemEntry[]>((resolve, reject) => reader.readEntries(resolve, reject))
       if (!value.length) {
         break
       }
@@ -61,8 +61,8 @@ export function useFileSystemEntry<Flatten extends boolean | undefined>(options?
 }
 
 export interface UseFileSystemEntryOptions<Flatten extends boolean | undefined> {
-  signal?: AbortSignal
-  flatten?: Flatten
+  readonly signal?: AbortSignal
+  readonly flatten?: Flatten
 }
 
 export type UseFileSystemEntryReturnValue<Flatten> = Flatten extends true ? File[] : (File | Folder)[]

--- a/ui/src/hooks/useHistorykana/index.ts
+++ b/ui/src/hooks/useHistorykana/index.ts
@@ -12,10 +12,10 @@ function postprocess(s: string): string {
   return s.replace(/[nｎ]$/, 'ん')
 }
 
-function extract(history: string[]): string {
+function extract(history: readonly string[]): string {
   return postprocess(historykana(history.map(preprocess), options))
 }
 
-export function useHistorykana(): (history: string[]) => string {
+export function useHistorykana(): (history: readonly string[]) => string {
   return extract
 }

--- a/ui/src/hooks/useMedia/index.ts
+++ b/ui/src/hooks/useMedia/index.ts
@@ -31,9 +31,9 @@ export function useMedia(number: number, options?: UseMediaOptions): [ Media, bo
 }
 
 export interface UseMediaOptions {
-  sourceIDs?: string[]
-  tagTagTypeIDs?: {
-    tagID: string
-    typeID: string
+  readonly sourceIDs?: readonly string[]
+  readonly tagTagTypeIDs?: readonly {
+    readonly tagID: string
+    readonly typeID: string
   }[]
 }

--- a/ui/src/hooks/useMetadataLike/index.ts
+++ b/ui/src/hooks/useMetadataLike/index.ts
@@ -5,11 +5,11 @@ import type { MetadataLikeQuery, MetadataLikeQueryVariables } from '@/graphql/Me
 import { MetadataLikeDocument } from '@/graphql/MetadataLike'
 
 export interface MetadataLike {
-  sources: {
-    id: MetadataLikeQuery['allSourcesLikeId']
-    url: MetadataLikeQuery['allSourcesLikeUrl']
+  readonly sources: {
+    readonly id: MetadataLikeQuery['allSourcesLikeId']
+    readonly url: MetadataLikeQuery['allSourcesLikeUrl']
   }
-  tags: MetadataLikeQuery['allTagsLike']
+  readonly tags: MetadataLikeQuery['allTagsLike']
 }
 
 export function useMetadataLike(variables: MetadataLikeQueryVariables | SkipToken): Partial<MetadataLike> {

--- a/ui/src/types/ExternalService.ts
+++ b/ui/src/types/ExternalService.ts
@@ -1,8 +1,8 @@
 export interface ExternalService {
-  id: string
-  slug: string
-  kind: string
-  name: string
-  baseUrl?: string | null
-  urlPattern?: string | null
+  readonly id: string
+  readonly slug: string
+  readonly kind: string
+  readonly name: string
+  readonly baseUrl?: string | null
+  readonly urlPattern?: string | null
 }

--- a/ui/src/types/Medium.ts
+++ b/ui/src/types/Medium.ts
@@ -1,15 +1,15 @@
 import type { Replica, Source, Tag, TagType } from '@/types'
 
 export interface TagTagType {
-  tag: Tag
-  type: TagType
+  readonly tag: Tag
+  readonly type: TagType
 }
 
 export interface Medium {
-  id: string
-  replicas?: Replica[]
-  sources?: Source[]
-  tags?: TagTagType[]
-  createdAt: string
-  updatedAt: string
+  readonly id: string
+  readonly replicas?: readonly Replica[]
+  readonly sources?: readonly Source[]
+  readonly tags?: readonly TagTagType[]
+  readonly createdAt: string
+  readonly updatedAt: string
 }

--- a/ui/src/types/Replica.ts
+++ b/ui/src/types/Replica.ts
@@ -1,22 +1,22 @@
 export interface Replica {
-  id: string
-  displayOrder: number
-  thumbnail?: {
-    id: string
-    width: number
-    height: number
-    url: string
-    createdAt: string
-    updatedAt: string
+  readonly id: string
+  readonly displayOrder: number
+  readonly thumbnail?: {
+    readonly id: string
+    readonly width: number
+    readonly height: number
+    readonly url: string
+    readonly createdAt: string
+    readonly updatedAt: string
   } | null
-  originalUrl: string
-  url?: string | null
-  mimeType?: string | null
-  width?: number | null
-  height?: number | null
-  status: {
-    phase: string
+  readonly originalUrl: string
+  readonly url?: string | null
+  readonly mimeType?: string | null
+  readonly width?: number | null
+  readonly height?: number | null
+  readonly status: {
+    readonly phase: string
   }
-  createdAt: string
-  updatedAt: string
+  readonly createdAt: string
+  readonly updatedAt: string
 }

--- a/ui/src/types/Source.ts
+++ b/ui/src/types/Source.ts
@@ -1,105 +1,105 @@
 import { ExternalService } from '@/types'
 
 export interface Source {
-  id: string
-  externalService: ExternalService
-  externalMetadata: unknown
-  url?: string | null
-  createdAt: string
-  updatedAt: string
+  readonly id: string
+  readonly externalService: ExternalService
+  readonly externalMetadata: unknown
+  readonly url?: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
 }
 
 export interface ExternalMetadataBluesky {
-  bluesky: {
-    id: string
-    creatorId: string
+  readonly bluesky: {
+    readonly id: string
+    readonly creatorId: string
   }
 }
 
 export interface ExternalMetadataFantia {
-  fantia: {
-    id: string
+  readonly fantia: {
+    readonly id: string
   }
 }
 
 export interface ExternalMetadataMastodon {
-  mastodon: {
-    id: string
-    creatorId: string
+  readonly mastodon: {
+    readonly id: string
+    readonly creatorId: string
   }
 }
 
 export interface ExternalMetadataMisskey {
-  misskey: {
-    id: string
+  readonly misskey: {
+    readonly id: string
   }
 }
 
 export interface ExternalMetadataNijie {
-  nijie: {
-    id: string
+  readonly nijie: {
+    readonly id: string
   }
 }
 
 export interface ExternalMetadataPixiv {
-  pixiv: {
-    id: string
+  readonly pixiv: {
+    readonly id: string
   }
 }
 
 export interface ExternalMetadataPixivFanbox {
-  pixiv_fanbox: {
-    id: string
-    creatorId: string
+  readonly pixiv_fanbox: {
+    readonly id: string
+    readonly creatorId: string
   }
 }
 
 export interface ExternalMetadataPleroma {
-  pleroma: {
-    id: string
+  readonly pleroma: {
+    readonly id: string
   }
 }
 
 export interface ExternalMetadataSeiga {
-  seiga: {
-    id: string
+  readonly seiga: {
+    readonly id: string
   }
 }
 
 export interface ExternalMetadataSkeb {
-  skeb: {
-    id: string
-    creatorId: string
+  readonly skeb: {
+    readonly id: string
+    readonly creatorId: string
   }
 }
 
 export interface ExternalMetadataThreads {
-  threads: {
-    id: string
-    creatorId?: string | null
+  readonly threads: {
+    readonly id: string
+    readonly creatorId?: string | null
   }
 }
 
 export interface ExternalMetadataWebsite {
-  website: {
-    url: string
+  readonly website: {
+    readonly url: string
   }
 }
 
 export interface ExternalMetadataX {
-  x: {
-    id: string
-    creatorId?: string | null
+  readonly x: {
+    readonly id: string
+    readonly creatorId?: string | null
   }
 }
 
 export interface ExternalMetadataXfolio {
-  xfolio: {
-    id: string
-    creatorId: string
+  readonly xfolio: {
+    readonly id: string
+    readonly creatorId: string
   }
 }
 
 export interface ExternalMetadataCustom {
-  custom: unknown
+  readonly custom: unknown
 }

--- a/ui/src/types/Tag.ts
+++ b/ui/src/types/Tag.ts
@@ -1,8 +1,8 @@
 export interface Tag {
-  id: string
-  name: string
-  kana: string
-  aliases: string[]
-  parent?: Tag | null
-  children?: Tag[]
+  readonly id: string
+  readonly name: string
+  readonly kana: string
+  readonly aliases: readonly string[]
+  readonly parent?: Tag | null
+  readonly children?: readonly Tag[]
 }

--- a/ui/src/types/TagType.ts
+++ b/ui/src/types/TagType.ts
@@ -1,6 +1,6 @@
 export interface TagType {
-  id: string
-  slug: string
-  name: string
-  kana: string
+  readonly id: string
+  readonly slug: string
+  readonly name: string
+  readonly kana: string
 }


### PR DESCRIPTION
This PR applies `readonly` to React states, parameters, and properties as well as fixes a bug that overwrites `Map` in React setter.