### PR TITLE
Add a lint rule to disallow use of `Readonly<T>`

### DIFF
--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -69,6 +69,16 @@ const configs = defineConfig(
           },
         },
       ],
+      '@typescript-eslint/no-restricted-types': [
+        'error',
+        {
+          types: {
+            Readonly: {
+              message: 'Use `readonly`, `ReadonlyMap`, or `ReadonlySet`.',
+            },
+          },
+        },
+      ],
       '@typescript-eslint/no-unused-vars': [
         'error',
         {


### PR DESCRIPTION
This PR adds a rule to disallow use of `Readonly<T>` when linting.