### PR TITLE
Bump yarn from 4.9.4 to 4.10.2 in /ui

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.8.4",
   "private": true,
   "author": "Chitoku <odango@chitoku.jp>",
-  "packageManager": "yarn@4.9.4",
+  "packageManager": "yarn@4.10.2",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Bumps yarn from 4.9.4 to 4.10.2 in /ui.