### PR TITLE
Add snapshot testing for SQLs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.snap linguist-generated=true
+*.snap linguist-language=toml

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -571,6 +571,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +869,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1206,6 +1224,12 @@ dependencies = [
  "tracing-futures",
  "uuid",
 ]
+
+[[package]]
+name = "guardian"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
@@ -1713,6 +1737,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "toml",
 ]
 
 [[package]]
@@ -2395,7 +2432,9 @@ dependencies = [
  "domain",
  "either",
  "futures",
+ "guardian",
  "include_dir",
+ "insta",
  "ordermap",
  "pretty_assertions",
  "sea-query",
@@ -2403,12 +2442,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sqlformat",
  "sqlx",
  "sqlx_migrator",
  "test-context",
  "tokio",
  "tracing",
  "tracing-futures",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -2995,6 +3036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3105,16 @@ checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0705994df478b895f05b8e290e0d46e53187b26f8d889d37b2a0881234922d94"
+dependencies = [
+ "unicode_categories",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -3652,6 +3709,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3665,7 +3731,7 @@ checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.11.4",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.0",
 ]
 
 [[package]]
@@ -3857,6 +3923,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "url"
@@ -4290,6 +4362,15 @@ name = "winnow"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]

--- a/api/crates/postgres/Cargo.toml
+++ b/api/crates/postgres/Cargo.toml
@@ -78,12 +78,22 @@ features = ["futures-03"]
 [dependencies.uuid]
 version = "1.18.1"
 
+[dev-dependencies.guardian]
+version = "1.3.0"
+
 [dev-dependencies.include_dir]
 version = "0.7.4"
+
+[dev-dependencies.insta]
+version = "1.43.2"
+features = ["toml"]
 
 [dev-dependencies.pretty_assertions]
 version = "1.4.1"
 features = ["unstable"]
+
+[dev-dependencies.sqlformat]
+version = "0.5.0"
 
 [dev-dependencies.test-context]
 version = "0.4.1"
@@ -91,3 +101,6 @@ version = "0.4.1"
 [dev-dependencies.tokio]
 version = "1.47.1"
 features = ["macros", "rt-multi-thread"]
+
+[dev-dependencies.tracing-subscriber]
+version = "0.3.20"

--- a/api/crates/postgres/tests/integration/external_services/delete_by_id.rs
+++ b/api/crates/postgres/tests/integration/external_services/delete_by_id.rs
@@ -2,10 +2,12 @@ use domain::{
     entity::external_services::ExternalServiceId,
     repository::{external_services::ExternalServicesRepository, DeleteResult},
 };
+use insta::assert_toml_snapshot;
 use postgres::external_services::PostgresExternalServicesRepository;
 use pretty_assertions::assert_eq;
 use sqlx::Row;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual, 1);
 
     let repository = PostgresExternalServicesRepository::new(ctx.pool.clone());
-    let actual = repository.delete_by_id(ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3"))).await.unwrap();
+    let actual = repository.delete_by_id(ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 
@@ -36,7 +38,9 @@ async fn succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual, 0);
 
-    let actual = repository.delete_by_id(ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3"))).await.unwrap();
+    let actual = repository.delete_by_id(ExternalServiceId::from(uuid!("4e0c68c7-e5ec-4d60-b9eb-733f47290cd3"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__create____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__create____test_context_wrapped_fails.snap
@@ -1,0 +1,25 @@
+---
+source: crates/postgres/tests/integration/external_services/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "external_services" (
+    "slug",
+    "kind",
+    "name",
+    "base_url",
+    "url_pattern"
+  )
+VALUES
+  ($1, $2, $3, $4, $5)
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__create____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__create____test_context_wrapped_succeeds.snap
@@ -1,0 +1,25 @@
+---
+source: crates/postgres/tests/integration/external_services/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "external_services" (
+    "slug",
+    "kind",
+    "name",
+    "base_url",
+    "url_pattern"
+  )
+VALUES
+  ($1, $2, $3, $4, $5)
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__delete_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__delete_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/external_services/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+DELETE FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__fetch_all____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__fetch_all____test_context_wrapped_succeeds.snap
@@ -1,0 +1,19 @@
+---
+source: crates/postgres/tests/integration/external_services/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+ORDER BY
+  "slug" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__fetch_by_ids____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__fetch_by_ids____test_context_wrapped_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/external_services/fetch_by_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" IN ($1, $2)
+ORDER BY
+  "slug" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_fails.snap
@@ -1,0 +1,20 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_all_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_all_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_base_url_remove_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_base_url_remove_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_base_url_set_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_base_url_set_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_name_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_name_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_slug_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_slug_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_url_pattern_remove_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_url_pattern_remove_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_url_pattern_set_succeeds.snap
+++ b/api/crates/postgres/tests/integration/external_services/snapshots/integration__external_services__update_by_id____test_context_wrapped_with_url_pattern_set_succeeds.snap
@@ -1,0 +1,46 @@
+---
+source: crates/postgres/tests/integration/external_services/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "external_services"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "base_url" = $3,
+  "url_pattern" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/main.rs
+++ b/api/crates/postgres/tests/integration/main.rs
@@ -1,5 +1,10 @@
+use std::{collections::HashMap, sync::{Arc, LazyLock, Mutex}};
+
+use guardian::ArcMutexGuardian;
 use include_dir::{include_dir, Dir};
 use postgres::Migrator;
+use serde::Serialize;
+use sqlformat::{Dialect, FormatOptions, QueryParams};
 use sqlx::{
     error::BoxDynError,
     postgres::{PgConnectOptions, PgPoolOptions},
@@ -7,6 +12,8 @@ use sqlx::{
 };
 use sqlx_migrator::migrator::{Migrate, Plan};
 use test_context::AsyncTestContext;
+use tracing::{field::{Field, Visit}, span::{Attributes, Id}, subscriber::Interest, Event, Level, Metadata, Span, Subscriber};
+use tracing_subscriber::{layer::{Context, SubscriberExt}, registry::LookupSpan, util::SubscriberInitExt};
 use uuid::Uuid;
 
 mod external_services;
@@ -18,7 +25,15 @@ mod tags;
 
 const FIXTURES: Dir = include_dir!("$CARGO_MANIFEST_DIR/tests/fixtures");
 
+static LAYER: LazyLock<Layer> = LazyLock::new(|| {
+    let layer = Layer::new("sqlx::query");
+    tracing_subscriber::registry().with(layer.clone()).try_init().unwrap();
+    layer
+});
+
 pub(crate) struct DatabaseContext {
+    pub layer: Layer,
+    pub span: Span,
     pub conn: PgConnection,
     pub pool: PgPool,
     pub name: String,
@@ -72,8 +87,164 @@ async fn drop_database(conn: &mut PgConnection, name: &str) -> Result<(), BoxDyn
     Ok(())
 }
 
+#[derive(Debug, Serialize)]
+struct Query {
+    sql: String,
+    rows_affected: u64,
+    rows_returned: u64,
+}
+
+impl Query {
+    fn new(sql: String, rows_affected: u64, rows_returned: u64) -> Self {
+        Self {
+            sql,
+            rows_affected,
+            rows_returned,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Queries {
+    queries: Vec<Query>,
+}
+
+impl Queries {
+    fn new(queries: Vec<Query>) -> Self {
+        Self {
+            queries,
+        }
+    }
+}
+
+type EventEntry = HashMap<&'static str, String>;
+
+struct Events<'a> {
+    id: &'a Id,
+    inner: ArcMutexGuardian<HashMap<Id, Vec<EventEntry>>>,
+}
+
+impl<'a> Events<'a> {
+    fn new(id: &'a Id, events: Arc<Mutex<HashMap<Id, Vec<EventEntry>>>>) -> Self {
+        Self {
+            id,
+            inner: ArcMutexGuardian::take(events).unwrap(),
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &'_ EventEntry> {
+        self.inner
+            .get(self.id)
+            .into_iter()
+            .flat_map(|i| i.iter())
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Layer {
+    target: &'static str,
+    spans: Arc<Mutex<HashMap<Id, Id>>>,
+    events: Arc<Mutex<HashMap<Id, Vec<EventEntry>>>>,
+}
+
+impl Layer {
+    fn new(target: &'static str) -> Self {
+        Self {
+            target,
+            ..Default::default()
+        }
+    }
+
+    fn events<'a>(&self, id: &'a Id) -> Events<'a> {
+        Events::new(id, self.events.clone())
+    }
+}
+
+impl<S> tracing_subscriber::Layer<S> for Layer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn register_callsite(&self, _metadata: &'static Metadata<'static>) -> Interest {
+        Interest::always()
+    }
+
+    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let Some(parent) = ctx.current_span().id().cloned() else { return };
+
+        let mut spans = self.spans.lock().unwrap();
+        spans.insert(id.clone(), parent);
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if event.metadata().target() != self.target {
+            return;
+        }
+
+        let Some(mut id) = ctx.current_span().id().cloned() else { return };
+
+        let mut visitor = Visitor::default();
+        event.record(&mut visitor);
+
+        let spans = self.spans.lock().unwrap();
+        while let Some(parent) = spans.get(&id) {
+            id = parent.clone();
+        }
+
+        let mut events = self.events.lock().unwrap();
+        events.entry(id).or_default().push(visitor.0);
+    }
+}
+
+#[derive(Default)]
+struct Visitor(HashMap<&'static str, String>);
+
+impl Visit for Visitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.0.insert(field.name(), format!("{value:?}"));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.insert(field.name(), value.to_string());
+    }
+}
+
+impl DatabaseContext {
+    pub fn format(&self, sql: &str) -> String {
+        sqlformat::format(sql, &QueryParams::None, &FormatOptions {
+            joins_as_top_level: true,
+            dialect: Dialect::PostgreSql,
+            ..Default::default()
+        })
+    }
+
+    pub fn queries(&self) -> Queries {
+        let id = self.span.id().unwrap();
+        let queries = self.layer
+            .events(&id)
+            .iter()
+            .map(|l| {
+                let statement = l.get("db.statement").map(String::as_ref);
+                let summary = l.get("summary").map(String::as_ref);
+                let rows_affected = l.get("rows_affected").unwrap().parse().unwrap();
+                let rows_returned = l.get("rows_returned").unwrap().parse().unwrap();
+                let sql = match (statement, summary) {
+                    (Some("") | None, Some(summary)) => summary,
+                    (Some(statement), _) => statement,
+                    (None, None) => "",
+                };
+                Query::new(self.format(sql), rows_affected, rows_returned)
+            })
+            .collect();
+
+        Queries::new(queries)
+    }
+}
+
 impl AsyncTestContext for DatabaseContext {
     async fn setup() -> Self {
+        let layer = LAYER.clone();
+        let span = tracing::span!(Level::DEBUG, "root");
+
         let name = format!("hoarder_{}", Uuid::new_v4());
         let mut conn = create_database(&name).await.unwrap();
 
@@ -86,7 +257,7 @@ impl AsyncTestContext for DatabaseContext {
         };
 
         match setup_database(&pool).await {
-            Ok(()) => Self { conn, pool, name },
+            Ok(()) => Self { layer, span, conn, pool, name },
             Err(e) => {
                 pool.close().await;
                 drop_database(&mut conn, &name).await.unwrap();

--- a/api/crates/postgres/tests/integration/media/delete_by_id.rs
+++ b/api/crates/postgres/tests/integration/media/delete_by_id.rs
@@ -2,10 +2,12 @@ use domain::{
     entity::media::MediumId,
     repository::{media::MediaRepository, DeleteResult},
 };
+use insta::assert_toml_snapshot;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use sqlx::Row;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual, 1);
 
     let repository = PostgresMediaRepository::new(ctx.pool.clone());
-    let actual = repository.delete_by_id(MediumId::from(uuid!("6356503d-6ab6-4e39-bb86-3311219c7fd1"))).await.unwrap();
+    let actual = repository.delete_by_id(MediumId::from(uuid!("6356503d-6ab6-4e39-bb86-3311219c7fd1"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 
@@ -36,7 +38,9 @@ async fn succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual, 0);
 
-    let actual = repository.delete_by_id(MediumId::from(uuid!("6356503d-6ab6-4e39-bb86-3311219c7fd1"))).await.unwrap();
+    let actual = repository.delete_by_id(MediumId::from(uuid!("6356503d-6ab6-4e39-bb86-3311219c7fd1"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_all.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_all.rs
@@ -3,10 +3,12 @@ use domain::{
     entity::media::{Medium, MediumId},
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -51,6 +53,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -65,7 +69,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -93,6 +97,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -107,7 +113,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -135,6 +141,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -149,7 +157,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -177,6 +185,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -191,7 +201,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -211,6 +221,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -225,7 +237,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -253,4 +265,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
@@ -6,10 +6,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -26,7 +28,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -100,6 +102,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -114,7 +118,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -189,6 +193,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -203,7 +209,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -299,6 +305,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -313,7 +321,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -420,6 +428,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -434,7 +444,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -477,6 +487,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -491,7 +503,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -587,4 +599,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_all_with_sources.rs
@@ -7,10 +7,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -27,7 +29,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -128,6 +130,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -142,7 +146,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -228,6 +232,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -242,7 +248,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -343,6 +349,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -357,7 +365,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -444,6 +452,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -458,7 +468,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -536,6 +546,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -550,7 +562,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -651,4 +663,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_all_with_tags.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_all_with_tags.rs
@@ -9,10 +9,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -29,7 +31,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -483,6 +485,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -497,7 +501,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -711,6 +715,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -725,7 +731,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1062,6 +1068,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1076,7 +1084,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1383,6 +1391,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1397,7 +1407,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1691,6 +1701,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1705,7 +1717,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -2042,4 +2054,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_ids.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_ids.rs
@@ -3,10 +3,12 @@ use domain::{
     entity::media::{Medium, MediumId},
     repository::media::MediaRepository,
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         None,
         false,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -43,4 +45,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_ids_with_replicas.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_ids_with_replicas.rs
@@ -6,10 +6,12 @@ use domain::{
     },
     repository::media::MediaRepository,
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -26,7 +28,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         None,
         true,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -113,4 +115,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_ids_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_ids_with_sources.rs
@@ -7,10 +7,12 @@ use domain::{
     },
     repository::media::MediaRepository,
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -27,7 +29,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         None,
         false,
         true,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -91,4 +93,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_ids_with_tags.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_ids_with_tags.rs
@@ -9,10 +9,12 @@ use domain::{
     },
     repository::media::MediaRepository,
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -29,7 +31,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         Some(TagDepth::new(2, 2)),
         false,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -294,4 +296,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_source_ids.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_source_ids.rs
@@ -6,10 +6,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -31,7 +33,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -59,6 +61,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -78,7 +82,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -106,6 +110,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -125,7 +131,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -145,6 +151,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -164,7 +172,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -176,6 +184,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -195,7 +205,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -215,6 +225,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -234,7 +246,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -246,4 +258,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
@@ -7,10 +7,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -32,7 +34,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -127,6 +129,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -146,7 +150,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -253,6 +257,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -272,7 +278,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -348,6 +354,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -367,7 +375,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -379,6 +387,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -398,7 +408,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -441,6 +451,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -460,7 +472,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -484,4 +496,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
@@ -7,10 +7,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -32,7 +34,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -133,6 +135,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -152,7 +156,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -239,6 +243,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -258,7 +264,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -322,6 +328,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -341,7 +349,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -382,6 +390,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -401,7 +411,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -465,6 +475,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -484,7 +496,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -511,4 +523,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
@@ -10,10 +10,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -35,7 +37,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -431,6 +433,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -450,7 +454,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -816,6 +820,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -835,7 +841,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1041,6 +1047,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1060,7 +1068,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1195,6 +1203,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1214,7 +1224,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1509,6 +1519,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1528,7 +1540,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1633,4 +1645,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
@@ -7,10 +7,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -33,7 +35,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -61,6 +63,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -81,7 +85,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -109,6 +113,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -129,7 +135,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -157,6 +163,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -177,7 +185,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -189,6 +197,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -209,7 +219,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -229,6 +239,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -249,7 +261,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -261,4 +273,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
@@ -8,10 +8,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -34,7 +36,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -108,6 +110,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -128,7 +132,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -214,6 +218,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -234,7 +240,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -320,6 +326,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -340,7 +348,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -352,6 +360,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -372,7 +382,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -415,6 +425,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -435,7 +447,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -459,4 +471,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
@@ -9,10 +9,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -35,7 +37,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -136,6 +138,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -156,7 +160,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -257,6 +261,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -277,7 +283,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -378,6 +384,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -398,7 +406,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -439,6 +447,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -459,7 +469,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -537,6 +547,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -557,7 +569,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -598,4 +610,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
+++ b/api/crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
@@ -9,10 +9,12 @@ use domain::{
     },
     repository::{media::MediaRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -35,7 +37,7 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -489,6 +491,8 @@ async fn asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -509,7 +513,7 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -963,6 +967,8 @@ async fn desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -983,7 +989,7 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1437,6 +1443,8 @@ async fn since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1457,7 +1465,7 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1592,6 +1600,8 @@ async fn since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1612,7 +1622,7 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -1906,6 +1916,8 @@ async fn until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 6).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1926,7 +1938,7 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Medium {
@@ -2061,4 +2073,6 @@ async fn until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/media/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "media"
+VALUES
+  (DEFAULT)
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_created_at_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_created_at_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/media/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "media" ("created_at")
+VALUES
+  ($1)
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_sources_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_sources_succeeds.snap
@@ -1,0 +1,61 @@
+---
+source: crates/postgres/tests/integration/media/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "media"
+VALUES
+  (DEFAULT)
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_sources_tags_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_sources_tags_succeeds.snap
@@ -1,0 +1,187 @@
+---
+source: crates/postgres/tests/integration/media/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "media"
+VALUES
+  (DEFAULT)
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6),
+  ($7, $8, $9)'''
+rows_affected = 3
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_tags_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__create____test_context_wrapped_with_tags_succeeds.snap
@@ -1,0 +1,177 @@
+---
+source: crates/postgres/tests/integration/media/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "media"
+VALUES
+  (DEFAULT)
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6),
+  ($7, $8, $9)'''
+rows_affected = 3
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__delete_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__delete_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/media/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+DELETE FROM
+  "media"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,19 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,19 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,49 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,49 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 6
+rows_returned = 6

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_replicas____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,49 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,49 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_sources____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,51 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,143 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 8
+rows_returned = 8
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14),
+          ($15, $16),
+          ($17, $18)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $19)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $20
+    AND "ancestor_id" IN ($21, $22, $23, $24, $25, $26, $27, $28)
+  )
+  OR (
+    "distance" <= $29
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $30
+        AND "descendant_id" IN ($31, $32, $33, $34, $35, $36, $37, $38)
+    )
+  )
+  OR (
+    "distance" <= $39
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $40
+        AND "ancestor_id" IN ($41, $42, $43, $44, $45, $46, $47, $48)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 19
+rows_returned = 19

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,139 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $1'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 4
+rows_returned = 4
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $11)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $12
+    AND "ancestor_id" IN ($13, $14, $15, $16)
+  )
+  OR (
+    "distance" <= $17
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $18
+        AND "descendant_id" IN ($19, $20, $21, $22)
+    )
+  )
+  OR (
+    "distance" <= $23
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $24
+        AND "ancestor_id" IN ($25, $26, $27, $28)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,143 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 6
+rows_returned = 6
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $15)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $16
+    AND "ancestor_id" IN ($17, $18, $19, $20, $21, $22)
+  )
+  OR (
+    "distance" <= $23
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $24
+        AND "descendant_id" IN ($25, $26, $27, $28, $29, $30)
+    )
+  )
+  OR (
+    "distance" <= $31
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $32
+        AND "ancestor_id" IN ($33, $34, $35, $36, $37, $38)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 27
+rows_returned = 27

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,143 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 6
+rows_returned = 6
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $15)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $16
+    AND "ancestor_id" IN ($17, $18, $19, $20, $21, $22)
+  )
+  OR (
+    "distance" <= $23
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $24
+        AND "descendant_id" IN ($25, $26, $27, $28, $29, $30)
+    )
+  )
+  OR (
+    "distance" <= $31
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $32
+        AND "ancestor_id" IN ($33, $34, $35, $36, $37, $38)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,142 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") < ($1, $2)
+ORDER BY
+  "created_at" DESC,
+  "id" DESC
+LIMIT
+  $3'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $13)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $14
+    AND "ancestor_id" IN ($15, $16, $17, $18, $19)
+  )
+  OR (
+    "distance" <= $20
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $21
+        AND "descendant_id" IN ($22, $23, $24, $25, $26)
+    )
+  )
+  OR (
+    "distance" <= $27
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $28
+        AND "ancestor_id" IN ($29, $30, $31, $32, $33)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 17
+rows_returned = 17

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_all_with_tags____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,143 @@
+---
+source: crates/postgres/tests/integration/media/fetch_all_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  ("created_at", "id") > ($1, $2)
+ORDER BY
+  "created_at" ASC,
+  "id" ASC
+LIMIT
+  $3'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 6
+rows_returned = 6
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $15)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $16
+    AND "ancestor_id" IN ($17, $18, $19, $20, $21, $22)
+  )
+  OR (
+    "distance" <= $23
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $24
+        AND "descendant_id" IN ($25, $26, $27, $28, $29, $30)
+    )
+  )
+  OR (
+    "distance" <= $31
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $32
+        AND "ancestor_id" IN ($33, $34, $35, $36, $37, $38)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 27
+rows_returned = 27

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids____test_context_wrapped_succeeds.snap
@@ -1,0 +1,18 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" IN ($1, $2)
+ORDER BY
+  "created_at" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids_with_replicas____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids_with_replicas____test_context_wrapped_succeeds.snap
@@ -1,0 +1,48 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" IN ($1, $2)
+ORDER BY
+  "created_at" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids_with_sources____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids_with_sources____test_context_wrapped_succeeds.snap
@@ -1,0 +1,48 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" IN ($1, $2)
+ORDER BY
+  "created_at" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids_with_tags____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_ids_with_tags____test_context_wrapped_succeeds.snap
@@ -1,0 +1,139 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" IN ($1, $2)
+ORDER BY
+  "created_at" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $13)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $14
+    AND "ancestor_id" IN ($15, $16, $17, $18, $19)
+  )
+  OR (
+    "distance" <= $20
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $21
+        AND "descendant_id" IN ($22, $23, $24, $25, $26)
+    )
+  )
+  OR (
+    "distance" <= $27
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $28
+        AND "ancestor_id" IN ($29, $30, $31, $32, $33)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 25
+rows_returned = 25

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,25 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,25 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,26 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,26 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,26 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,26 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,55 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,55 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 6
+rows_returned = 6

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_replicas____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,55 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,55 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_sources____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,56 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,148 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 7
+rows_returned = 7
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14),
+          ($15, $16)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $17)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $18
+    AND "ancestor_id" IN ($19, $20, $21, $22, $23, $24, $25)
+  )
+  OR (
+    "distance" <= $26
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $27
+        AND "descendant_id" IN ($28, $29, $30, $31, $32, $33, $34)
+    )
+  )
+  OR (
+    "distance" <= $35
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $36
+        AND "ancestor_id" IN ($37, $38, $39, $40, $41, $42, $43)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 27
+rows_returned = 27

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,148 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  "source_id" IN ($1, $2, $3)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 7
+rows_returned = 7
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14),
+          ($15, $16)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $17)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $18
+    AND "ancestor_id" IN ($19, $20, $21, $22, $23, $24, $25)
+  )
+  OR (
+    "distance" <= $26
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $27
+        AND "descendant_id" IN ($28, $29, $30, $31, $32, $33, $34)
+    )
+  )
+  OR (
+    "distance" <= $35
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $36
+        AND "ancestor_id" IN ($37, $38, $39, $40, $41, $42, $43)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 27
+rows_returned = 27

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,146 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 4
+rows_returned = 4
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $11)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $12
+    AND "ancestor_id" IN ($13, $14, $15, $16)
+  )
+  OR (
+    "distance" <= $17
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $18
+        AND "descendant_id" IN ($19, $20, $21, $22)
+    )
+  )
+  OR (
+    "distance" <= $23
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $24
+        AND "ancestor_id" IN ($25, $26, $27, $28)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,141 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,147 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $13)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $14
+    AND "ancestor_id" IN ($15, $16, $17, $18, $19)
+  )
+  OR (
+    "distance" <= $20
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $21
+        AND "descendant_id" IN ($22, $23, $24, $25, $26)
+    )
+  )
+  OR (
+    "distance" <= $27
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $28
+        AND "ancestor_id" IN ($29, $30, $31, $32, $33)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 17
+rows_returned = 17

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_source_ids_with_tags____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,141 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_source_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_sources" ON "media_sources"."medium_id" = "media"."id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND "source_id" IN ($3, $4, $5)
+GROUP BY
+  "id"
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 11
+rows_returned = 11

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,29 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,29 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,30 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,30 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,30 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,30 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,59 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,59 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1, $2)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_replicas____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_replicas.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,59 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,59 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2, $3)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1, $2)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 4
+rows_returned = 4

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_sources____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,60 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_sources.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_asc_succeeds.snap
@@ -1,0 +1,153 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 8
+rows_returned = 8
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14),
+          ($15, $16),
+          ($17, $18)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $19)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $20
+    AND "ancestor_id" IN ($21, $22, $23, $24, $25, $26, $27, $28)
+  )
+  OR (
+    "distance" <= $29
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $30
+        AND "descendant_id" IN ($31, $32, $33, $34, $35, $36, $37, $38)
+    )
+  )
+  OR (
+    "distance" <= $39
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $40
+        AND "ancestor_id" IN ($41, $42, $43, $44, $45, $46, $47, $48)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 19
+rows_returned = 19

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_desc_succeeds.snap
@@ -1,0 +1,153 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("ancestor_id", "tag_type_id") IN (($1, $2))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $3
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 8
+rows_returned = 8
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14),
+          ($15, $16),
+          ($17, $18)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $19)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $20
+    AND "ancestor_id" IN ($21, $22, $23, $24, $25, $26, $27, $28)
+  )
+  OR (
+    "distance" <= $29
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $30
+        AND "descendant_id" IN ($31, $32, $33, $34, $35, $36, $37, $38)
+    )
+  )
+  OR (
+    "distance" <= $39
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $40
+        AND "ancestor_id" IN ($41, $42, $43, $44, $45, $46, $47, $48)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 20
+rows_returned = 20

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_since_asc_succeeds.snap
@@ -1,0 +1,154 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3, $4)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 8
+rows_returned = 8
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12),
+          ($13, $14),
+          ($15, $16),
+          ($17, $18)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $19)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $20
+    AND "ancestor_id" IN ($21, $22, $23, $24, $25, $26, $27, $28)
+  )
+  OR (
+    "distance" <= $29
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $30
+        AND "descendant_id" IN ($31, $32, $33, $34, $35, $36, $37, $38)
+    )
+  )
+  OR (
+    "distance" <= $39
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $40
+        AND "ancestor_id" IN ($41, $42, $43, $44, $45, $46, $47, $48)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 20
+rows_returned = 20

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_since_desc_succeeds.snap
@@ -1,0 +1,145 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_until_asc_succeeds.snap
@@ -1,0 +1,151 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") < ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" DESC,
+  "media"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2, $3)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 5
+rows_returned = 5
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2),
+          ($3, $4),
+          ($5, $6),
+          ($7, $8),
+          ($9, $10),
+          ($11, $12)
+      ) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $13)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $14
+    AND "ancestor_id" IN ($15, $16, $17, $18, $19)
+  )
+  OR (
+    "distance" <= $20
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $21
+        AND "descendant_id" IN ($22, $23, $24, $25, $26)
+    )
+  )
+  OR (
+    "distance" <= $27
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $28
+        AND "ancestor_id" IN ($29, $30, $31, $32, $33)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 17
+rows_returned = 17

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__fetch_by_tag_ids_with_tags____test_context_wrapped_until_desc_succeeds.snap
@@ -1,0 +1,145 @@
+---
+source: crates/postgres/tests/integration/media/fetch_by_tag_ids_with_tags.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+INNER JOIN
+  "media_tags" ON "media_tags"."medium_id" = "media"."id"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "media_tags"."tag_id"
+WHERE
+  ("created_at", "id") > ($1, $2)
+  AND ("ancestor_id", "tag_type_id") IN (($3, $4))
+GROUP BY
+  "id"
+HAVING
+  COUNT(DISTINCT ("ancestor_id", "tag_type_id")) = $5
+ORDER BY
+  "media"."created_at" ASC,
+  "media"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_mismatch_fails.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_mismatch_fails.snap
@@ -1,0 +1,23 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_succeeds.snap
@@ -1,0 +1,131 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  "medium_id" = $1'''
+rows_affected = 3
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP,
+  "created_at" = $1
+WHERE
+  "id" = $2
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_with_replicas_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_with_replicas_succeeds.snap
@@ -1,0 +1,161 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  "medium_id" = $1'''
+rows_affected = 3
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP,
+  "created_at" = $1
+WHERE
+  "id" = $2
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_with_sources_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_with_sources_succeeds.snap
@@ -1,0 +1,161 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  "medium_id" = $1'''
+rows_affected = 3
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP,
+  "created_at" = $1
+WHERE
+  "id" = $2
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_with_tags_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_replicas_with_tags_succeeds.snap
@@ -1,0 +1,246 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  "medium_id" = $1'''
+rows_affected = 3
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP,
+  "created_at" = $1
+WHERE
+  "id" = $2
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 11
+rows_returned = 11
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_too_few_replicas_fails.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_too_few_replicas_fails.snap
@@ -1,0 +1,23 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_too_many_replicas_fails.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_reorder_too_many_replicas_fails.snap
@@ -1,0 +1,23 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,86 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $1
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_with_replicas_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_with_replicas_succeeds.snap
@@ -1,0 +1,116 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $1
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_with_sources_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_with_sources_succeeds.snap
@@ -1,0 +1,116 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $1
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "medium_id",
+  "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "media_sources"
+INNER JOIN
+  "sources" ON "sources"."id" = "media_sources"."source_id"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "media_sources"."medium_id" IN ($1)
+ORDER BY
+  "media_sources"."medium_id" ASC,
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_with_tags_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__update_by_id____test_context_wrapped_with_tags_succeeds.snap
@@ -1,0 +1,201 @@
+---
+source: crates/postgres/tests/integration/media/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "media"."id",
+  "media"."created_at",
+  "media"."updated_at",
+  "replicas"."id" AS "replica_id"
+FROM
+  "media"
+INNER JOIN
+  "replicas" ON "replicas"."medium_id" = "media"."id"
+WHERE
+  "media"."id" = $1
+ORDER BY
+  "media"."id" ASC,
+  "replicas"."display_order" ASC
+FOR UPDATE'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_sources" ("medium_id", "source_id")
+VALUES
+  ($1, $2),
+  ($3, $4)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_sources"
+WHERE
+  "source_id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "media_tags" ("medium_id", "tag_id", "tag_type_id")
+VALUES
+  ($1, $2, $3),
+  ($4, $5, $6)
+ON CONFLICT
+DO NOTHING'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "media_tags"
+WHERE
+  "medium_id" = $1
+  AND ("tag_id", "tag_type_id") IN (($2, $3))'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "media"
+SET
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $1
+RETURNING
+  "id",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "media_tags"."medium_id",
+  "media_tags"."tag_id",
+  "tag_types"."id" AS "tag_type_id",
+  "tag_types"."slug" AS "tag_type_slug",
+  "tag_types"."name" AS "tag_type_name",
+  "tag_types"."kana" AS "tag_type_kana"
+FROM
+  "media_tags"
+INNER JOIN
+  "tag_types" ON "tag_types"."id" = "media_tags"."tag_type_id"
+INNER JOIN
+  (
+    SELECT
+      "tags"."id",
+      array_agg(
+        "ancestors"."kana"
+        ORDER BY
+          "tag_paths"."distance" DESC
+      ) AS "display_order"
+    FROM
+      "tags"
+    INNER JOIN
+      "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+    INNER JOIN
+      "tags" AS "ancestors" ON "tag_paths"."ancestor_id" = "ancestors"."id"
+    WHERE
+      "ancestor_id" <> $1
+    GROUP BY
+      "tags"."id"
+    ORDER BY
+      "display_order" ASC
+  ) AS "ancestors" ON "ancestors"."id" = "media_tags"."tag_id"
+WHERE
+  "media_tags"."medium_id" IN ($2)
+ORDER BY
+  "media_tags"."medium_id" ASC,
+  "tag_types"."kana" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 11
+rows_returned = 11
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/media/snapshots/integration__media__watch_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/media/snapshots/integration__media__watch_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,137 @@
+---
+source: crates/postgres/tests/integration/media/watch_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = 'LISTEN "replicas"'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "medium_id" IN ($1)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/media/update_by_id.rs
+++ b/api/crates/postgres/tests/integration/media/update_by_id.rs
@@ -14,11 +14,13 @@ use domain::{
     repository::media::MediaRepository,
 };
 use futures::TryStreamExt;
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::{assert_eq, assert_matches};
 use sqlx::Row;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::{uuid, Uuid};
 
 use super::DatabaseContext;
@@ -57,7 +59,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         None,
         false,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, Vec::new());
     assert_eq!(actual.tags, OrderMap::<TagType, Vec<Tag>>::new());
@@ -109,6 +111,8 @@ async fn succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -145,7 +149,7 @@ async fn with_tags_succeeds(ctx: &DatabaseContext) {
         Some(TagDepth::new(2, 2)),
         false,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, Vec::new());
     assert_eq!(actual.tags, {
@@ -290,6 +294,8 @@ async fn with_tags_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -326,7 +332,7 @@ async fn with_replicas_succeeds(ctx: &DatabaseContext) {
         None,
         true,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, Vec::new());
     assert_eq!(actual.tags, OrderMap::<TagType, Vec<Tag>>::new());
@@ -422,6 +428,8 @@ async fn with_replicas_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -458,7 +466,7 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
         None,
         false,
         true,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, vec![
         Source {
@@ -539,6 +547,8 @@ async fn with_sources_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -579,7 +589,7 @@ async fn reorder_replicas_succeeds(ctx: &DatabaseContext) {
         None,
         false,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, Vec::new());
     assert_eq!(actual.tags, OrderMap::<TagType, Vec<Tag>>::new());
@@ -639,6 +649,8 @@ async fn reorder_replicas_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -679,7 +691,7 @@ async fn reorder_replicas_with_tags_succeeds(ctx: &DatabaseContext) {
         Some(TagDepth::new(2, 2)),
         false,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, Vec::new());
     assert_eq!(actual.tags, {
@@ -832,6 +844,8 @@ async fn reorder_replicas_with_tags_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -872,7 +886,7 @@ async fn reorder_replicas_with_replicas_succeeds(ctx: &DatabaseContext) {
         None,
         true,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, Vec::new());
     assert_eq!(actual.tags, OrderMap::<TagType, Vec<Tag>>::new());
@@ -976,6 +990,8 @@ async fn reorder_replicas_with_replicas_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1016,7 +1032,7 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
         None,
         false,
         true,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.sources, vec![
         Source {
@@ -1105,6 +1121,8 @@ async fn reorder_replicas_with_sources_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual[2].get::<Uuid, &str>("id"), uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"));
     assert_eq!(actual[2].get::<Option<i32>, &str>("display_order"), Some(3));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1144,7 +1162,7 @@ async fn reorder_too_few_replicas_fails(ctx: &DatabaseContext) {
         None,
         false,
         false,
-    ).await.unwrap_err();
+    ).instrument(ctx.span.clone()).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::MediumReplicasNotMatch { medium_id, expected_replicas, actual_replicas } if (medium_id, expected_replicas, actual_replicas) == (
         &MediumId::from(uuid!("6356503d-6ab6-4e39-bb86-3311219c7fd1")),
@@ -1158,6 +1176,8 @@ async fn reorder_too_few_replicas_fails(ctx: &DatabaseContext) {
             ReplicaId::from(uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5")),
         ],
     ));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1199,7 +1219,7 @@ async fn reorder_too_many_replicas_fails(ctx: &DatabaseContext) {
         None,
         false,
         false,
-    ).await.unwrap_err();
+    ).instrument(ctx.span.clone()).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::MediumReplicasNotMatch { medium_id, expected_replicas, actual_replicas } if (medium_id, expected_replicas, actual_replicas) == (
         &MediumId::from(uuid!("6356503d-6ab6-4e39-bb86-3311219c7fd1")),
@@ -1215,6 +1235,8 @@ async fn reorder_too_many_replicas_fails(ctx: &DatabaseContext) {
             ReplicaId::from(uuid!("790dc278-2c53-4988-883c-43a037664b24")),
         ],
     ));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1255,7 +1277,7 @@ async fn reorder_replicas_mismatch_fails(ctx: &DatabaseContext) {
         None,
         false,
         false,
-    ).await.unwrap_err();
+    ).instrument(ctx.span.clone()).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::MediumReplicasNotMatch { medium_id, expected_replicas, actual_replicas } if (medium_id, expected_replicas, actual_replicas) == (
         &MediumId::from(uuid!("6356503d-6ab6-4e39-bb86-3311219c7fd1")),
@@ -1270,4 +1292,6 @@ async fn reorder_replicas_mismatch_fails(ctx: &DatabaseContext) {
             ReplicaId::from(uuid!("790dc278-2c53-4988-883c-43a037664b24")),
         ],
     ));
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/media/watch_by_id.rs
+++ b/api/crates/postgres/tests/integration/media/watch_by_id.rs
@@ -7,10 +7,12 @@ use domain::{
     repository::media::MediaRepository,
 };
 use futures::{pin_mut, TryStreamExt};
+use insta::assert_toml_snapshot;
 use ordermap::OrderMap;
 use postgres::media::PostgresMediaRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -24,7 +26,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         None,
         true,
         false,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
     pin_mut!(stream);
 
     let actual = stream.try_next().await.unwrap();
@@ -162,4 +164,6 @@ async fn succeeds(ctx: &DatabaseContext) {
         created_at: Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 6).unwrap(),
         updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
     }));
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/replicas/delete_by_id.rs
+++ b/api/crates/postgres/tests/integration/replicas/delete_by_id.rs
@@ -4,10 +4,12 @@ use domain::{
     repository::{replicas::ReplicasRepository, DeleteResult},
 };
 use futures::TryStreamExt;
+use insta::assert_toml_snapshot;
 use postgres::replicas::PostgresReplicasRepository;
 use pretty_assertions::assert_eq;
 use sqlx::Row;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::{uuid, Uuid};
 
 use super::DatabaseContext;
@@ -25,7 +27,7 @@ async fn with_only_replica_succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual, 1);
 
     let repository = PostgresReplicasRepository::new(ctx.pool.clone());
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("9b73469d-55fe-4017-aee8-dd8f8d7d067a"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("9b73469d-55fe-4017-aee8-dd8f8d7d067a"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 
@@ -38,9 +40,11 @@ async fn with_only_replica_succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual, 0);
 
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("9b73469d-55fe-4017-aee8-dd8f8d7d067a"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("9b73469d-55fe-4017-aee8-dd8f8d7d067a"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -56,7 +60,7 @@ async fn with_first_replica_succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual, 1);
 
     let repository = PostgresReplicasRepository::new(ctx.pool.clone());
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 
@@ -88,9 +92,11 @@ async fn with_first_replica_succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual[1].get::<DateTime<Utc>, &str>("created_at"), Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap());
     assert_ne!(actual[1].get::<DateTime<Utc>, &str>("updated_at"), Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap());
 
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -106,7 +112,7 @@ async fn with_middle_replica_succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual, 1);
 
     let repository = PostgresReplicasRepository::new(ctx.pool.clone());
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("6fae1497-e987-492e-987a-f9870b7d3c5b"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("6fae1497-e987-492e-987a-f9870b7d3c5b"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 
@@ -138,9 +144,11 @@ async fn with_middle_replica_succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual[1].get::<DateTime<Utc>, &str>("created_at"), Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap());
     assert_ne!(actual[1].get::<DateTime<Utc>, &str>("updated_at"), Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap());
 
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("6fae1497-e987-492e-987a-f9870b7d3c5b"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("6fae1497-e987-492e-987a-f9870b7d3c5b"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -156,7 +164,7 @@ async fn with_last_replica_succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual, 1);
 
     let repository = PostgresReplicasRepository::new(ctx.pool.clone());
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 
@@ -188,7 +196,9 @@ async fn with_last_replica_succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual[1].get::<DateTime<Utc>, &str>("created_at"), Utc.with_ymd_and_hms(2022, 1, 2, 3, 4, 11).unwrap());
     assert_ne!(actual[1].get::<DateTime<Utc>, &str>("updated_at"), Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap());
 
-    let actual = repository.delete_by_id(ReplicaId::from(uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"))).await.unwrap();
+    let actual = repository.delete_by_id(ReplicaId::from(uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/replicas/fetch_by_ids.rs
+++ b/api/crates/postgres/tests/integration/replicas/fetch_by_ids.rs
@@ -3,9 +3,11 @@ use domain::{
     entity::replicas::{Replica, ReplicaId, ReplicaStatus, Size, Thumbnail, ThumbnailId},
     repository::replicas::ReplicasRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::replicas::PostgresReplicasRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -18,7 +20,7 @@ async fn succeeds(ctx: &DatabaseContext) {
         ReplicaId::from(uuid!("12ca56e2-6e77-43b9-9da9-9d968c80a1a5")),
         ReplicaId::from(uuid!("1706c7bb-4152-44b2-9bbb-1179d09a19be")),
         ReplicaId::from(uuid!("6fae1497-e987-492e-987a-f9870b7d3c5b")),
-    ].into_iter()).await.unwrap();
+    ].into_iter()).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Replica {
@@ -65,4 +67,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/replicas/fetch_thumbnail_by_id.rs
+++ b/api/crates/postgres/tests/integration/replicas/fetch_thumbnail_by_id.rs
@@ -3,9 +3,11 @@ use domain::{
     error::ErrorKind,
     repository::replicas::ReplicasRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::replicas::PostgresReplicasRepository;
 use pretty_assertions::{assert_eq, assert_matches};
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -16,13 +18,15 @@ async fn succeeds(ctx: &DatabaseContext) {
     let repository = PostgresReplicasRepository::new(ctx.pool.clone());
     let actual = repository.fetch_thumbnail_by_id(
         ThumbnailId::from(uuid!("9785df5f-f975-4253-9b50-b5e3abb92a70")),
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x20,
         0x18, 0x00, 0x00, 0x00, 0x30, 0x01, 0x00, 0x9d, 0x01, 0x2a, 0x01, 0x00, 0x01, 0x00, 0x02, 0x00,
         0x34, 0x25, 0xa4, 0x00, 0x03, 0x70, 0x00, 0xfe, 0xfb, 0xfd, 0x50, 0x00,
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -31,7 +35,9 @@ async fn fails(ctx: &DatabaseContext) {
     let repository = PostgresReplicasRepository::new(ctx.pool.clone());
     let actual = repository.fetch_thumbnail_by_id(
         ThumbnailId::from(uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")),
-    ).await.unwrap_err();
+    ).instrument(ctx.span.clone()).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::ThumbnailNotFound { id } if id == &ThumbnailId::from(uuid!("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")));
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_first_replica_with_thumbnail_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_first_replica_with_thumbnail_succeeds.snap
@@ -1,0 +1,83 @@
+---
+source: crates/postgres/tests/integration/replicas/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*) + $1
+FROM
+  "replicas"
+WHERE
+  "medium_id" = $2'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "replicas" (
+    "medium_id",
+    "display_order",
+    "original_url",
+    "mime_type",
+    "width",
+    "height",
+    "phase"
+  )
+VALUES
+  ($1, $2, $3, $4, $5, $6, $7)
+RETURNING
+  "id",
+  "medium_id",
+  "display_order",
+  "original_url",
+  "mime_type",
+  "width",
+  "height",
+  "phase",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "thumbnails" ("replica_id", "data", "width", "height")
+VALUES
+  ($1, $2, $3, $4)
+RETURNING
+  "id",
+  "width",
+  "height",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  pg_notify($1, $2)'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_first_replica_without_thumbnail_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_first_replica_without_thumbnail_succeeds.snap
@@ -1,0 +1,68 @@
+---
+source: crates/postgres/tests/integration/replicas/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*) + $1
+FROM
+  "replicas"
+WHERE
+  "medium_id" = $2'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "replicas" (
+    "medium_id",
+    "display_order",
+    "original_url",
+    "mime_type",
+    "width",
+    "height",
+    "phase"
+  )
+VALUES
+  ($1, $2, $3, $4, $5, $6, $7)
+RETURNING
+  "id",
+  "medium_id",
+  "display_order",
+  "original_url",
+  "mime_type",
+  "width",
+  "height",
+  "phase",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  pg_notify($1, $2)'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_non_first_replica_with_thumbnail_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_non_first_replica_with_thumbnail_succeeds.snap
@@ -1,0 +1,83 @@
+---
+source: crates/postgres/tests/integration/replicas/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*) + $1
+FROM
+  "replicas"
+WHERE
+  "medium_id" = $2'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "replicas" (
+    "medium_id",
+    "display_order",
+    "original_url",
+    "mime_type",
+    "width",
+    "height",
+    "phase"
+  )
+VALUES
+  ($1, $2, $3, $4, $5, $6, $7)
+RETURNING
+  "id",
+  "medium_id",
+  "display_order",
+  "original_url",
+  "mime_type",
+  "width",
+  "height",
+  "phase",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "thumbnails" ("replica_id", "data", "width", "height")
+VALUES
+  ($1, $2, $3, $4)
+RETURNING
+  "id",
+  "width",
+  "height",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  pg_notify($1, $2)'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_non_first_replica_without_thumbnail_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__create____test_context_wrapped_non_first_replica_without_thumbnail_succeeds.snap
@@ -1,0 +1,68 @@
+---
+source: crates/postgres/tests/integration/replicas/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "created_at",
+  "updated_at"
+FROM
+  "media"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*) + $1
+FROM
+  "replicas"
+WHERE
+  "medium_id" = $2'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "replicas" (
+    "medium_id",
+    "display_order",
+    "original_url",
+    "mime_type",
+    "width",
+    "height",
+    "phase"
+  )
+VALUES
+  ($1, $2, $3, $4, $5, $6, $7)
+RETURNING
+  "id",
+  "medium_id",
+  "display_order",
+  "original_url",
+  "mime_type",
+  "width",
+  "height",
+  "phase",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  pg_notify($1, $2)'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_first_replica_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_first_replica_succeeds.snap
@@ -1,0 +1,113 @@
+---
+source: crates/postgres/tests/integration/replicas/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  "id" IN ($1, $2)'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_last_replica_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_last_replica_succeeds.snap
@@ -1,0 +1,113 @@
+---
+source: crates/postgres/tests/integration/replicas/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  "id" IN ($1, $2)'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_middle_replica_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_middle_replica_succeeds.snap
@@ -1,0 +1,113 @@
+---
+source: crates/postgres/tests/integration/replicas/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  "id" IN ($1, $2)'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = $1,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $2'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_only_replica_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__delete_by_id____test_context_wrapped_with_only_replica_succeeds.snap
@@ -1,0 +1,89 @@
+---
+source: crates/postgres/tests/integration/replicas/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "display_order" = NULL
+WHERE
+  $1 = $2'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "siblings"."id",
+  "siblings"."medium_id",
+  "siblings"."display_order",
+  "siblings"."original_url",
+  "siblings"."mime_type",
+  "siblings"."width",
+  "siblings"."height",
+  "siblings"."phase",
+  "siblings"."created_at",
+  "siblings"."updated_at"
+FROM
+  "replicas"
+INNER JOIN
+  "replicas" AS "siblings" ON "siblings"."medium_id" = "replicas"."medium_id"
+WHERE
+  "replicas"."id" = $1
+ORDER BY
+  "siblings"."display_order" ASC
+FOR UPDATE
+  OF "siblings"'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "replicas"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_by_ids____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_by_ids____test_context_wrapped_succeeds.snap
@@ -1,0 +1,33 @@
+---
+source: crates/postgres/tests/integration/replicas/fetch_by_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "replicas"."id" IN ($1, $2, $3)
+ORDER BY
+  "medium_id" ASC,
+  "display_order" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_by_original_url____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_by_original_url____test_context_wrapped_fails.snap
@@ -1,0 +1,30 @@
+---
+source: crates/postgres/tests/integration/replicas/fetch_by_original_url.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "original_url" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_by_original_url____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_by_original_url____test_context_wrapped_succeeds.snap
@@ -1,0 +1,30 @@
+---
+source: crates/postgres/tests/integration/replicas/fetch_by_original_url.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "replicas"."id" AS "replica_id",
+  "replicas"."medium_id" AS "replica_medium_id",
+  "replicas"."display_order" AS "replica_display_order",
+  "replicas"."original_url" AS "replica_original_url",
+  "replicas"."mime_type" AS "replica_mime_type",
+  "replicas"."width" AS "replica_width",
+  "replicas"."height" AS "replica_height",
+  "replicas"."phase" AS "replica_phase",
+  "replicas"."created_at" AS "replica_created_at",
+  "replicas"."updated_at" AS "replica_updated_at",
+  "thumbnails"."id" AS "thumbnail_id",
+  "thumbnails"."width" AS "thumbnail_width",
+  "thumbnails"."height" AS "thumbnail_height",
+  "thumbnails"."created_at" AS "thumbnail_created_at",
+  "thumbnails"."updated_at" AS "thumbnail_updated_at"
+FROM
+  "replicas"
+LEFT JOIN
+  "thumbnails" ON "replicas"."id" = "thumbnails"."replica_id"
+WHERE
+  "original_url" = $1'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_thumbnail_by_id____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_thumbnail_by_id____test_context_wrapped_fails.snap
@@ -1,0 +1,14 @@
+---
+source: crates/postgres/tests/integration/replicas/fetch_thumbnail_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "data"
+FROM
+  "thumbnails"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_thumbnail_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__fetch_thumbnail_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,14 @@
+---
+source: crates/postgres/tests/integration/replicas/fetch_thumbnail_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "data"
+FROM
+  "thumbnails"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__update_by_id____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__update_by_id____test_context_wrapped_fails.snap
@@ -1,0 +1,24 @@
+---
+source: crates/postgres/tests/integration/replicas/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "medium_id",
+  "display_order",
+  "original_url",
+  "mime_type",
+  "width",
+  "height",
+  "phase",
+  "created_at",
+  "updated_at"
+FROM
+  "replicas"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__update_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/replicas/snapshots/integration__replicas__update_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,84 @@
+---
+source: crates/postgres/tests/integration/replicas/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "medium_id",
+  "display_order",
+  "original_url",
+  "mime_type",
+  "width",
+  "height",
+  "phase",
+  "created_at",
+  "updated_at"
+FROM
+  "replicas"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "replicas"
+SET
+  "updated_at" = CURRENT_TIMESTAMP,
+  "original_url" = $1,
+  "mime_type" = $2,
+  "width" = $3,
+  "height" = $4
+WHERE
+  "id" = $5
+RETURNING
+  "id",
+  "medium_id",
+  "display_order",
+  "original_url",
+  "mime_type",
+  "width",
+  "height",
+  "phase",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "thumbnails" ("replica_id", "data", "width", "height")
+VALUES
+  ($1, $2, $3, $4)
+ON CONFLICT
+  ("replica_id")
+DO UPDATE SET
+  "data" = "excluded"."data",
+  "width" = "excluded"."width",
+  "height" = "excluded"."height",
+  "updated_at" = CURRENT_TIMESTAMP
+RETURNING
+  "id",
+  "width",
+  "height",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  pg_notify($1, $2)'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/fetch_by_external_metadata_like_id.rs
+++ b/api/crates/postgres/tests/integration/sources/fetch_by_external_metadata_like_id.rs
@@ -6,9 +6,11 @@ use domain::{
     },
     repository::sources::SourcesRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::sources::PostgresSourcesRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -17,7 +19,7 @@ use super::DatabaseContext;
 #[tokio::test]
 async fn succeeds(ctx: &DatabaseContext) {
     let repository = PostgresSourcesRepository::new(ctx.pool.clone());
-    let actual = repository.fetch_by_external_metadata_like_id("8888888").await.unwrap();
+    let actual = repository.fetch_by_external_metadata_like_id("8888888").instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Source {
@@ -35,4 +37,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 14).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/sources/fetch_by_ids.rs
+++ b/api/crates/postgres/tests/integration/sources/fetch_by_ids.rs
@@ -6,9 +6,11 @@ use domain::{
     },
     repository::sources::SourcesRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::sources::PostgresSourcesRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -20,7 +22,7 @@ async fn succeeds(ctx: &DatabaseContext) {
     let actual = repository.fetch_by_ids([
         SourceId::from(uuid!("76a94241-1736-4823-bb59-bef097c687e1")),
         SourceId::from(uuid!("94055dd8-7a22-4137-b8eb-3a374df5e5d1")),
-    ].into_iter()).await.unwrap();
+    ].into_iter()).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Source {
@@ -52,4 +54,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 15).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_custom_number.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_custom_number.snap
@@ -1,0 +1,44 @@
+---
+source: crates/postgres/tests/integration/sources/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "sources" (
+    "external_service_id",
+    "external_metadata",
+    "external_metadata_extra"
+  )
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_custom_object.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_custom_object.snap
@@ -1,0 +1,44 @@
+---
+source: crates/postgres/tests/integration/sources/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "sources" (
+    "external_service_id",
+    "external_metadata",
+    "external_metadata_extra"
+  )
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_custom_string.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_custom_string.snap
@@ -1,0 +1,44 @@
+---
+source: crates/postgres/tests/integration/sources/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "sources" (
+    "external_service_id",
+    "external_metadata",
+    "external_metadata_extra"
+  )
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_default.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_default.snap
@@ -1,0 +1,44 @@
+---
+source: crates/postgres/tests/integration/sources/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "sources" (
+    "external_service_id",
+    "external_metadata",
+    "external_metadata_extra"
+  )
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_extra.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__create____test_context_wrapped_succeeds_with_extra.snap
@@ -1,0 +1,44 @@
+---
+source: crates/postgres/tests/integration/sources/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "sources" (
+    "external_service_id",
+    "external_metadata",
+    "external_metadata_extra"
+  )
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__delete_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__delete_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/sources/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+DELETE FROM
+  "sources"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "sources"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata____test_context_wrapped_not_found.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata____test_context_wrapped_not_found.snap
@@ -1,0 +1,27 @@
+---
+source: crates/postgres/tests/integration/sources/fetch_by_external_metadata.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "sources"."id" AS "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "sources"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "external_service_id" = $1
+  AND "external_metadata" @> $2'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata____test_context_wrapped_succeeds.snap
@@ -1,0 +1,27 @@
+---
+source: crates/postgres/tests/integration/sources/fetch_by_external_metadata.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "sources"."id" AS "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "sources"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "external_service_id" = $1
+  AND "external_metadata" @> $2'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata____test_context_wrapped_succeeds_with_extra.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata____test_context_wrapped_succeeds_with_extra.snap
@@ -1,0 +1,27 @@
+---
+source: crates/postgres/tests/integration/sources/fetch_by_external_metadata.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "sources"."id" AS "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "sources"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "external_service_id" = $1
+  AND "external_metadata" @> $2'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata_like_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_external_metadata_like_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,29 @@
+---
+source: crates/postgres/tests/integration/sources/fetch_by_external_metadata_like_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "sources"."id" AS "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "sources"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  ("external_metadata" ->> $1) = $2
+ORDER BY
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_ids____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__fetch_by_ids____test_context_wrapped_succeeds.snap
@@ -1,0 +1,29 @@
+---
+source: crates/postgres/tests/integration/sources/fetch_by_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "sources"."id" AS "source_id",
+  "sources"."external_metadata" AS "source_external_metadata",
+  "sources"."external_metadata_extra" AS "source_external_metadata_extra",
+  "sources"."created_at" AS "source_created_at",
+  "sources"."updated_at" AS "source_updated_at",
+  "external_services"."id" AS "external_service_id",
+  "external_services"."slug" AS "external_service_slug",
+  "external_services"."kind" AS "external_service_kind",
+  "external_services"."name" AS "external_service_name",
+  "external_services"."base_url" AS "external_service_base_url",
+  "external_services"."url_pattern" AS "external_service_url_pattern"
+FROM
+  "sources"
+INNER JOIN
+  "external_services" ON "external_services"."id" = "sources"."external_service_id"
+WHERE
+  "sources"."id" IN ($1, $2)
+ORDER BY
+  "external_services"."slug" ASC,
+  "sources"."external_metadata" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__update_by_id____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__update_by_id____test_context_wrapped_fails.snap
@@ -1,0 +1,20 @@
+---
+source: crates/postgres/tests/integration/sources/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"
+FROM
+  "sources"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__update_by_id____test_context_wrapped_with_external_metadata_succeeds.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__update_by_id____test_context_wrapped_with_external_metadata_succeeds.snap
@@ -1,0 +1,62 @@
+---
+source: crates/postgres/tests/integration/sources/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"
+FROM
+  "sources"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "sources"
+SET
+  "external_service_id" = $1,
+  "external_metadata" = $2,
+  "external_metadata_extra" = $3,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $4
+RETURNING
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__update_by_id____test_context_wrapped_with_external_service_and_external_metadata_succeeds.snap
+++ b/api/crates/postgres/tests/integration/sources/snapshots/integration__sources__update_by_id____test_context_wrapped_with_external_service_and_external_metadata_succeeds.snap
@@ -1,0 +1,62 @@
+---
+source: crates/postgres/tests/integration/sources/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"
+FROM
+  "sources"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "sources"
+SET
+  "external_service_id" = $1,
+  "external_metadata" = $2,
+  "external_metadata_extra" = $3,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $4
+RETURNING
+  "id",
+  "external_service_id",
+  "external_metadata",
+  "external_metadata_extra",
+  "created_at",
+  "updated_at"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "kind",
+  "name",
+  "base_url",
+  "url_pattern"
+FROM
+  "external_services"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/sources/update_by_id.rs
+++ b/api/crates/postgres/tests/integration/sources/update_by_id.rs
@@ -7,11 +7,13 @@ use domain::{
     error::ErrorKind,
     repository::sources::SourcesRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::sources::PostgresSourcesRepository;
 use pretty_assertions::{assert_eq, assert_matches};
 use serde_json::json;
 use sqlx::Row;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::{uuid, Uuid};
 
 use super::DatabaseContext;
@@ -24,7 +26,7 @@ async fn with_external_metadata_succeeds(ctx: &DatabaseContext) {
         SourceId::from(uuid!("94055dd8-7a22-4137-b8eb-3a374df5e5d1")),
         None,
         Some(ExternalMetadata::Pixiv { id: 123456789 }),
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.id, SourceId::from(uuid!("94055dd8-7a22-4137-b8eb-3a374df5e5d1")));
     assert_eq!(
@@ -62,6 +64,8 @@ async fn with_external_metadata_succeeds(ctx: &DatabaseContext) {
             "type": "pixiv",
         }),
     );
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -72,7 +76,7 @@ async fn with_external_service_and_external_metadata_succeeds(ctx: &DatabaseCont
         SourceId::from(uuid!("94055dd8-7a22-4137-b8eb-3a374df5e5d1")),
         Some(ExternalServiceId::from(uuid!("2018afa2-aed9-46de-af9e-02e5fab64ed7"))),
         Some(ExternalMetadata::Skeb { id: 7777, creator_id: "creator_03".to_string() }),
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.id, SourceId::from(uuid!("94055dd8-7a22-4137-b8eb-3a374df5e5d1")));
     assert_eq!(
@@ -111,6 +115,8 @@ async fn with_external_service_and_external_metadata_succeeds(ctx: &DatabaseCont
     assert_eq!(actual.get::<serde_json::Value, &str>("external_metadata_extra"), json!({
         "type": "skeb",
     }));
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -121,7 +127,9 @@ async fn fails(ctx: &DatabaseContext) {
         SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")),
         None,
         None,
-    ).await.unwrap_err();
+    ).instrument(ctx.span.clone()).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::SourceNotFound { id } if id == &SourceId::from(uuid!("11111111-1111-1111-1111-111111111111")));
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tag_types/create.rs
+++ b/api/crates/postgres/tests/integration/tag_types/create.rs
@@ -2,10 +2,12 @@ use domain::{
     error::ErrorKind,
     repository::tag_types::TagTypesRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::tag_types::PostgresTagTypesRepository;
 use pretty_assertions::{assert_eq, assert_matches};
 use sqlx::Row;
 use test_context::test_context;
+use tracing::Instrument;
 
 use super::DatabaseContext;
 
@@ -13,7 +15,7 @@ use super::DatabaseContext;
 #[tokio::test]
 async fn succeeds(ctx: &DatabaseContext) {
     let repository = PostgresTagTypesRepository::new(ctx.pool.clone());
-    let actual = repository.create("foobar", "FooBar", "foobar").await.unwrap();
+    let actual = repository.create("foobar", "FooBar", "foobar").instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual.slug, "foobar".to_string());
     assert_eq!(actual.name, "FooBar".to_string());
@@ -28,13 +30,17 @@ async fn succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual.get::<&str, &str>("slug"), "foobar");
     assert_eq!(actual.get::<&str, &str>("name"), "FooBar");
     assert_eq!(actual.get::<&str, &str>("kana"), "foobar");
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
 #[tokio::test]
 async fn fails(ctx: &DatabaseContext) {
     let repository = PostgresTagTypesRepository::new(ctx.pool.clone());
-    let actual = repository.create("character", "キャラクター", "キャラクター").await.unwrap_err();
+    let actual = repository.create("character", "キャラクター", "キャラクター").instrument(ctx.span.clone()).await.unwrap_err();
 
     assert_matches!(actual.kind(), ErrorKind::TagTypeSlugDuplicate { slug } if slug == "character");
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tag_types/delete_by_id.rs
+++ b/api/crates/postgres/tests/integration/tag_types/delete_by_id.rs
@@ -2,10 +2,12 @@ use domain::{
     entity::tag_types::TagTypeId,
     repository::{tag_types::TagTypesRepository, DeleteResult},
 };
+use insta::assert_toml_snapshot;
 use postgres::tag_types::PostgresTagTypesRepository;
 use pretty_assertions::assert_eq;
 use sqlx::Row;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn succeeds(ctx: &DatabaseContext) {
     assert_eq!(actual, 1);
 
     let repository = PostgresTagTypesRepository::new(ctx.pool.clone());
-    let actual = repository.delete_by_id(TagTypeId::from(uuid!("1e5021f0-d8ef-4859-815a-747bf3175724"))).await.unwrap();
+    let actual = repository.delete_by_id(TagTypeId::from(uuid!("1e5021f0-d8ef-4859-815a-747bf3175724"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::Deleted(1));
 
@@ -36,7 +38,9 @@ async fn succeeds(ctx: &DatabaseContext) {
 
     assert_eq!(actual, 0);
 
-    let actual = repository.delete_by_id(TagTypeId::from(uuid!("1e5021f0-d8ef-4859-815a-747bf3175724"))).await.unwrap();
+    let actual = repository.delete_by_id(TagTypeId::from(uuid!("1e5021f0-d8ef-4859-815a-747bf3175724"))).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, DeleteResult::NotFound);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tag_types/fetch_all.rs
+++ b/api/crates/postgres/tests/integration/tag_types/fetch_all.rs
@@ -2,9 +2,11 @@ use domain::{
     entity::tag_types::{TagType, TagTypeId},
     repository::tag_types::TagTypesRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::tag_types::PostgresTagTypesRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -13,7 +15,7 @@ use super::DatabaseContext;
 #[tokio::test]
 async fn succeeds(ctx: &DatabaseContext) {
     let repository = PostgresTagTypesRepository::new(ctx.pool.clone());
-    let actual = repository.fetch_all().await.unwrap();
+    let actual = repository.fetch_all().instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         TagType {
@@ -35,4 +37,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             kana: "さくひん".to_string(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tag_types/fetch_by_ids.rs
+++ b/api/crates/postgres/tests/integration/tag_types/fetch_by_ids.rs
@@ -2,9 +2,11 @@ use domain::{
     entity::tag_types::{TagType, TagTypeId},
     repository::tag_types::TagTypesRepository,
 };
+use insta::assert_toml_snapshot;
 use postgres::tag_types::PostgresTagTypesRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -16,7 +18,7 @@ async fn succeeds(ctx: &DatabaseContext) {
     let actual = repository.fetch_by_ids([
         TagTypeId::from(uuid!("67738231-9b3a-4f45-94dc-1ba302e50e38")),
         TagTypeId::from(uuid!("1e5021f0-d8ef-4859-815a-747bf3175724")),
-    ].into_iter()).await.unwrap();
+    ].into_iter()).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         TagType {
@@ -32,4 +34,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             kana: "さくひん".to_string(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__create____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__create____test_context_wrapped_fails.snap
@@ -1,0 +1,17 @@
+---
+source: crates/postgres/tests/integration/tag_types/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_types" ("slug", "name", "kana")
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id",
+  "slug",
+  "name",
+  "kana"'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__create____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__create____test_context_wrapped_succeeds.snap
@@ -1,0 +1,17 @@
+---
+source: crates/postgres/tests/integration/tag_types/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_types" ("slug", "name", "kana")
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id",
+  "slug",
+  "name",
+  "kana"'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__delete_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__delete_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,21 @@
+---
+source: crates/postgres/tests/integration/tag_types/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_types"
+WHERE
+  "id" = $1'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_types"
+WHERE
+  "id" = $1'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__fetch_all____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__fetch_all____test_context_wrapped_succeeds.snap
@@ -1,0 +1,17 @@
+---
+source: crates/postgres/tests/integration/tag_types/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "name",
+  "kana"
+FROM
+  "tag_types"
+ORDER BY
+  "kana" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__fetch_by_ids____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__fetch_by_ids____test_context_wrapped_succeeds.snap
@@ -1,0 +1,19 @@
+---
+source: crates/postgres/tests/integration/tag_types/fetch_by_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "name",
+  "kana"
+FROM
+  "tag_types"
+WHERE
+  "id" IN ($1, $2)
+ORDER BY
+  "kana" ASC'''
+rows_affected = 2
+rows_returned = 2

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__update_by_id____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__update_by_id____test_context_wrapped_fails.snap
@@ -1,0 +1,18 @@
+---
+source: crates/postgres/tests/integration/tag_types/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "name",
+  "kana"
+FROM
+  "tag_types"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__update_by_id____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__update_by_id____test_context_wrapped_succeeds.snap
@@ -1,0 +1,41 @@
+---
+source: crates/postgres/tests/integration/tag_types/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "name",
+  "kana"
+FROM
+  "tag_types"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "tag_types"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "kana" = $3
+WHERE
+  "id" = $4
+RETURNING
+  "id",
+  "slug",
+  "name",
+  "kana"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__update_by_id____test_context_wrapped_with_slug_name_kana_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tag_types/snapshots/integration__tag_types__update_by_id____test_context_wrapped_with_slug_name_kana_succeeds.snap
@@ -1,0 +1,41 @@
+---
+source: crates/postgres/tests/integration/tag_types/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "slug",
+  "name",
+  "kana"
+FROM
+  "tag_types"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "tag_types"
+SET
+  "slug" = $1,
+  "name" = $2,
+  "kana" = $3
+WHERE
+  "id" = $4
+RETURNING
+  "id",
+  "slug",
+  "name",
+  "kana"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/fetch_all.rs
+++ b/api/crates/postgres/tests/integration/tags/fetch_all.rs
@@ -2,8 +2,10 @@ use domain::{
     entity::tags::{TagDepth, TagId},
     repository::{tags::TagsRepository, Direction, Order},
 };
+use insta::assert_toml_snapshot;
 use postgres::tags::PostgresTagsRepository;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -19,7 +21,9 @@ async fn with_out_of_bounds_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert!(actual.is_empty());
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+++ b/api/crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
@@ -5,9 +5,11 @@ use domain::{
     repository::{tags::TagsRepository, Direction, Order},
 };
 use chrono::{TimeZone, Utc};
+use insta::assert_toml_snapshot;
 use postgres::tags::PostgresTagsRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn root_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -98,6 +100,8 @@ async fn root_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -111,7 +115,7 @@ async fn root_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -248,6 +252,8 @@ async fn root_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -261,7 +267,7 @@ async fn root_since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -347,6 +353,8 @@ async fn root_since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -360,7 +368,7 @@ async fn root_since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -384,6 +392,8 @@ async fn root_since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -397,7 +407,7 @@ async fn root_until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -421,6 +431,8 @@ async fn root_until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 13).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -434,7 +446,7 @@ async fn root_until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -520,6 +532,8 @@ async fn root_until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -533,7 +547,7 @@ async fn no_root_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -585,6 +599,8 @@ async fn no_root_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 13).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -598,7 +614,7 @@ async fn no_root_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -721,6 +737,8 @@ async fn no_root_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -734,7 +752,7 @@ async fn no_root_since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -845,6 +863,8 @@ async fn no_root_since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 11).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -858,7 +878,7 @@ async fn no_root_since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -919,6 +939,8 @@ async fn no_root_since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -932,7 +954,7 @@ async fn no_root_until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -993,6 +1015,8 @@ async fn no_root_until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -1006,7 +1030,7 @@ async fn no_root_until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -1117,4 +1141,6 @@ async fn no_root_until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+++ b/api/crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
@@ -5,9 +5,11 @@ use domain::{
     repository::{tags::TagsRepository, Direction, Order},
 };
 use chrono::{TimeZone, Utc};
+use insta::assert_toml_snapshot;
 use postgres::tags::PostgresTagsRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn root_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -57,6 +59,8 @@ async fn root_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -70,7 +74,7 @@ async fn root_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -104,6 +108,8 @@ async fn root_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -117,7 +123,7 @@ async fn root_since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -141,6 +147,8 @@ async fn root_since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -154,7 +162,7 @@ async fn root_since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -178,6 +186,8 @@ async fn root_since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -191,7 +201,7 @@ async fn root_until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -215,6 +225,8 @@ async fn root_until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 13).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -228,7 +240,7 @@ async fn root_until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -252,6 +264,8 @@ async fn root_until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -265,7 +279,7 @@ async fn no_root_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -299,6 +313,8 @@ async fn no_root_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 13).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -312,7 +328,7 @@ async fn no_root_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -346,6 +362,8 @@ async fn no_root_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -359,7 +377,7 @@ async fn no_root_since_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -393,6 +411,8 @@ async fn no_root_since_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 3, 4, 5, 6, 11).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -406,7 +426,7 @@ async fn no_root_since_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Forward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -440,6 +460,8 @@ async fn no_root_since_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -453,7 +475,7 @@ async fn no_root_until_asc_succeeds(ctx: &DatabaseContext) {
         Order::Ascending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -487,6 +509,8 @@ async fn no_root_until_asc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
@@ -500,7 +524,7 @@ async fn no_root_until_desc_succeeds(ctx: &DatabaseContext) {
         Order::Descending,
         Direction::Backward,
         3,
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -534,4 +558,6 @@ async fn no_root_until_desc_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 9).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tags/fetch_by_ids.rs
+++ b/api/crates/postgres/tests/integration/tags/fetch_by_ids.rs
@@ -5,9 +5,11 @@ use domain::{
     repository::tags::TagsRepository,
 };
 use chrono::{TimeZone, Utc};
+use insta::assert_toml_snapshot;
 use postgres::tags::PostgresTagsRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -23,7 +25,7 @@ async fn succeeds(ctx: &DatabaseContext) {
             TagId::from(uuid!("d1a302b5-7b49-44be-9019-ac337077786a")),
         ].into_iter(),
         TagDepth::new(2, 2),
-    ).await.unwrap();
+    ).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -146,4 +148,6 @@ async fn succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 7).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tags/fetch_by_name_or_alias_like.rs
+++ b/api/crates/postgres/tests/integration/tags/fetch_by_name_or_alias_like.rs
@@ -5,9 +5,11 @@ use domain::{
     repository::tags::TagsRepository,
 };
 use chrono::{TimeZone, Utc};
+use insta::assert_toml_snapshot;
 use postgres::tags::PostgresTagsRepository;
 use pretty_assertions::assert_eq;
 use test_context::test_context;
+use tracing::Instrument;
 use uuid::uuid;
 
 use super::DatabaseContext;
@@ -16,7 +18,7 @@ use super::DatabaseContext;
 #[tokio::test]
 async fn with_name_succeeds(ctx: &DatabaseContext) {
     let repository = PostgresTagsRepository::new(ctx.pool.clone());
-    let actual = repository.fetch_by_name_or_alias_like("り", TagDepth::new(2, 2)).await.unwrap();
+    let actual = repository.fetch_by_name_or_alias_like("り", TagDepth::new(2, 2)).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -180,13 +182,15 @@ async fn with_name_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
 #[tokio::test]
 async fn with_name_case_insensitive_succeeds(ctx: &DatabaseContext) {
     let repository = PostgresTagsRepository::new(ctx.pool.clone());
-    let actual = repository.fetch_by_name_or_alias_like("project", TagDepth::new(2, 2)).await.unwrap();
+    let actual = repository.fetch_by_name_or_alias_like("project", TagDepth::new(2, 2)).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -241,13 +245,15 @@ async fn with_name_case_insensitive_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 10).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
 #[tokio::test]
 async fn with_alias_succeeds(ctx: &DatabaseContext) {
     let repository = PostgresTagsRepository::new(ctx.pool.clone());
-    let actual = repository.fetch_by_name_or_alias_like("げ", TagDepth::new(2, 2)).await.unwrap();
+    let actual = repository.fetch_by_name_or_alias_like("げ", TagDepth::new(2, 2)).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -280,13 +286,15 @@ async fn with_alias_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }
 
 #[test_context(DatabaseContext)]
 #[tokio::test]
 async fn with_name_and_alias_succeeds(ctx: &DatabaseContext) {
     let repository = PostgresTagsRepository::new(ctx.pool.clone());
-    let actual = repository.fetch_by_name_or_alias_like("ん", TagDepth::new(2, 2)).await.unwrap();
+    let actual = repository.fetch_by_name_or_alias_like("ん", TagDepth::new(2, 2)).instrument(ctx.span.clone()).await.unwrap();
 
     assert_eq!(actual, vec![
         Tag {
@@ -338,4 +346,6 @@ async fn with_name_and_alias_succeeds(ctx: &DatabaseContext) {
             updated_at: Utc.with_ymd_and_hms(2022, 2, 3, 4, 5, 8).unwrap(),
         },
     ]);
+
+    assert_toml_snapshot!(ctx.queries());
 }

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_descendant_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_descendant_fails.snap
@@ -1,0 +1,15 @@
+---
+source: crates/postgres/tests/integration/tags/attach_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*)
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+  AND "descendant_id" = $2'''
+rows_affected = 1
+rows_returned = 1

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_non_existing_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_non_existing_fails.snap
@@ -1,0 +1,75 @@
+---
+source: crates/postgres/tests/integration/tags/attach_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*)
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+  AND "descendant_id" = $2'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "tag_path_ancestors"."ancestor_id",
+      "tag_path_descendants"."descendant_id",
+      "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+    FROM
+      "tag_paths" AS "tag_path_ancestors"
+    INNER JOIN
+      "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+    WHERE
+      "tag_path_ancestors"."descendant_id" = $1
+      AND "tag_path_descendants"."ancestor_id" = $2
+      AND "tag_path_ancestors"."ancestor_id" <> $3
+      AND "tag_path_descendants"."descendant_id" <> $4
+  )'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "ancestor_id",
+      "descendant_id",
+      "distance"
+    WHERE
+      "descendant_id" = $1
+      AND "ancestor_id" <> "descendant_id"
+  )'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_root_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_root_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/postgres/tests/integration/tags/attach_by_id.rs
+expression: ctx.queries()
+---
+queries = []

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_root_parent_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_root_parent_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/postgres/tests/integration/tags/attach_by_id.rs
+expression: ctx.queries()
+---
+queries = []

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_self_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_self_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/postgres/tests/integration/tags/attach_by_id.rs
+expression: ctx.queries()
+---
+queries = []

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_with_depth_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_with_depth_succeeds.snap
@@ -1,0 +1,176 @@
+---
+source: crates/postgres/tests/integration/tags/attach_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*)
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+  AND "descendant_id" = $2'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "tag_path_ancestors"."ancestor_id",
+      "tag_path_descendants"."descendant_id",
+      "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+    FROM
+      "tag_paths" AS "tag_path_ancestors"
+    INNER JOIN
+      "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+    WHERE
+      "tag_path_ancestors"."descendant_id" = $1
+      AND "tag_path_descendants"."ancestor_id" = $2
+      AND "tag_path_ancestors"."ancestor_id" <> $3
+      AND "tag_path_descendants"."descendant_id" <> $4
+  )'''
+rows_affected = 8
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "ancestor_id",
+      "descendant_id",
+      "distance"
+    WHERE
+      "descendant_id" = $1
+      AND "ancestor_id" <> "descendant_id"
+  )'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "tag_path_ancestors"."ancestor_id",
+  "tag_path_descendants"."descendant_id",
+  "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+FROM
+  "tag_paths" AS "tag_path_ancestors"
+INNER JOIN
+  "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+WHERE
+  "tag_path_ancestors"."descendant_id" = $1
+  AND "tag_path_descendants"."ancestor_id" = $2
+  AND "tag_path_ancestors"."ancestor_id" <> $3
+  AND "tag_path_descendants"."descendant_id" <> $4'''
+rows_affected = 8
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $6
+    AND "ancestor_id" IN ($7)
+  )
+  OR (
+    "distance" <= $8
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $9
+        AND "descendant_id" IN ($10)
+    )
+  )
+  OR (
+    "distance" <= $11
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "ancestor_id" IN ($13)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_without_depth_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__attach_by_id____test_context_wrapped_without_depth_succeeds.snap
@@ -1,0 +1,150 @@
+---
+source: crates/postgres/tests/integration/tags/attach_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  COUNT(*)
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+  AND "descendant_id" = $2'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "tag_path_ancestors"."ancestor_id",
+      "tag_path_descendants"."descendant_id",
+      "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+    FROM
+      "tag_paths" AS "tag_path_ancestors"
+    INNER JOIN
+      "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+    WHERE
+      "tag_path_ancestors"."descendant_id" = $1
+      AND "tag_path_descendants"."ancestor_id" = $2
+      AND "tag_path_ancestors"."ancestor_id" <> $3
+      AND "tag_path_descendants"."descendant_id" <> $4
+  )'''
+rows_affected = 8
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "ancestor_id",
+      "descendant_id",
+      "distance"
+    WHERE
+      "descendant_id" = $1
+      AND "ancestor_id" <> "descendant_id"
+  )'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "tag_path_ancestors"."ancestor_id",
+  "tag_path_descendants"."descendant_id",
+  "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+FROM
+  "tag_paths" AS "tag_path_ancestors"
+INNER JOIN
+  "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+WHERE
+  "tag_path_ancestors"."descendant_id" = $1
+  AND "tag_path_descendants"."ancestor_id" = $2
+  AND "tag_path_ancestors"."ancestor_id" <> $3
+  AND "tag_path_descendants"."descendant_id" <> $4'''
+rows_affected = 8
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $6
+  AND "ancestor_id" IN ($7)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__create____test_context_wrapped_with_parent_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__create____test_context_wrapped_with_parent_succeeds.snap
@@ -1,0 +1,139 @@
+---
+source: crates/postgres/tests/integration/tags/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "tags" ("name", "kana", "aliases")
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+VALUES
+  ($1, $2, $3)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "tag_path_ancestors"."ancestor_id",
+  "tag_path_descendants"."descendant_id",
+  "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+FROM
+  "tag_paths" AS "tag_path_ancestors"
+INNER JOIN
+  "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+WHERE
+  "tag_path_ancestors"."descendant_id" = $1
+  AND "tag_path_descendants"."ancestor_id" = $2
+  AND "tag_path_ancestors"."ancestor_id" <> $3
+  AND "tag_path_descendants"."descendant_id" <> $4'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $6
+    AND "ancestor_id" IN ($7)
+  )
+  OR (
+    "distance" <= $8
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $9
+        AND "descendant_id" IN ($10)
+    )
+  )
+  OR (
+    "distance" <= $11
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "ancestor_id" IN ($13)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 5
+rows_returned = 5
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__create____test_context_wrapped_without_parent_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__create____test_context_wrapped_without_parent_succeeds.snap
@@ -1,0 +1,139 @@
+---
+source: crates/postgres/tests/integration/tags/create.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+INSERT INTO
+  "tags" ("name", "kana", "aliases")
+VALUES
+  ($1, $2, $3)
+RETURNING
+  "id"'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+VALUES
+  ($1, $2, $3)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "tag_path_ancestors"."ancestor_id",
+  "tag_path_descendants"."descendant_id",
+  "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+FROM
+  "tag_paths" AS "tag_path_ancestors"
+INNER JOIN
+  "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+WHERE
+  "tag_path_ancestors"."descendant_id" = $1
+  AND "tag_path_descendants"."ancestor_id" = $2
+  AND "tag_path_ancestors"."ancestor_id" <> $3
+  AND "tag_path_descendants"."descendant_id" <> $4'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $6
+    AND "ancestor_id" IN ($7)
+  )
+  OR (
+    "distance" <= $8
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $9
+        AND "descendant_id" IN ($10)
+    )
+  )
+  OR (
+    "distance" <= $11
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "ancestor_id" IN ($13)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_leaf_with_recursive_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_leaf_with_recursive_succeeds.snap
@@ -1,0 +1,63 @@
+---
+source: crates/postgres/tests/integration/tags/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "descendant_id",
+  "distance"
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+ORDER BY
+  "ancestor_id" ASC,
+  "descendant_id" ASC
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tags"
+WHERE
+  "id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "descendant_id",
+  "distance"
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+ORDER BY
+  "ancestor_id" ASC,
+  "descendant_id" ASC
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tags"
+WHERE
+  $1 = $2'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_leaf_without_recursive_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_leaf_without_recursive_succeeds.snap
@@ -1,0 +1,63 @@
+---
+source: crates/postgres/tests/integration/tags/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "descendant_id",
+  "distance"
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+ORDER BY
+  "ancestor_id" ASC,
+  "descendant_id" ASC
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tags"
+WHERE
+  "id" IN ($1)'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "descendant_id",
+  "distance"
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+ORDER BY
+  "ancestor_id" ASC,
+  "descendant_id" ASC
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tags"
+WHERE
+  $1 = $2'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_node_with_recursive_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_node_with_recursive_succeeds.snap
@@ -1,0 +1,63 @@
+---
+source: crates/postgres/tests/integration/tags/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "descendant_id",
+  "distance"
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+ORDER BY
+  "ancestor_id" ASC,
+  "descendant_id" ASC
+FOR UPDATE'''
+rows_affected = 7
+rows_returned = 7
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tags"
+WHERE
+  "id" IN ($1, $2, $3, $4, $5, $6, $7)'''
+rows_affected = 7
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "descendant_id",
+  "distance"
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+ORDER BY
+  "ancestor_id" ASC,
+  "descendant_id" ASC
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tags"
+WHERE
+  $1 = $2'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_node_without_recursive_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_node_without_recursive_fails.snap
@@ -1,0 +1,19 @@
+---
+source: crates/postgres/tests/integration/tags/delete_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "descendant_id",
+  "distance"
+FROM
+  "tag_paths"
+WHERE
+  "ancestor_id" = $1
+ORDER BY
+  "ancestor_id" ASC,
+  "descendant_id" ASC
+FOR UPDATE'''
+rows_affected = 7
+rows_returned = 7

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_root_with_recursive_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_root_with_recursive_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/postgres/tests/integration/tags/delete_by_id.rs
+expression: ctx.queries()
+---
+queries = []

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_root_without_recursive_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__delete_by_id____test_context_wrapped_root_without_recursive_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/postgres/tests/integration/tags/delete_by_id.rs
+expression: ctx.queries()
+---
+queries = []

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_non_existing_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_non_existing_fails.snap
@@ -1,0 +1,63 @@
+---
+source: crates/postgres/tests/integration/tags/detach_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "tag_path_ancestors"."ancestor_id",
+      "tag_path_descendants"."descendant_id",
+      "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+    FROM
+      "tag_paths" AS "tag_path_ancestors"
+    INNER JOIN
+      "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+    WHERE
+      "tag_path_ancestors"."descendant_id" = $1
+      AND "tag_path_descendants"."ancestor_id" = $2
+      AND "tag_path_ancestors"."ancestor_id" <> $3
+      AND "tag_path_descendants"."descendant_id" <> $4
+  )'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "ancestor_id",
+      "descendant_id",
+      "distance"
+    WHERE
+      "descendant_id" = $1
+      AND "ancestor_id" <> "descendant_id"
+  )'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_root_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_root_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/postgres/tests/integration/tags/detach_by_id.rs
+expression: ctx.queries()
+---
+queries = []

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_with_depth_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_with_depth_succeeds.snap
@@ -1,0 +1,164 @@
+---
+source: crates/postgres/tests/integration/tags/detach_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "tag_path_ancestors"."ancestor_id",
+      "tag_path_descendants"."descendant_id",
+      "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+    FROM
+      "tag_paths" AS "tag_path_ancestors"
+    INNER JOIN
+      "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+    WHERE
+      "tag_path_ancestors"."descendant_id" = $1
+      AND "tag_path_descendants"."ancestor_id" = $2
+      AND "tag_path_ancestors"."ancestor_id" <> $3
+      AND "tag_path_descendants"."descendant_id" <> $4
+  )'''
+rows_affected = 8
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "ancestor_id",
+      "descendant_id",
+      "distance"
+    WHERE
+      "descendant_id" = $1
+      AND "ancestor_id" <> "descendant_id"
+  )'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "tag_path_ancestors"."ancestor_id",
+  "tag_path_descendants"."descendant_id",
+  "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+FROM
+  "tag_paths" AS "tag_path_ancestors"
+INNER JOIN
+  "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+WHERE
+  "tag_path_ancestors"."descendant_id" = $1
+  AND "tag_path_descendants"."ancestor_id" = $2
+  AND "tag_path_ancestors"."ancestor_id" <> $3
+  AND "tag_path_descendants"."descendant_id" <> $4'''
+rows_affected = 4
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $6
+    AND "ancestor_id" IN ($7)
+  )
+  OR (
+    "distance" <= $8
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $9
+        AND "descendant_id" IN ($10)
+    )
+  )
+  OR (
+    "distance" <= $11
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "ancestor_id" IN ($13)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 11
+rows_returned = 11
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_without_depth_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__detach_by_id____test_context_wrapped_without_depth_succeeds.snap
@@ -1,0 +1,138 @@
+---
+source: crates/postgres/tests/integration/tags/detach_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "tag_path_ancestors"."ancestor_id",
+      "tag_path_descendants"."descendant_id",
+      "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+    FROM
+      "tag_paths" AS "tag_path_ancestors"
+    INNER JOIN
+      "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+    WHERE
+      "tag_path_ancestors"."descendant_id" = $1
+      AND "tag_path_descendants"."ancestor_id" = $2
+      AND "tag_path_ancestors"."ancestor_id" <> $3
+      AND "tag_path_descendants"."descendant_id" <> $4
+  )'''
+rows_affected = 8
+rows_returned = 0
+
+[[queries]]
+sql = '''
+DELETE FROM
+  "tag_paths"
+WHERE
+  ("ancestor_id", "descendant_id", "distance") IN (
+    SELECT
+      "ancestor_id",
+      "descendant_id",
+      "distance"
+    WHERE
+      "descendant_id" = $1
+      AND "ancestor_id" <> "descendant_id"
+  )'''
+rows_affected = 2
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "ancestor_id",
+  $1,
+  "distance" + $2
+FROM
+  "tag_paths"
+WHERE
+  "descendant_id" = $3'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+INSERT INTO
+  "tag_paths" ("ancestor_id", "descendant_id", "distance")
+SELECT
+  "tag_path_ancestors"."ancestor_id",
+  "tag_path_descendants"."descendant_id",
+  "tag_path_ancestors"."distance" + "tag_path_descendants"."distance"
+FROM
+  "tag_paths" AS "tag_path_ancestors"
+INNER JOIN
+  "tag_paths" AS "tag_path_descendants" ON "tag_path_ancestors"."descendant_id" = "tag_path_descendants"."ancestor_id"
+WHERE
+  "tag_path_ancestors"."descendant_id" = $1
+  AND "tag_path_descendants"."ancestor_id" = $2
+  AND "tag_path_ancestors"."ancestor_id" <> $3
+  AND "tag_path_descendants"."descendant_id" <> $4'''
+rows_affected = 4
+rows_returned = 0
+
+[[queries]]
+sql = 'RELEASE SAVEPOINT _sqlx_savepoint_1'
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $6
+  AND "ancestor_id" IN ($7)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all____test_context_wrapped_with_out_of_bounds_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all____test_context_wrapped_with_out_of_bounds_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 0
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $3)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $4
+    AND $5 = $6
+  )
+  OR (
+    "distance" <= $7
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $8
+        AND $9 = $10
+    )
+  )
+  OR (
+    "distance" <= $11
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND $13 = $14
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_asc_succeeds.snap
@@ -1,0 +1,90 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $2'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 11
+rows_returned = 11

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_desc_succeeds.snap
@@ -1,0 +1,90 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $2'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 19
+rows_returned = 19

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_since_asc_succeeds.snap
@@ -1,0 +1,91 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 17
+rows_returned = 17

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_since_desc_succeeds.snap
@@ -1,0 +1,91 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_until_asc_succeeds.snap
@@ -1,0 +1,91 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_no_root_until_desc_succeeds.snap
@@ -1,0 +1,91 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 17
+rows_returned = 17

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_asc_succeeds.snap
@@ -1,0 +1,94 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND "tag_paths"."ancestor_id" = $2
+  AND "tag_paths"."distance" = $3
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_desc_succeeds.snap
@@ -1,0 +1,94 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND "tag_paths"."ancestor_id" = $2
+  AND "tag_paths"."distance" = $3
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 27
+rows_returned = 27

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_since_asc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 17
+rows_returned = 17

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_since_desc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_until_asc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_depth____test_context_wrapped_root_until_desc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 17
+rows_returned = 17

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_asc_succeeds.snap
@@ -1,0 +1,64 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $2'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $10
+  AND "ancestor_id" IN ($11, $12, $13)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_desc_succeeds.snap
@@ -1,0 +1,64 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $2'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $10
+  AND "ancestor_id" IN ($11, $12, $13)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_since_asc_succeeds.snap
@@ -1,0 +1,65 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $10
+  AND "ancestor_id" IN ($11, $12, $13)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_since_desc_succeeds.snap
@@ -1,0 +1,65 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $10
+  AND "ancestor_id" IN ($11, $12, $13)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_until_asc_succeeds.snap
@@ -1,0 +1,65 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $10
+  AND "ancestor_id" IN ($11, $12, $13)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_no_root_until_desc_succeeds.snap
@@ -1,0 +1,65 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $10
+  AND "ancestor_id" IN ($11, $12, $13)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 3
+rows_returned = 3

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_asc_succeeds.snap
@@ -1,0 +1,94 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND "tag_paths"."ancestor_id" = $2
+  AND "tag_paths"."distance" = $3
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_desc_succeeds.snap
@@ -1,0 +1,94 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND "tag_paths"."ancestor_id" = $2
+  AND "tag_paths"."distance" = $3
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $4'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 23
+rows_returned = 23

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_since_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_since_asc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_since_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_since_desc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_until_asc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_until_asc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") < ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" DESC,
+  "tags"."id" DESC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 5
+rows_returned = 5

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_until_desc_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_all_with_no_depth____test_context_wrapped_root_until_desc_succeeds.snap
@@ -1,0 +1,95 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_all_with_no_depth.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+INNER JOIN
+  "tag_paths" ON "tag_paths"."descendant_id" = "tags"."id"
+WHERE
+  "tags"."id" <> $1
+  AND ("tags"."kana", "tags"."id") > ($2, $3)
+  AND "tag_paths"."ancestor_id" = $4
+  AND "tag_paths"."distance" = $5
+ORDER BY
+  "tags"."kana" ASC,
+  "tags"."id" ASC
+LIMIT
+  $6'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_ids____test_context_wrapped_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_ids____test_context_wrapped_succeeds.snap
@@ -1,0 +1,74 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_by_ids.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_alias_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_alias_succeeds.snap
@@ -1,0 +1,97 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_by_name_or_alias_like.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+LEFT JOIN
+  (
+    SELECT
+      "id",
+      unnest("aliases") AS "alias"
+    FROM
+      "tags"
+  ) AS "tags_aliases" ON "tags_aliases"."id" = "tags"."id"
+WHERE
+  ("name" ILIKE $1)
+  OR ("kana" ILIKE $2)
+  OR ("alias" ILIKE $3)
+ORDER BY
+  "kana" ASC'''
+rows_affected = 2
+rows_returned = 2
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $7)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $8
+    AND "ancestor_id" IN ($9, $10)
+  )
+  OR (
+    "distance" <= $11
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "descendant_id" IN ($13, $14)
+    )
+  )
+  OR (
+    "distance" <= $15
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $16
+        AND "ancestor_id" IN ($17, $18)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 7
+rows_returned = 7

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_name_and_alias_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_name_and_alias_succeeds.snap
@@ -1,0 +1,97 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_by_name_or_alias_like.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+LEFT JOIN
+  (
+    SELECT
+      "id",
+      unnest("aliases") AS "alias"
+    FROM
+      "tags"
+  ) AS "tags_aliases" ON "tags_aliases"."id" = "tags"."id"
+WHERE
+  ("name" ILIKE $1)
+  OR ("kana" ILIKE $2)
+  OR ("alias" ILIKE $3)
+ORDER BY
+  "kana" ASC'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 11
+rows_returned = 11

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_name_case_insensitive_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_name_case_insensitive_succeeds.snap
@@ -1,0 +1,97 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_by_name_or_alias_like.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+LEFT JOIN
+  (
+    SELECT
+      "id",
+      unnest("aliases") AS "alias"
+    FROM
+      "tags"
+  ) AS "tags_aliases" ON "tags_aliases"."id" = "tags"."id"
+WHERE
+  ("name" ILIKE $1)
+  OR ("kana" ILIKE $2)
+  OR ("alias" ILIKE $3)
+ORDER BY
+  "kana" ASC'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $6
+    AND "ancestor_id" IN ($7)
+  )
+  OR (
+    "distance" <= $8
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $9
+        AND "descendant_id" IN ($10)
+    )
+  )
+  OR (
+    "distance" <= $11
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "ancestor_id" IN ($13)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 11
+rows_returned = 11

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_name_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__fetch_by_name_or_alias_like____test_context_wrapped_with_name_succeeds.snap
@@ -1,0 +1,97 @@
+---
+source: crates/postgres/tests/integration/tags/fetch_by_name_or_alias_like.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "tags"."id"
+FROM
+  "tags"
+LEFT JOIN
+  (
+    SELECT
+      "id",
+      unnest("aliases") AS "alias"
+    FROM
+      "tags"
+  ) AS "tags_aliases" ON "tags_aliases"."id" = "tags"."id"
+WHERE
+  ("name" ILIKE $1)
+  OR ("kana" ILIKE $2)
+  OR ("alias" ILIKE $3)
+ORDER BY
+  "kana" ASC'''
+rows_affected = 3
+rows_returned = 3
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4), ($5, $6), ($7, $8)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $9)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $10
+    AND "ancestor_id" IN ($11, $12, $13)
+  )
+  OR (
+    "distance" <= $14
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $15
+        AND "descendant_id" IN ($16, $17, $18)
+    )
+  )
+  OR (
+    "distance" <= $19
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $20
+        AND "ancestor_id" IN ($21, $22, $23)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 15
+rows_returned = 15

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_fails.snap
@@ -1,0 +1,20 @@
+---
+source: crates/postgres/tests/integration/tags/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "name",
+  "kana",
+  "aliases",
+  "created_at",
+  "updated_at"
+FROM
+  "tags"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_root_fails.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_root_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/postgres/tests/integration/tags/update_by_id.rs
+expression: ctx.queries()
+---
+queries = []

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_with_depth_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_with_depth_succeeds.snap
@@ -1,0 +1,110 @@
+---
+source: crates/postgres/tests/integration/tags/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "name",
+  "kana",
+  "aliases",
+  "created_at",
+  "updated_at"
+FROM
+  "tags"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "tags"
+SET
+  "name" = $1,
+  "kana" = $2,
+  "aliases" = $3,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $4'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  (
+    "distance" = $6
+    AND "ancestor_id" IN ($7)
+  )
+  OR (
+    "distance" <= $8
+    AND "descendant_id" IN (
+      SELECT
+        "ancestor_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $9
+        AND "descendant_id" IN ($10)
+    )
+  )
+  OR (
+    "distance" <= $11
+    AND "ancestor_id" IN (
+      SELECT
+        "descendant_id"
+      FROM
+        "tag_paths"
+      WHERE
+        "distance" <= $12
+        AND "ancestor_id" IN ($13)
+    )
+  )
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 13
+rows_returned = 13
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0

--- a/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_without_depth_succeeds.snap
+++ b/api/crates/postgres/tests/integration/tags/snapshots/integration__tags__update_by_id____test_context_wrapped_without_depth_succeeds.snap
@@ -1,0 +1,84 @@
+---
+source: crates/postgres/tests/integration/tags/update_by_id.rs
+expression: ctx.queries()
+---
+[[queries]]
+sql = '''
+SELECT
+  "id",
+  "name",
+  "kana",
+  "aliases",
+  "created_at",
+  "updated_at"
+FROM
+  "tags"
+WHERE
+  "id" = $1
+FOR UPDATE'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = '''
+UPDATE
+  "tags"
+SET
+  "name" = $1,
+  "kana" = $2,
+  "aliases" = $3,
+  "updated_at" = CURRENT_TIMESTAMP
+WHERE
+  "id" = $4'''
+rows_affected = 1
+rows_returned = 0
+
+[[queries]]
+sql = '''
+SELECT
+  "tag_orders"."order",
+  "distance",
+  "tag_ancestors"."id" AS "ancestor_id",
+  "tag_ancestors"."name" AS "ancestor_name",
+  "tag_ancestors"."kana" AS "ancestor_kana",
+  "tag_ancestors"."aliases" AS "ancestor_aliases",
+  "tag_ancestors"."created_at" AS "ancestor_created_at",
+  "tag_ancestors"."updated_at" AS "ancestor_updated_at",
+  "tag_descendants"."id" AS "descendant_id",
+  "tag_descendants"."name" AS "descendant_name",
+  "tag_descendants"."kana" AS "descendant_kana",
+  "tag_descendants"."aliases" AS "descendant_aliases",
+  "tag_descendants"."created_at" AS "descendant_created_at",
+  "tag_descendants"."updated_at" AS "descendant_updated_at"
+FROM
+  "tag_paths"
+LEFT JOIN
+  (
+    SELECT
+      "column1" AS "order",
+      "column2" AS "id"
+    FROM
+      (
+        VALUES
+          ($1, $2), ($3, $4)) AS "tag_orders"
+  ) AS "tag_orders" ON "tag_orders"."id" = "descendant_id"
+  AND "ancestor_id" IN ("descendant_id", $5)
+INNER JOIN
+  "tags" AS "tag_ancestors" ON "tag_ancestors"."id" = "tag_paths"."ancestor_id"
+INNER JOIN
+  "tags" AS "tag_descendants" ON "tag_descendants"."id" = "tag_paths"."descendant_id"
+WHERE
+  "distance" = $6
+  AND "ancestor_id" IN ($7)
+ORDER BY
+  "distance" ASC,
+  "tag_orders"."order" ASC,
+  "tag_ancestors"."kana" ASC,
+  "tag_descendants"."kana" ASC'''
+rows_affected = 1
+rows_returned = 1
+
+[[queries]]
+sql = 'COMMIT'
+rows_affected = 0
+rows_returned = 0


### PR DESCRIPTION
This PR introduces snapshot testing using insta for SQLs in the `postgres` crate.