### PR TITLE
Sort tags in queries when paginating

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -851,9 +851,9 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -2393,6 +2393,7 @@ dependencies = [
  "cow-utils",
  "derive_more",
  "domain",
+ "either",
  "futures",
  "include_dir",
  "ordermap",

--- a/api/crates/postgres/Cargo.toml
+++ b/api/crates/postgres/Cargo.toml
@@ -28,6 +28,9 @@ version = "0.1.3"
 version = "2.0.1"
 features = ["constructor", "from", "into"]
 
+[dependencies.either]
+version = "1.15.0"
+
 [dependencies.futures]
 version = "0.3.31"
 features = ["std"]


### PR DESCRIPTION
This PR fixes API to sort tags in SQL when paginating them. Related: #1037.