### PR TITLE
Bump sea-query from 0.32.7 to 1.0.0-rc.14 in /api in the sea-query group

### DIFF
--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -2464,7 +2464,7 @@ dependencies = [
  "ordermap",
  "pretty_assertions",
  "sea-query",
- "sea-query-binder",
+ "sea-query-sqlx",
  "serde",
  "serde_json",
  "serde_with",
@@ -2826,9 +2826,9 @@ checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "sea-query"
-version = "0.32.7"
+version = "1.0.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
+checksum = "fdeac8832b5b36a57b38ef6d2956cd6244c04508669f2a932439c8ca25dbad0f"
 dependencies = [
  "chrono",
  "inherent",
@@ -2838,30 +2838,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sea-query-binder"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
-dependencies = [
- "chrono",
- "sea-query",
- "serde_json",
- "sqlx",
- "uuid",
-]
-
-[[package]]
 name = "sea-query-derive"
-version = "0.4.2"
+version = "1.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9834af2c4bd8c5162f00c89f1701fb6886119a88062cf76fe842ea9e232b9839"
+checksum = "217e9422de35f26c16c5f671fce3c075a65e10322068dbc66078428634af6195"
 dependencies = [
  "darling 0.20.10",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
- "thiserror 1.0.68",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.8.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68873fa1776b4c25a26e7679f8ee22332978c721168ec1b0b32b6583d5a9381d"
+dependencies = [
+ "chrono",
+ "sea-query",
+ "serde_json",
+ "sqlx",
+ "uuid",
 ]
 
 [[package]]

--- a/api/crates/postgres/Cargo.toml
+++ b/api/crates/postgres/Cargo.toml
@@ -41,12 +41,12 @@ version = "0.5.12"
 features = ["serde"]
 
 [dependencies.sea-query]
-version = "0.32.7"
+version = "1.0.0-rc.14"
 features = ["derive", "backend-postgres", "thread-safe"]
 default-features = false
 
-[dependencies.sea-query-binder]
-version = "0.7.0"
+[dependencies.sea-query-sqlx]
+version = "0.8.0-rc.9"
 features = ["postgres-array", "sqlx-postgres", "with-chrono", "with-json", "with-uuid"]
 
 [dependencies.serde]

--- a/api/crates/postgres/src/expr.rs
+++ b/api/crates/postgres/src/expr.rs
@@ -1,4 +1,4 @@
-use sea_query::{SimpleExpr, Value};
+use sea_query::{Expr, Value};
 
 pub(crate) mod aggregate;
 pub(crate) mod array;
@@ -6,15 +6,15 @@ pub(crate) mod conditional;
 pub(crate) mod notify;
 pub(crate) mod string;
 
-pub(crate) trait SimpleExprTrait {
-    fn to_constant(self) -> SimpleExpr;
+pub(crate) trait ExprTrait {
+    fn to_constant(self) -> Expr;
 }
 
-impl<T> SimpleExprTrait for T
+impl<T> ExprTrait for T
 where
     T: Into<Value>,
 {
-    fn to_constant(self) -> SimpleExpr {
-        SimpleExpr::Constant(self.into())
+    fn to_constant(self) -> Expr {
+        Expr::Constant(self.into())
     }
 }

--- a/api/crates/postgres/src/expr/aggregate.rs
+++ b/api/crates/postgres/src/expr/aggregate.rs
@@ -1,11 +1,11 @@
-use sea_query::{Expr, SimpleExpr};
+use sea_query::Expr;
 
 pub(crate) struct AggregateExpr;
 
 impl AggregateExpr {
-    pub fn bool_or<T>(arg: T) -> SimpleExpr
+    pub fn bool_or<T>(arg: T) -> Expr
     where
-        T: Into<SimpleExpr>,
+        T: Into<Expr>,
     {
         Expr::cust_with_expr("bool_or($1)", arg)
     }

--- a/api/crates/postgres/src/expr/array.rs
+++ b/api/crates/postgres/src/expr/array.rs
@@ -1,27 +1,27 @@
-use sea_query::{Expr, SimpleExpr};
+use sea_query::Expr;
 
 pub(crate) struct ArrayExpr;
 
 impl ArrayExpr {
-    pub fn length<T1, T2>(arg1: T1, arg2: T2) -> SimpleExpr
+    pub fn length<T1, T2>(arg1: T1, arg2: T2) -> Expr
     where
-        T1: Into<SimpleExpr>,
-        T2: Into<SimpleExpr>,
+        T1: Into<Expr>,
+        T2: Into<Expr>,
     {
         Expr::cust_with_exprs("array_length($1, $2)", [arg1.into(), arg2.into()])
     }
 
-    pub fn string_to_array<T1, T2>(arg1: T1, arg2: T2) -> SimpleExpr
+    pub fn string_to_array<T1, T2>(arg1: T1, arg2: T2) -> Expr
     where
-        T1: Into<SimpleExpr>,
-        T2: Into<SimpleExpr>,
+        T1: Into<Expr>,
+        T2: Into<Expr>,
     {
         Expr::cust_with_exprs("string_to_array($1, $2)", [arg1.into(), arg2.into()])
     }
 
-    pub fn unnest<T>(arg: T) -> SimpleExpr
+    pub fn unnest<T>(arg: T) -> Expr
     where
-        T: Into<SimpleExpr>,
+        T: Into<Expr>,
     {
         Expr::cust_with_expr("unnest($1)", arg)
     }

--- a/api/crates/postgres/src/expr/conditional.rs
+++ b/api/crates/postgres/src/expr/conditional.rs
@@ -1,12 +1,12 @@
-use sea_query::{Expr, SimpleExpr};
+use sea_query::Expr;
 
 pub(crate) struct ConditionalExpr;
 
 impl ConditionalExpr {
-    pub fn null_if<T1, T2>(arg1: T1, arg2: T2) -> SimpleExpr
+    pub fn null_if<T1, T2>(arg1: T1, arg2: T2) -> Expr
     where
-        T1: Into<SimpleExpr>,
-        T2: Into<SimpleExpr>,
+        T1: Into<Expr>,
+        T2: Into<Expr>,
     {
         Expr::cust_with_exprs("NULLIF($1, $2)", [arg1.into(), arg2.into()])
     }

--- a/api/crates/postgres/src/expr/notify.rs
+++ b/api/crates/postgres/src/expr/notify.rs
@@ -1,9 +1,9 @@
-use sea_query::{Expr, SimpleExpr};
+use sea_query::Expr;
 
 pub(crate) struct NotifyExpr;
 
 impl NotifyExpr {
-    pub fn notify<T1, T2>(arg1: T1, arg2: T2) -> SimpleExpr
+    pub fn notify<T1, T2>(arg1: T1, arg2: T2) -> Expr
     where
         T1: ToString,
         T2: ToString,

--- a/api/crates/postgres/src/expr/string.rs
+++ b/api/crates/postgres/src/expr/string.rs
@@ -1,29 +1,29 @@
-use sea_query::{Expr, SimpleExpr};
+use sea_query::Expr;
 
 pub(crate) struct StringExpr;
 
 impl StringExpr {
-    pub fn regexp_replace<T1, T2, T3>(arg1: T1, arg2: T2, arg3: T3) -> SimpleExpr
+    pub fn regexp_replace<T1, T2, T3>(arg1: T1, arg2: T2, arg3: T3) -> Expr
     where
-        T1: Into<SimpleExpr>,
-        T2: Into<SimpleExpr>,
-        T3: Into<SimpleExpr>,
+        T1: Into<Expr>,
+        T2: Into<Expr>,
+        T3: Into<Expr>,
     {
         Expr::cust_with_exprs("regexp_replace($1, $2, $3)", [arg1.into(), arg2.into(), arg3.into()])
     }
 
-    pub fn rtrim<T1, T2>(arg1: T1, arg2: T2) -> SimpleExpr
+    pub fn rtrim<T1, T2>(arg1: T1, arg2: T2) -> Expr
     where
-        T1: Into<SimpleExpr>,
-        T2: Into<SimpleExpr>,
+        T1: Into<Expr>,
+        T2: Into<Expr>,
     {
         Expr::cust_with_exprs("rtrim($1, $2)", [arg1.into(), arg2.into()])
     }
 
-    pub fn strpos<T1, T2>(arg1: T1, arg2: T2) -> SimpleExpr
+    pub fn strpos<T1, T2>(arg1: T1, arg2: T2) -> Expr
     where
-        T1: Into<SimpleExpr>,
-        T2: Into<SimpleExpr>,
+        T1: Into<Expr>,
+        T2: Into<Expr>,
     {
         Expr::cust_with_exprs("strpos($1, $2)", [arg1.into(), arg2.into()])
     }

--- a/api/crates/postgres/src/external_services.rs
+++ b/api/crates/postgres/src/external_services.rs
@@ -5,8 +5,8 @@ use domain::{
     repository::{external_services::ExternalServicesRepository, DeleteResult},
 };
 use futures::TryStreamExt;
-use sea_query::{Expr, Iden, LockType, Order, PostgresQueryBuilder, Query};
-use sea_query_binder::SqlxBinder;
+use sea_query::{Expr, ExprTrait, Iden, LockType, Order, PostgresQueryBuilder, Query};
+use sea_query_sqlx::SqlxBinder;
 use sqlx::{FromRow, PgPool};
 
 use crate::sea_query_uuid_value;

--- a/api/crates/postgres/src/media.rs
+++ b/api/crates/postgres/src/media.rs
@@ -16,13 +16,13 @@ use domain::{
 };
 use futures::{future::ready, stream, Stream, StreamExt, TryStreamExt};
 use ordermap::{OrderMap, OrderSet};
-use sea_query::{BinOper, Expr, Iden, JoinType, Keyword, LockType, OnConflict, Order, PgFunc, PostgresQueryBuilder, Query};
-use sea_query_binder::SqlxBinder;
+use sea_query::{BinOper, Expr, ExprTrait, Iden, JoinType, Keyword, LockType, OnConflict, Order, PgFunc, PostgresQueryBuilder, Query};
+use sea_query_sqlx::SqlxBinder;
 use sqlx::{postgres::PgListener, types::Json, FromRow, PgConnection, PgPool};
 use tracing_futures::Instrument;
 
 use crate::{
-    expr::SimpleExprTrait,
+    expr::ExprTrait as _,
     external_services::{PostgresExternalService, PostgresExternalServiceId},
     replicas::{PostgresMediumReplica, PostgresReplica, PostgresReplicaId, PostgresReplicaNotification, PostgresReplicaThumbnail, PostgresReplicaThumbnailRow, PostgresThumbnail},
     sea_query_uuid_value,

--- a/api/crates/postgres/src/migrations/v1.rs
+++ b/api/crates/postgres/src/migrations/v1.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use domain::entity::tags::TagId;
-use sea_query::{ColumnDef, ColumnType, Expr, ForeignKey, ForeignKeyAction, Index, OnConflict, PgFunc, PostgresQueryBuilder, Query, Table};
-use sea_query_binder::SqlxBinder;
+use sea_query::{ColumnDef, ColumnType, Expr, ExprTrait, ForeignKey, ForeignKeyAction, Index, OnConflict, PgFunc, PostgresQueryBuilder, Query, Table};
+use sea_query_sqlx::SqlxBinder;
 use sqlx::{Connection, PgConnection, Postgres};
 use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
 use uuid::Uuid;

--- a/api/crates/postgres/src/migrations/v2.rs
+++ b/api/crates/postgres/src/migrations/v2.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use domain::entity::objects::{EntryUrl, EntryUrlPath};
-use sea_query::{Expr, LockType, PostgresQueryBuilder, Query};
-use sea_query_binder::SqlxBinder;
+use sea_query::{Expr, ExprTrait, LockType, PostgresQueryBuilder, Query};
+use sea_query_sqlx::SqlxBinder;
 use sqlx::{migrate::MigrateError, FromRow, Connection, PgConnection, Postgres};
 use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
 

--- a/api/crates/postgres/src/migrations/v3.rs
+++ b/api/crates/postgres/src/migrations/v3.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sea_query::{ColumnDef, Expr, Iden, PostgresQueryBuilder, Query, Table};
+use sea_query::{ColumnDef, Expr, ExprTrait, Iden, PostgresQueryBuilder, Query, Table};
 use sqlx::{PgConnection, Postgres};
 use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
 

--- a/api/crates/postgres/src/migrations/v4.rs
+++ b/api/crates/postgres/src/migrations/v4.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sea_query::{BinOper, Expr, PostgresQueryBuilder, Query};
+use sea_query::{BinOper, Expr, ExprTrait, PostgresQueryBuilder, Query};
 use sqlx::{PgConnection, Postgres};
 use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
 

--- a/api/crates/postgres/src/migrations/v6.rs
+++ b/api/crates/postgres/src/migrations/v6.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sea_query::{extension::postgres::PgExpr, Expr, PostgresQueryBuilder, Query};
+use sea_query::{extension::postgres::PgExpr, Expr, ExprTrait, PostgresQueryBuilder, Query};
 use sqlx::{PgConnection, Postgres};
 use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
 

--- a/api/crates/postgres/src/migrations/v8.rs
+++ b/api/crates/postgres/src/migrations/v8.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use sea_query::{extension::postgres::PgExpr, ColumnDef, Expr, PostgresQueryBuilder, Query, Table};
+use sea_query::{extension::postgres::PgExpr, ColumnDef, Expr, ExprTrait, PostgresQueryBuilder, Query, Table};
 use sqlx::{PgConnection, Postgres};
 use sqlx_migrator::{error::Error, migration::Migration, operation::Operation, vec_box};
 

--- a/api/crates/postgres/src/replicas.rs
+++ b/api/crates/postgres/src/replicas.rs
@@ -11,14 +11,14 @@ use domain::{
     error::{Error, ErrorKind, Result},
     repository::{replicas::ReplicasRepository, DeleteResult},
 };
-use sea_query::{Asterisk, Expr, Iden, JoinType, Keyword, LockType, OnConflict, Order, PostgresQueryBuilder, Query, Value};
-use sea_query_binder::SqlxBinder;
+use sea_query::{Asterisk, Expr, ExprTrait, Iden, JoinType, Keyword, LockType, OnConflict, Order, PostgresQueryBuilder, Query, Value};
+use sea_query_sqlx::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::{FromRow, PgPool, Row, Type};
 
 use crate::{
-    expr::{notify::NotifyExpr, SimpleExprTrait},
+    expr::{notify::NotifyExpr, ExprTrait as _},
     media::{PostgresMedium, PostgresMediumId},
     sea_query_uuid_value,
 };
@@ -156,7 +156,7 @@ impl From<PostgresReplicaPhase> for Value {
         let mut phase = value.to_string();
         phase.make_ascii_lowercase();
 
-        Self::String(Some(Box::new(phase)))
+        Self::String(Some(phase))
     }
 }
 

--- a/api/crates/postgres/src/sources.rs
+++ b/api/crates/postgres/src/sources.rs
@@ -11,9 +11,9 @@ use domain::{
 use futures::{future::ready, TryStreamExt};
 use sea_query::{
     extension::postgres::PgExpr,
-    Expr, Iden, JoinType, LockType, Order, PostgresQueryBuilder, Query
+    Expr, ExprTrait, Iden, JoinType, LockType, Order, PostgresQueryBuilder, Query,
 };
-use sea_query_binder::SqlxBinder;
+use sea_query_sqlx::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use sqlx::{types::Json, FromRow, PgPool};

--- a/api/crates/postgres/src/tag_types.rs
+++ b/api/crates/postgres/src/tag_types.rs
@@ -5,8 +5,8 @@ use domain::{
     repository::{tag_types::TagTypesRepository, DeleteResult},
 };
 use futures::TryStreamExt;
-use sea_query::{Expr, Iden, LockType, Order, PostgresQueryBuilder, Query};
-use sea_query_binder::SqlxBinder;
+use sea_query::{Expr, ExprTrait, Iden, LockType, Order, PostgresQueryBuilder, Query};
+use sea_query_sqlx::SqlxBinder;
 use sqlx::{FromRow, PgPool};
 
 use crate::sea_query_uuid_value;

--- a/api/crates/postgres/src/tags.rs
+++ b/api/crates/postgres/src/tags.rs
@@ -11,12 +11,12 @@ use domain::{
 use either::{Left, Right};
 use futures::{TryFutureExt, TryStreamExt};
 use ordermap::OrderMap;
-use sea_query::{extension::postgres::PgExpr, Alias, Asterisk, BinOper, Cond, Expr, Func, Iden, IntoIden, JoinType, LikeExpr, LockType, Order, PostgresQueryBuilder, Query, SelectStatement};
-use sea_query_binder::SqlxBinder;
+use sea_query::{extension::postgres::PgExpr, Asterisk, BinOper, Cond, Expr, ExprTrait, Func, Iden, IntoIden, JoinType, LikeExpr, LockType, Order, PostgresQueryBuilder, Query, SelectStatement};
+use sea_query_sqlx::SqlxBinder;
 use sqlx::{Acquire, FromRow, PgConnection, PgPool, Postgres, Row, Transaction};
 
 use crate::{
-    expr::{aggregate::AggregateExpr, array::ArrayExpr, conditional::ConditionalExpr, string::StringExpr, SimpleExprTrait},
+    expr::{aggregate::AggregateExpr, array::ArrayExpr, conditional::ConditionalExpr, string::StringExpr, ExprTrait as _},
     sea_query_uuid_value,
 };
 
@@ -634,7 +634,7 @@ impl TagsRepository for PostgresTagsRepository {
             for (column, coalesce) in [
                 (Expr::col((table.clone(), PostgresTag::Name)), false),
                 (Expr::col((table.clone(), PostgresTag::Kana)), false),
-                (Expr::col((Alias::new(format!("{}_aliases", table.to_string())), ALIAS)), true),
+                (Expr::col((format!("{}_aliases", table), ALIAS)), true),
             ] {
                 sql.order_by_expr(
                     AggregateExpr::bool_or(query


### PR DESCRIPTION
This PR updates sea-query to 1.0.0-rc.14 and sea-query-sqlx to 0.8.0-rc.9 and adapts the code base to the changes.