### PR TITLE
Remove unnecessary cloning from storage crate

### DIFF
--- a/api/crates/storage/src/filesystem.rs
+++ b/api/crates/storage/src/filesystem.rs
@@ -150,15 +150,16 @@ impl ObjectsRepository for FilesystemObjectsRepository {
 
         let canonical_path = canonicalize(&fullpath)
             .await
-            .map_err(|e| Error::new(ErrorKind::ObjectGetFailed { url: url.to_string() }, e))?
+            .map_err(|e| Error::new(ErrorKind::ObjectGetFailed { url: url.to_string() }, e))?;
+
+        let canonical_path = canonical_path
             .strip_prefix(&self.root_dir)
-            .map_err(|e| Error::new(ErrorKind::ObjectUrlInvalid { url: url.to_string() }, e))?
-            .to_owned();
+            .map_err(|e| Error::new(ErrorKind::ObjectUrlInvalid { url: url.to_string() }, e))?;
 
         let mut entries: Vec<_> = ReadDirStream::new(readdir)
             .map_err(|e| Error::new(ErrorKind::ObjectListFailed { url: url.to_string() }, e))
             .try_filter_map(|dir| {
-                let canonical_path = Path::new("/").join(&canonical_path);
+                let canonical_path = Path::new("/").join(canonical_path);
                 async move {
                     let entry = FilesystemEntry::from_dir_entry(canonical_path, &dir).await?;
                     Ok(Some(entry.into_entry()))

--- a/api/crates/storage/src/filesystem/entry.rs
+++ b/api/crates/storage/src/filesystem/entry.rs
@@ -36,7 +36,7 @@ impl FilesystemEntry {
         P: AsRef<Path>,
     {
         let path = path.as_ref();
-        let name = path.file_name().unwrap_or_default().to_string_lossy().into_owned().to_string();
+        let name = path.file_name().unwrap_or_default().to_string_lossy().into_owned();
         let url = FilesystemEntryUrl::from_path(Path::new(MAIN_SEPARATOR_STR).join(path))
             .map(|url| url.into_url())
             .ok();


### PR DESCRIPTION
This PR removes unnecessary clone from the `storage` crate.