### PR TITLE
Fix the source not shown in URL

### DIFF
--- a/ui/src/components/SourceURL/builder.ts
+++ b/ui/src/components/SourceURL/builder.ts
@@ -147,8 +147,8 @@ const builders = [
 
 export const buildURL = (externalService: ExternalService, externalMetadata: Record<string, Record<string, unknown>>): string | null => {
   for (const { kind, build } of builders) {
-    if (externalService.kind === kind) {
-      return build(externalService, externalMetadata)
+    if (externalService.kind === kind && externalMetadata[kind]) {
+      return build(externalService, externalMetadata[kind])
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug in `<SourceURL />` (introduced in #986) to correctly show the source in URL.