### PR TITLE
Use `either` crate for iterators in different types

### DIFF
--- a/api/crates/graphql/Cargo.toml
+++ b/api/crates/graphql/Cargo.toml
@@ -36,6 +36,9 @@ default-features = false
 version = "2.0.1"
 features = ["constructor"]
 
+[dependencies.either]
+version = "1.15.0"
+
 [dependencies.futures]
 version = "0.3.31"
 features = ["std"]


### PR DESCRIPTION
This PR refactors `graphql` by using `either` crate for iterators that have different concrete types.